### PR TITLE
Implement suit puncturing

### DIFF
--- a/Content.Server/Atmos/Components/PressureProtectionComponent.cs
+++ b/Content.Server/Atmos/Components/PressureProtectionComponent.cs
@@ -17,6 +17,13 @@ public sealed partial class PressureProtectionComponent : Component
 
     [DataField]
     public float LowPressureModifier;
+
+    /// <summary>
+    /// If the entity is also Damageable, the total damage that can be dealt before this pressure protection is
+    /// compromised.
+    /// </summary>
+    [DataField]
+    public float CompromisedDamageThreshold = 50f;
 }
 
 /// <summary>

--- a/Content.Server/Atmos/Components/PressureProtectionComponent.cs
+++ b/Content.Server/Atmos/Components/PressureProtectionComponent.cs
@@ -18,12 +18,16 @@ public sealed partial class PressureProtectionComponent : Component
     [DataField]
     public float LowPressureModifier;
 
+    // ES START
+
     /// <summary>
     /// If the entity is also Damageable, the total damage that can be dealt before this pressure protection is
     /// compromised.
     /// </summary>
     [DataField]
     public float CompromisedDamageThreshold = 50f;
+
+    // ES END
 }
 
 /// <summary>

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Alert;
 using Content.Shared.Atmos;
 using Content.Shared.Damage;
 using Content.Shared.Database;
+using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
@@ -29,6 +30,8 @@ namespace Content.Server.Atmos.EntitySystems
             SubscribeLocalEvent<PressureProtectionComponent, GotUnequippedEvent>(OnPressureProtectionUnequipped);
             SubscribeLocalEvent<PressureProtectionComponent, ComponentInit>(OnUpdateResistance);
             SubscribeLocalEvent<PressureProtectionComponent, ComponentRemove>(OnUpdateResistance);
+            SubscribeLocalEvent<BarotraumaComponent, DamageChangedEvent>(OnDamaged);
+            SubscribeLocalEvent<PressureProtectionComponent, ExaminedEvent>(OnExamine);
 
             SubscribeLocalEvent<PressureImmunityComponent, ComponentInit>(OnPressureImmuneInit);
             SubscribeLocalEvent<PressureImmunityComponent, ComponentRemove>(OnPressureImmuneRemove);
@@ -194,6 +197,13 @@ namespace Content.Server.Atmos.EntitySystems
             highModifier = ev.HighPressureModifier;
             lowMultiplier = ev.LowPressureMultiplier;
             lowModifier = ev.LowPressureModifier;
+
+            // If damaged beyond compromised threshold, we don't offer any protection.
+            if (TryComp<DamageableComponent>(ent.Owner, out var damage)) {
+                if (damage.TotalDamage > comp.CompromisedDamageThreshold) {
+                    return false;
+                }
+            }
             return true;
         }
 
@@ -286,6 +296,25 @@ namespace Content.Server.Atmos.EntitySystems
                     }
                 }
             }
+        }
+
+        private void OnDamaged(EntityUid uid, BarotraumaComponent comp, DamageChangedEvent args)
+        {
+            // We actually only care that the entity with an equipped PressureProtectionComponent has been damaged. But
+            // since there's no (easy?) way to get the wearer of an item, and since we know that if the worn item is
+            // damaged then the wearer must be too, have the wearer subscribe to this event instead.
+            UpdateCachedResistances(uid, comp);
+        }
+
+        private void OnExamine(Entity<PressureProtectionComponent> ent, ref ExaminedEvent args)
+        {
+            if (TryComp<DamageableComponent>(ent.Owner, out var damage)) {
+                if (damage.TotalDamage > ent.Comp.CompromisedDamageThreshold) {
+                    args.PushMarkup(Loc.GetString("pressure-protection-compromised"));
+                    return;
+                }
+            }
+            args.PushMarkup(Loc.GetString("pressure-protection-working"));
         }
     }
 }

--- a/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/BarotraumaSystem.cs
@@ -30,8 +30,10 @@ namespace Content.Server.Atmos.EntitySystems
             SubscribeLocalEvent<PressureProtectionComponent, GotUnequippedEvent>(OnPressureProtectionUnequipped);
             SubscribeLocalEvent<PressureProtectionComponent, ComponentInit>(OnUpdateResistance);
             SubscribeLocalEvent<PressureProtectionComponent, ComponentRemove>(OnUpdateResistance);
+            // ES START
             SubscribeLocalEvent<BarotraumaComponent, DamageChangedEvent>(OnDamaged);
             SubscribeLocalEvent<PressureProtectionComponent, ExaminedEvent>(OnExamine);
+            // ES END
 
             SubscribeLocalEvent<PressureImmunityComponent, ComponentInit>(OnPressureImmuneInit);
             SubscribeLocalEvent<PressureImmunityComponent, ComponentRemove>(OnPressureImmuneRemove);
@@ -198,12 +200,14 @@ namespace Content.Server.Atmos.EntitySystems
             lowMultiplier = ev.LowPressureMultiplier;
             lowModifier = ev.LowPressureModifier;
 
+            // ES START
             // If damaged beyond compromised threshold, we don't offer any protection.
             if (TryComp<DamageableComponent>(ent.Owner, out var damage)) {
                 if (damage.TotalDamage > comp.CompromisedDamageThreshold) {
                     return false;
                 }
             }
+            // ES END
             return true;
         }
 
@@ -298,6 +302,7 @@ namespace Content.Server.Atmos.EntitySystems
             }
         }
 
+        // ES START
         private void OnDamaged(EntityUid uid, BarotraumaComponent comp, DamageChangedEvent args)
         {
             // We actually only care that the entity with an equipped PressureProtectionComponent has been damaged. But
@@ -305,6 +310,7 @@ namespace Content.Server.Atmos.EntitySystems
             // damaged then the wearer must be too, have the wearer subscribe to this event instead.
             UpdateCachedResistances(uid, comp);
         }
+        // ES END
 
         private void OnExamine(Entity<PressureProtectionComponent> ent, ref ExaminedEvent args)
         {

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -25,6 +25,7 @@ namespace Content.Shared.Damage
         [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
         [Dependency] private readonly IConfigurationManager _config = default!;
         [Dependency] private readonly SharedChemistryGuideDataSystem _chemistryGuideData = default!;
+        [Dependency] private readonly InventorySystem _inv = default!;
 
         private EntityQuery<AppearanceComponent> _appearanceQuery;
         private EntityQuery<DamageableComponent> _damageableQuery;
@@ -190,6 +191,17 @@ namespace Content.Shared.Damage
 
             if (before.Cancelled)
                 return null;
+
+            // Hit anything the target is wearing, too. But on recursive hits, only pass positive values. Healing the
+            // player shouldn't also fix their hardsuit.
+            // TODO: The player drinking acid shouldn't deal heat damage to worn items. However, DamageSystem doesn't
+            // currently support this kind of modeling.
+            var dp = DamageSpecifier.GetPositive(damage);
+            var e = _inv.GetSlotEnumerator(uid.Value);
+            while (e.NextItem(out var item)) {
+                // We're recursing on a different uid, so don't pass the DamageableComponent in.
+                TryChangeDamage(item, dp, ignoreResistances, interruptsDoAfters, null, origin);
+            }
 
             // Apply resistances
             if (!ignoreResistances)

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -192,6 +192,8 @@ namespace Content.Shared.Damage
             if (before.Cancelled)
                 return null;
 
+            // ES START
+
             // Hit anything the target is wearing, too. But on recursive hits, only pass positive values. Healing the
             // player shouldn't also fix their hardsuit.
             // TODO: The player drinking acid shouldn't deal heat damage to worn items. However, DamageSystem doesn't
@@ -202,6 +204,8 @@ namespace Content.Shared.Damage
                 // We're recursing on a different uid, so don't pass the DamageableComponent in.
                 TryChangeDamage(item, dp, ignoreResistances, interruptsDoAfters, null, origin);
             }
+
+            // ES END
 
             // Apply resistances
             if (!ignoreResistances)

--- a/Content.Shared/Inventory/InventoryComponent.cs
+++ b/Content.Shared/Inventory/InventoryComponent.cs
@@ -16,7 +16,10 @@ public sealed partial class InventoryComponent : Component
 
     [DataField("speciesId")] public string? SpeciesId { get; set; }
 
+    [ViewVariables]
     public SlotDefinition[] Slots = Array.Empty<SlotDefinition>();
+
+    [ViewVariables]
     public ContainerSlot[] Containers = Array.Empty<ContainerSlot>();
 
     [DataField]

--- a/Resources/Locale/en-US/clothing/components/pressure-protection.ftl
+++ b/Resources/Locale/en-US/clothing/components/pressure-protection.ftl
@@ -1,0 +1,2 @@
+pressure-protection-working = It is in good working order.
+pressure-protection-compromised = Its pressure protection is compromised.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -8,6 +8,8 @@
     - outerClothing
   - type: Sprite
     state: icon
+  - type: Damageable
+    damageContainer: Inorganic
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -8,8 +8,10 @@
     - outerClothing
   - type: Sprite
     state: icon
+# ES START
   - type: Damageable
     damageContainer: Inorganic
+# ES END
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
Implement basic suit puncturing.

## Why / Balance
 Closes #4 .

## Technical details
I suggest rebase-merge instead of squash merge. Changes are summarized in commit history:

- Add VV fields, not related to this PR, but I used this while debugging it
- Pass positive damage to worn clothing see TODO in comments
- Implement puncture damage in pressure-protecting suits

## Media
NT reminds employees to check integrity of PPE before walking in space:

https://github.com/user-attachments/assets/feae36eb-a4d7-407c-85fe-95d903ff5e61
