### PR TITLE
Add equipment override for stations

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -22,6 +22,9 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+// ES START
+using Content.Shared._ES.Spawning.Components;
+// ES END
 
 namespace Content.Server.Station.Systems;
 
@@ -141,16 +144,27 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
             }
         }
 
-        if (loadout != null)
+// ES START
+        if (job != null &&
+            TryComp<ESStationGearOverrideComponent>(station, out var esJobOverride) &&
+            esJobOverride.Overrides.TryGetValue(job.Value, out var esGearOverride))
         {
-            EquipRoleLoadout(entity.Value, loadout, roleProto!);
+            EquipStartingGear(entity.Value, _prototypeManager.Index(esGearOverride), raiseEvent: false);
         }
+        else
+        {
+            if (loadout != null)
+            {
+                EquipRoleLoadout(entity.Value, loadout, roleProto!);
+            }
 
-        if (prototype?.StartingGear != null)
-        {
-            var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
-            EquipStartingGear(entity.Value, startingGear, raiseEvent: false);
+            else if (prototype?.StartingGear != null)
+            {
+                var startingGear = _prototypeManager.Index<StartingGearPrototype>(prototype.StartingGear);
+                EquipStartingGear(entity.Value, startingGear, raiseEvent: false);
+            }
         }
+// ES END
 
         var gearEquippedEv = new StartingGearEquippedEvent(entity.Value);
         RaiseLocalEvent(entity.Value, ref gearEquippedEv);

--- a/Content.Shared/_ES/Spawning/Components/ESStationGearOverrideComponent.cs
+++ b/Content.Shared/_ES/Spawning/Components/ESStationGearOverrideComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Spawning.Components;
+
+/// <summary>
+/// Used to add equipment overrides for jobs on a station
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESStationGearOverrideComponent : Component
+{
+    /// <summary>
+    /// Maps a job to a starting gear that overrides its base equipment.
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<JobPrototype>, ProtoId<StartingGearPrototype>> Overrides = new();
+}

--- a/Resources/Prototypes/_ES/Roles/Jobs/gear_russian.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/gear_russian.yml
@@ -1,0 +1,8 @@
+- type: startingGear
+  id: ESPassengerRussianGear
+  equipment:
+    id: PassengerPDA
+    ears: ClothingHeadsetGrey
+    jumpsuit: ClothingUniformJumpsuitColorGrey
+    shoes: ClothingShoesColorBlack
+    back: ClothingBackpack


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a component for stations to allow adding overrides for starting gear per jobs. useful for alt stations where we want to give jobs unique fits. 

doesn't support shit for loadouts but we dont use em so uhhhh its fine ig.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
