### PR TITLE
Make headsets unable to broadcast on common radio

### DIFF
--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -39,12 +39,12 @@ public sealed partial class RadioChannelPrototype : IPrototype
     [DataField("longRange"), ViewVariables]
     public bool LongRange = false;
 
-    // ES START
+// ES START
     /// <summary>
     /// Whitelist that limits who is able to send this message.
     /// Note that this refers to a radio source: headsets, intercoms, etc.
     /// </summary>
     [DataField]
     public EntityWhitelist? SenderWhitelist;
-    // ES END
+// ES END
 }

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -1,4 +1,7 @@
 using Robust.Shared.Prototypes;
+// ES START
+using Content.Shared.Whitelist;
+// ES END
 
 namespace Content.Shared.Radio;
 
@@ -35,4 +38,13 @@ public sealed partial class RadioChannelPrototype : IPrototype
     /// </summary>
     [DataField("longRange"), ViewVariables]
     public bool LongRange = false;
+
+    // ES START
+    /// <summary>
+    /// Whitelist that limits who is able to send this message.
+    /// Note that this refers to a radio source: headsets, intercoms, etc.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? SenderWhitelist;
+    // ES END
 }

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -5,7 +5,7 @@
   frequency: 1459
   color: "#2cdb2c"
 # ES START
-  sendWhitelist:
+  senderWhitelist:
     components:
     - Intercom
 # ES END

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -4,6 +4,11 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+# ES START
+  sendWhitelist:
+    components:
+    - Intercom
+# ES END
 
 - type: radioChannel
   id: CentCom


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes the common radio channel to be read-only through headsets, borgs, pais, etc. The only way to broadcast on common is to use intercoms.

Goal is to promote a little bit more isolating gameplay where you do not always have a way to signal to everyone at once. hopefully this makes stealth, kidnappings, etc. a lot more viable at large.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
