### PR TITLE
Add light in Space

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.cs
@@ -104,7 +104,9 @@ public sealed partial class ShuttleSystem : SharedShuttleSystem
             return;
 
         EnsureComp<ShuttleComponent>(ev.EntityUid);
-        EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+// ES START
+        // EnsureComp<ImplicitRoofComponent>(ev.EntityUid);
+// ES END
     }
 
     private void OnShuttleStartup(EntityUid uid, ShuttleComponent component, ComponentStartup args)

--- a/Content.Server/_ES/Multistation/ESMultistationConfigPrototype.cs
+++ b/Content.Server/_ES/Multistation/ESMultistationConfigPrototype.cs
@@ -29,6 +29,12 @@ public sealed partial class ESMultistationConfigPrototype : IPrototype, IInherit
     [DataField]
     public float StationDistance = 128f;
 
+    /// <summary>
+    /// Components applied to the map.
+    /// </summary>
+    [DataField]
+    public ComponentRegistry MapComponents = new();
+
     [DataField]
     public List<ProtoId<GameMapPrototype>> MapPool = new();
 

--- a/Content.Server/_ES/Multistation/ESMultistationSystem.cs
+++ b/Content.Server/_ES/Multistation/ESMultistationSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Maps;
 using Content.Server.Procedural;
 using Content.Server.Shuttles.Systems;
 using Content.Shared._ES.CCVar;
+using Content.Shared._ES.Light.Components;
 using Content.Shared.CCVar;
 using Robust.Server.GameObjects;
 using Robust.Server.Player;
@@ -79,6 +80,8 @@ public sealed class ESMultistationSystem : EntitySystem
         if (!_prototype.TryIndex<ESMultistationConfigPrototype>(_currentConfig, out var config))
             config = _prototype.Index(DefaultConfig);
 
+        EntityManager.AddComponents(ev.DefaultMap, config.MapComponents);
+
         var configComp = EnsureComp<ESMultistationMapComponent>(ev.DefaultMap);
         configComp.Config = config.ID;
 
@@ -105,6 +108,9 @@ public sealed class ESMultistationSystem : EntitySystem
             {
                 throw new Exception($"Failed to load game-map grid {station.ID}");
             }
+
+            // TODO: more robust system, potentially?
+            AddComp<ESTileBasedRoofComponent>(grid.Value);
 
             var g = new List<EntityUid> { grid.Value.Owner };
             RaiseLocalEvent(new PostGameMapLoad(station, ev.DefaultMapId, g, null));

--- a/Content.Shared/_ES/Light/Components/ESTileBasedRoofComponent.cs
+++ b/Content.Shared/_ES/Light/Components/ESTileBasedRoofComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Maps;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Light.Components;
+
+/// <summary>
+/// Applies roofs to a grid based on the tiles on the floor.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESTileBasedRoofComponent : Component
+{
+    /// <summary>
+    /// Which tiles count as unroofed
+    /// </summary>
+    // TODO: ideally this is on the prototype but for my life i cannot be fucked with it.
+    [DataField]
+    public HashSet<ProtoId<ContentTileDefinition>> UnRoofedTiles = new()
+    {
+        "Lattice", // Space structures
+        "FloorGlass", // See-through tiles
+        "FloorRGlass",
+        "FloorAsteroidSand", // natural non-station tiles
+        "PlatingAsteroid",
+    };
+}

--- a/Content.Shared/_ES/Light/ESRoofSystem.cs
+++ b/Content.Shared/_ES/Light/ESRoofSystem.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Content.Shared._ES.Light.Components;
+using Content.Shared.Light.Components;
+using Content.Shared.Light.EntitySystems;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Light;
+
+public sealed class ESRoofSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly SharedRoofSystem _roof = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESTileBasedRoofComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ESTileBasedRoofComponent, TileChangedEvent>(OnTileChanged);
+    }
+
+    private void OnMapInit(Entity<ESTileBasedRoofComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<MapGridComponent>(ent, out var grid))
+            return;
+
+        RemComp<ImplicitRoofComponent>(ent);
+        var roof = EnsureComp<RoofComponent>(ent);
+        var tiles = ent.Comp.UnRoofedTiles.Select(p => (int) _prototype.Index(p).TileId).ToHashSet();
+
+        // GOD we should batch these
+        var enumerator = _map.GetAllTilesEnumerator(ent, grid, ignoreEmpty: true);
+        while (enumerator.MoveNext(out var tile))
+        {
+            _roof.SetRoof((ent.Owner, grid, roof), tile.Value.GridIndices, !tiles.Contains(tile.Value.Tile.TypeId));
+        }
+    }
+
+    private void OnTileChanged(Entity<ESTileBasedRoofComponent> ent, ref TileChangedEvent args)
+    {
+        if (!TryComp<MapGridComponent>(ent, out var grid))
+            return;
+        var roof = EnsureComp<RoofComponent>(ent);
+
+        var tiles = ent.Comp.UnRoofedTiles.Select(p => (int) _prototype.Index(p).TileId).ToHashSet();
+
+        foreach (var entry in args.Changes)
+        {
+            _roof.SetRoof((ent.Owner, grid, roof), entry.GridIndices, !tiles.Contains(entry.NewTile.TypeId));
+        }
+    }
+}

--- a/Resources/Prototypes/_ES/Maps/multistation.yml
+++ b/Resources/Prototypes/_ES/Maps/multistation.yml
@@ -4,6 +4,9 @@
   minStations: 2
   mapPool:
   - ESTestMap
+  mapComponents:
+  - type: MapLight
+    ambientLightColor: '#ffffff'
   dungeons:
   - configs: [ "VGRoid" ]
     count: 1
@@ -16,6 +19,7 @@
       inherent: true
     - type: IFF
       color: "#d67e27"
+    - type: ESTileBasedRoof
   - configs: [ "ChunkDebris" ]
     count: 16, 20
     distance: 312, 450


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Space now has LIGHT. Being in space or on space-ish locales will bathe you in beautiful #FFFFFF light rather than pitch-black.

Certain tiles filter light through to allow for pretty ambience and other things when on grids.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1043" height="843" alt="image" src="https://github.com/user-attachments/assets/cf626c3b-5bf7-4891-af57-7943398c3e2a" />
<img width="654" height="658" alt="image" src="https://github.com/user-attachments/assets/f58c47b2-c809-4744-8c22-275c4cc5d719" />
<img width="1417" height="1150" alt="image" src="https://github.com/user-attachments/assets/6de69951-5c1c-4e34-bf3f-b0b6015c6135" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
