### PR TITLE
Mild spawn menu tweaks

### DIFF
--- a/Content.Client/_ES/Spawning/Ui/ESSpawningWindow.xaml.cs
+++ b/Content.Client/_ES/Spawning/Ui/ESSpawningWindow.xaml.cs
@@ -131,6 +131,11 @@ public sealed partial class ESSpawningWindow : FancyWindow
                 if (!JobIsSupported(job))
                     continue;
 
+                // Q: WHAT THE FUCK IS THIS LINQ
+                // A: If a job is in multiple departments, only show it for the lowest-ranking department it appears in
+                if (_prototypeManager.EnumeratePrototypes<DepartmentPrototype>().Where(p => p.Roles.Contains(job)).MinBy(p => p.Weight) != department)
+                    continue;
+
                 GetJobCount(job, out var count, out var filteredCount);
 
                 var button = new ESJobButton(job, count, filteredCount, _prototypeManager, _sprites)
@@ -292,10 +297,13 @@ public sealed class ESJobButton : ContainerButton
             ? Loc.GetString("es-spawn-menu-job-slot-capped", ("amount", amount))
             : Loc.GetString("es-spawn-menu-job-slot-uncapped");
 
-        JobFilteredAmountLabel.Visible = filteredAmount != 0;
-        JobFilteredAmountLabel.Text = filteredAmount != null
-            ? Loc.GetString("es-spawn-menu-job-slot-excluded", ("amount", filteredAmount))
-            : Loc.GetString("es-spawn-menu-job-slot-excluded-uncapped");
+        // We don't care if the number of available slots increases by infinity. that is meaningless.
+        JobFilteredAmountLabel.Visible = filteredAmount != 0 && filteredAmount != null;
+        JobFilteredAmountLabel.Text = Loc.GetString("es-spawn-menu-job-slot-excluded", ("amount", filteredAmount ?? 0));
+
+        if (!Disabled && amount == 0)
+            Disabled = true;
+
     }
 }
 

--- a/Content.Client/_ES/Spawning/Ui/ESSpawningWindow.xaml.cs
+++ b/Content.Client/_ES/Spawning/Ui/ESSpawningWindow.xaml.cs
@@ -298,8 +298,10 @@ public sealed class ESJobButton : ContainerButton
             : Loc.GetString("es-spawn-menu-job-slot-uncapped");
 
         // We don't care if the number of available slots increases by infinity. that is meaningless.
-        JobFilteredAmountLabel.Visible = filteredAmount != 0 && filteredAmount != null;
-        JobFilteredAmountLabel.Text = Loc.GetString("es-spawn-menu-job-slot-excluded", ("amount", filteredAmount ?? 0));
+        JobFilteredAmountLabel.Visible = filteredAmount != 0 && amount != null;
+        JobFilteredAmountLabel.Text = filteredAmount != null
+            ? Loc.GetString("es-spawn-menu-job-slot-excluded", ("amount", filteredAmount))
+            : Loc.GetString("es-spawn-menu-job-slot-excluded-uncapped");
 
         if (!Disabled && amount == 0)
             Disabled = true;

--- a/Resources/Locale/en-US/_ES/spawning/spawn-menu.ftl
+++ b/Resources/Locale/en-US/_ES/spawning/spawn-menu.ftl
@@ -11,4 +11,4 @@ es-spawn-menu-job-department-format = [font="DefaultBold" size=16][color=white]{
 es-spawn-menu-job-slot-capped = ({$amount} open)
 es-spawn-menu-job-slot-uncapped = (∞ open)
 es-spawn-menu-job-slot-excluded = [bold][color=red](-{$amount})[/colpr][/bold]
-es-spawn-menu-job-slot-excluded-uncapped = [bold][color=red](-∞)[/colpr][/bold]
+es-spawn-menu-job-slot-excluded-uncapped = [bold][color=red](-[/bold]∞[bold])[/colpr][/bold]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- don't dupe jobs on the spawn menu
- gray out buttons when players take a job
- make spawning prefer lower-pop stations
- remove minus indicators for infinity values (who cares if you are infinity down from infinity. or 2 down from infinity)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
