### PR TITLE
Don't play gravity shake or powered light turn-on if round just started

### DIFF
--- a/Content.Shared/Gravity/SharedGravitySystem.Shake.cs
+++ b/Content.Shared/Gravity/SharedGravitySystem.Shake.cs
@@ -1,7 +1,14 @@
+using Content.Shared.GameTicking;
+using Robust.Shared.Timing;
+
 namespace Content.Shared.Gravity;
 
 public abstract partial class SharedGravitySystem
 {
+    // ES START
+    [Dependency] private readonly SharedGameTicker _ticker = default!;
+    // ES END
+
     protected const float GravityKick = 100.0f;
     protected const float ShakeCooldown = 0.2f;
 
@@ -36,6 +43,13 @@ public abstract partial class SharedGravitySystem
 
         if (!Resolve(uid, ref gravity, false))
             return;
+
+        // ES START
+        // do not shake grid if the round just started
+        // i did not want to have to think this logic through more. this is the simplest solution i could think of
+        if (Timing.CurTime - _ticker.RoundStartTimeSpan < TimeSpan.FromSeconds(30))
+            return;
+        // ES END
 
         if (!TryComp<GravityShakeComponent>(uid, out var shake))
         {


### PR DESCRIPTION
this isnt a particularly clean solution but it works fine and i couldn't think of another one that wouldn't involve convoluted init flow shit