### PR TITLE
Make hv/mv electrocute through insuls when powered

### DIFF
--- a/Content.Shared/Electrocution/InsulatedComponent.cs
+++ b/Content.Shared/Electrocution/InsulatedComponent.cs
@@ -6,6 +6,14 @@ namespace Content.Shared.Electrocution
     [Access(typeof(SharedElectrocutionSystem))]
     public sealed partial class InsulatedComponent : Component
     {
+// ES START
+        /// <summary>
+        /// The max value beyond which the insulation will fail.
+        /// </summary>
+        [DataField, AutoNetworkedField]
+        public float MaxSiemensThreshold = 1f;
+// ES END
+
         // Technically, people could cheat and figure out which budget insulated gloves are gud and which ones are bad.
         // We might want to rethink this a little bit.
         /// <summary>

--- a/Content.Shared/Electrocution/SharedElectrocutionSystem.cs
+++ b/Content.Shared/Electrocution/SharedElectrocutionSystem.cs
@@ -71,6 +71,10 @@ namespace Content.Shared.Electrocution
 
         private void OnInsulatedElectrocutionAttempt(EntityUid uid, InsulatedComponent insulated, ElectrocutionAttemptEvent args)
         {
+            // ES START
+            if (args.SiemensCoefficient > insulated.MaxSiemensThreshold)
+                return;
+            // ES END
             args.SiemensCoefficient *= insulated.Coefficient;
         }
     }

--- a/Resources/Prototypes/Entities/Structures/Power/cables.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cables.yml
@@ -93,6 +93,8 @@
   - type: CableVisualizer
     statePrefix: hvcable_
   # ES START
+  - type: Electrified
+    siemensCoefficient: 2
   #- type: AmbientSound
   #  enabled: false
   #  volume: -14
@@ -154,6 +156,10 @@
   - type: CableVisualizer
     statePrefix: mvcable_
     extraLayerPrefix: mvstripes_
+# ES START
+  - type: Electrified
+    siemensCoefficient: 1.5
+# ES END
 
 - type: entity
   id: CableMVUncuttable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes MV/HV wires electrocute through insulated gloves when cut. The only way to cut them is to disable power at the source (SMES, substation, generator, etc.)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes wire sabo more difficult since it limits mass snipping to only being possible on the APC/LV level. for any greater destruction, you need to break into a substation and attack it from there, which poses a greater barrier.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
