### PR TITLE
Adjust throw spin behavior + more tile friction

### DIFF
--- a/Content.Shared/Hands/Components/HandsComponent.cs
+++ b/Content.Shared/Hands/Components/HandsComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.DisplacementMap;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Throwing;
 using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -45,7 +46,9 @@ public sealed partial class HandsComponent : Component
     ///     Modifies the speed at which items are thrown.
     /// </summary>
     [DataField]
-    public float BaseThrowspeed = 11f;
+    // ES START
+    public float BaseThrowspeed = ThrowingSystem.ESThrowSpeedDefault;
+    // ES END
 
     /// <summary>
     ///     Distance after which longer throw targets stop increasing throw impulse.

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -70,7 +70,9 @@ namespace Content.Shared.Maps
         /// <summary>
         /// Base friction modifier for this tile.
         /// </summary>
-        [DataField("friction")] public float Friction { get; set; } = 1f;
+        // ES START
+        [DataField("friction")] public float Friction { get; set; } = 2.5f;
+        // ES END
 
         [DataField("variants")] public byte Variants { get; set; } = 1;
 

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -196,7 +196,7 @@ public sealed class ThrowingSystem : EntitySystem
             {
                 // ES START
                 // We step the amount of 'full spins' according to distance
-                // less than 3m we dont want to spin at all, then 1 more full spin each 3 more
+                // less than 4m we dont want to spin at all, then 1 more full spin each 4 more
                 // this is so we can normalize the rotation to 0 at the end of the throw without it looking weird
                 // (we want to avoid arbitrarily rotated items where possible for readability reasons)
                 var spins = MathF.Floor(direction.Length() / ESThrowSpinStep);

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -20,11 +20,19 @@ public sealed class ThrowingSystem : EntitySystem
 {
     public const float ThrowAngularImpulse = 5f;
 
+    // ES START
+    public const float ESThrowSpinStep = 4f;
+
+    public const float ESThrowSpeedDefault = 8.5f;
+    // ES END
+
     public const float PushbackDefault = 2f;
 
     public const float FlyTimePercentage = 0.8f;
 
-    private const float TileFrictionMod = 1.5f;
+    // ES START
+    private const float TileFrictionMod = 2.5f;
+    // ES END
 
     private float _frictionModifier;
     private float _airDamping;
@@ -49,7 +57,9 @@ public sealed class ThrowingSystem : EntitySystem
     public void TryThrow(
         EntityUid uid,
         EntityCoordinates coordinates,
-        float baseThrowSpeed = 10.0f,
+        // ES START
+        float baseThrowSpeed = ESThrowSpeedDefault,
+        // ES END
         EntityUid? user = null,
         float pushbackRatio = PushbackDefault,
         float? friction = null,
@@ -82,7 +92,9 @@ public sealed class ThrowingSystem : EntitySystem
     /// <param name="unanchor">If true and the thrown entity has <see cref="AnchorableComponent"/>, unanchor the thrown entity</param>
     public void TryThrow(EntityUid uid,
         Vector2 direction,
-        float baseThrowSpeed = 10.0f,
+        // ES START
+        float baseThrowSpeed = ESThrowSpeedDefault,
+        // ES END
         EntityUid? user = null,
         float pushbackRatio = PushbackDefault,
         float? friction = null,
@@ -127,7 +139,9 @@ public sealed class ThrowingSystem : EntitySystem
         PhysicsComponent physics,
         TransformComponent transform,
         EntityQuery<ProjectileComponent> projectileQuery,
-        float baseThrowSpeed = 10.0f,
+        // ES START
+        float baseThrowSpeed = ESThrowSpeedDefault,
+        // ES END
         EntityUid? user = null,
         float pushbackRatio = PushbackDefault,
         float? friction = null,
@@ -180,7 +194,15 @@ public sealed class ThrowingSystem : EntitySystem
         {
             if (physics.InvI > 0f && (!TryComp(uid, out throwingAngle) || throwingAngle.AngularVelocity))
             {
-                _physics.ApplyAngularImpulse(uid, ThrowAngularImpulse / physics.InvI, body: physics);
+                // ES START
+                // We step the amount of 'full spins' according to distance
+                // less than 3m we dont want to spin at all, then 1 more full spin each 3 more
+                // this is so we can normalize the rotation to 0 at the end of the throw without it looking weird
+                // (we want to avoid arbitrarily rotated items where possible for readability reasons)
+                var spins = MathF.Floor(direction.Length() / ESThrowSpinStep);
+                if (spins > 0)
+                    _physics.ApplyAngularImpulse(uid, spins * MathF.Tau / (flyTime * physics.InvI), body: physics);
+                // ES END
             }
             else
             {

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -25,6 +25,9 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
         [Dependency] private readonly SharedPhysicsSystem _physics = default!;
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
+        // ES START
+        [Dependency] private readonly SharedTransformSystem _transform = default!;
+        // ES END
 
         private const string ThrowingFixture = "throw-fixture";
 
@@ -125,6 +128,11 @@ namespace Content.Shared.Throwing
             // Assume it's uninteresting if it has no thrower. For now anyway.
             if (thrownItem.Thrower is not null)
                 _adminLogger.Add(LogType.Landed, LogImpact.Low, $"{ToPrettyString(uid):entity} thrown by {ToPrettyString(thrownItem.Thrower.Value):thrower} landed.");
+
+            // ES START
+            _transform.SetLocalRotation(uid, Angle.Zero);
+            _physics.SetAngularVelocity(uid, 0f, body: physics);
+            // ES END
 
             _broadphase.RegenerateContacts((uid, physics));
             var landEvent = new LandEvent(thrownItem.Thrower, playSound);

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1077,7 +1077,9 @@
     collection: FootstepCarpet
   barestepSounds:
     collection: BarestepCarpet
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemArcadeBlue
   heatCapacity: 10000
 
@@ -1092,7 +1094,9 @@
     collection: FootstepCarpet
   barestepSounds:
     collection: BarestepCarpet
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemArcadeBlue2
   heatCapacity: 10000
 
@@ -1107,7 +1111,9 @@
     collection: FootstepCarpet
   barestepSounds:
     collection: BarestepCarpet
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemArcadeRed
   heatCapacity: 10000
 
@@ -1122,7 +1128,9 @@
     collection: FootstepCarpet
   barestepSounds:
     collection: BarestepCarpet
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemEighties
   heatCapacity: 10000
 
@@ -1137,7 +1145,9 @@
     collection: FootstepCarpet
   barestepSounds:
     collection: BarestepCarpet
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemCarpetClown
   heatCapacity: 10000
 
@@ -1152,7 +1162,9 @@
     collection: FootstepCarpet
   barestepSounds:
     collection: BarestepCarpet
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemCarpetOffice
   heatCapacity: 10000
 
@@ -1171,7 +1183,9 @@
   deconstructTools: [ Prying ]
   footstepSounds:
     collection: FootstepFloor
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemBoxing
   heatCapacity: 10000
 
@@ -1190,7 +1204,9 @@
   deconstructTools: [ Prying ]
   footstepSounds:
     collection: FootstepFloor
-  friction: 1.25
+  # ES START
+  friction: 4
+  # ES END
   itemDrop: FloorTileItemGym
   heatCapacity: 10000
 

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -1,4 +1,7 @@
-﻿- type: tile
+﻿# ES START
+# modified to remove different friction values, since we change friction to be higher overall.
+
+- type: tile
   id: Plating
   name: tiles-plating
   sprite: /Textures/Tiles/plating.png
@@ -6,7 +9,6 @@
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 1.5
   heatCapacity: 10000
 
 - type: tile
@@ -22,7 +24,6 @@
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 1.5
   heatCapacity: 10000
 
 - type: tile
@@ -33,7 +34,6 @@
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 1.5
   heatCapacity: 10000
 
 - type: tile
@@ -44,7 +44,6 @@
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 1.5
   heatCapacity: 10000
 
 - type: tile
@@ -55,7 +54,6 @@
   isSubfloor: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 0.75 #a little less then actual snow
   heatCapacity: 10000
 
 - type: tile
@@ -68,7 +66,6 @@
   weather: true
   footstepSounds:
     collection: FootstepCatwalk
-  friction: 1.5
   isSpace: true
   itemDrop: PartRodMetal1
   heatCapacity: 10000
@@ -84,7 +81,6 @@
   weather: true
   footstepSounds:
     collection: FootstepPlating
-  friction: 1.5
   isSpace: true
   itemDrop: PartRodMetal1
   heatCapacity: 10000


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

the bigger stuff
- throwing now calculates an integer amount of times to 'spin' the item based on distance (stepping by 1 every 4 tiles and starting at 0 spins)
- throwing resets angularvelocity/localrotation to 0 on landing, reorienting items (looks fine bc it should already be close to 0 rotation because of above)

minor changes
- throw speed slightly reduced
- tile friction increased by default, things stop faster now

motivation is to avoid having items be arbitrarily rotated often for readability purposes. throwing was 99.9% of the causes of that

https://github.com/user-attachments/assets/beba845d-1f84-4dfe-a9b5-f511955cc174


