### PR TITLE
Clientside inherent mob lights

### DIFF
--- a/Content.Client/_ES/Lighting/ESInherentLightComponent.cs
+++ b/Content.Client/_ES/Lighting/ESInherentLightComponent.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._ES.Lighting;
+
+/// <summary>
+///     This is used for showing a clientside pointlight for your own controlled mob, like in SS13.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESInherentLightComponent : Component
+{
+    [ViewVariables]
+    public EntityUid? LightEntity = null;
+
+    /// <summary>
+    ///     Prototype to spawn as the light entity.
+    ///     Should obviously have a pointlight of some kind, with netsync false, and disabled by default.
+    /// </summary>
+    [DataField]
+    public EntProtoId LightPrototype = "ESMobDefaultInherentLight";
+}

--- a/Content.Client/_ES/Lighting/ESInherentLightSystem.cs
+++ b/Content.Client/_ES/Lighting/ESInherentLightSystem.cs
@@ -1,0 +1,46 @@
+using System.Numerics;
+using Robust.Client.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+
+namespace Content.Client._ES.Lighting;
+
+/// <summary>
+///     Handles enabling and disabling mob inherent pointlights when locally attaching to a new mob.
+/// </summary>
+public sealed class ESInherentLightSystem : EntitySystem
+{
+    [Dependency] private readonly PointLightSystem _light = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnPlayerAttach);
+        SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnPlayerDetach);
+    }
+
+    private void OnPlayerAttach(LocalPlayerAttachedEvent ev)
+    {
+        if (!TryComp<ESInherentLightComponent>(ev.Entity, out var light)
+            || light.LightEntity != null)
+            return;
+
+        // Don't enable inherent light if the mob already has a pointlight on itself
+        if (TryComp<PointLightComponent>(ev.Entity, out var selfPointLight) && selfPointLight.Enabled)
+            return;
+
+        light.LightEntity = SpawnAttachedTo(light.LightPrototype, new EntityCoordinates(ev.Entity, Vector2.Zero));
+        _light.SetEnabled(light.LightEntity.Value, true);
+    }
+
+    private void OnPlayerDetach(LocalPlayerDetachedEvent ev)
+    {
+        if (!TryComp<ESInherentLightComponent>(ev.Entity, out var light)
+            || light.LightEntity == null
+            || !TryComp<PointLightComponent>(light.LightEntity, out var inherentPointLight))
+            return;
+
+        QueueDel(light.LightEntity);
+        light.LightEntity = null;
+    }
+}

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -20,7 +20,10 @@ namespace Content.Server.Entry
             "LightFade",
             "HolidayRsiSwap",
             "OptionsVisualizer",
-            "MultipartMachineGhost"
+            "MultipartMachineGhost",
+            // ES START
+            "ESInherentLight",
+            // ES END
         };
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -4,6 +4,9 @@
   save: false
   id: BaseMob
   abstract: true
+  # ES START
+  parent: [ ESBaseMob ]
+  # ES END
   components:
   - type: Sprite
     noRot: true

--- a/Resources/Prototypes/_ES/Entities/Mobs/Player/base.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Player/base.yml
@@ -1,0 +1,6 @@
+# Base mob components that originate from ES.
+- type: entity
+  id: ESBaseMob
+  abstract: true
+  components:
+  - type: ESInherentLight

--- a/Resources/Prototypes/_ES/Entities/Mobs/moblights.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/moblights.yml
@@ -1,0 +1,15 @@
+# Inherent point light prototypes that can be attached to mobs using ESInherentLightComponent.
+- type: entity
+  id: ESMobDefaultInherentLight
+  name: inherent light
+  components:
+  - type: PointLight
+    netsync: false
+    color: "#ffffff"
+    energy: 2.5
+    radius: 1.35
+    # ES TODO uncomment once engine lighting done
+    # falloff: 30
+    # curveFactor: 1.0
+    castShadows: false
+    enabled: false


### PR DESCRIPTION
<img width="360" height="296" alt="image" src="https://github.com/user-attachments/assets/54391f87-abfe-41e3-aef5-f9f8d754aa7a" />

this took me like 2.5 hours instead of 20 minutes because spawning the entity and doing `SetParent` didnt make the light show up but using `SpawnAttachedTo` did make the light show up

works entirely clientside on attach/detach. no serverside entities spawned for this. cleans itself up on detach so there's only ever one

should probably add different prototypes for mobs that can see in the dark better (like spiders or something)