### PR TITLE
Create troupe gamerules for handling mask assignment

### DIFF
--- a/Content.Server/_ES/Masks/Components/ESTroupeRuleComponent.cs
+++ b/Content.Server/_ES/Masks/Components/ESTroupeRuleComponent.cs
@@ -1,0 +1,46 @@
+using Content.Shared._ES.Masks;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._ES.Masks.Components;
+
+[RegisterComponent]
+public sealed partial class ESTroupeRuleComponent : Component
+{
+    /// <summary>
+    /// Priority for the assignment of players.
+    /// Rules with equal priority will be assigned simultaneously.
+    /// </summary>
+    [DataField]
+    public int Priority = 1;
+
+    /// <summary>
+    /// Troupe that is associated with this rule
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<ESTroupePrototype> Troupe;
+
+    /// <summary>
+    /// Minimum numbers of members present
+    /// </summary>
+    [DataField]
+    public int MinTargetMembers = 1;
+
+    /// <summary>
+    /// Maximum number of members present
+    /// </summary>
+    [DataField]
+    public int MaxTargetMembers = int.MaxValue;
+
+    /// <summary>
+    /// Proportion of players who will be selected for this troupe.
+    /// Use 1 / X to convert to a percentage (i.e. value of "3" means 1/3 of players will be in this troupe)
+    /// </summary>
+    [DataField]
+    public int PlayersPerTargetMember = 5;
+
+    /// <summary>
+    /// Minds that are a part of this troupe.
+    /// </summary>
+    [DataField]
+    public List<EntityUid> TroupeMemberMinds = new();
+}

--- a/Content.Server/_ES/Masks/Components/ESTroupeRuleComponent.cs
+++ b/Content.Server/_ES/Masks/Components/ESTroupeRuleComponent.cs
@@ -3,7 +3,11 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server._ES.Masks.Components;
 
+/// <summary>
+/// Handles assigning masks to players when they join into the round.
+/// </summary>
 [RegisterComponent]
+[Access(typeof(ESMaskSystem))]
 public sealed partial class ESTroupeRuleComponent : Component
 {
     /// <summary>

--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -87,8 +87,17 @@ public sealed class ESMaskSystem : EntitySystem
             var player = _random.PickAndTake(filteredPlayers);
             players.Remove(player);
 
-            Debug.Assert(_mind.TryGetMind(player, out var mind, out var mindComp), $"Failed to get mind for session {player}");
-            Debug.Assert(TryGetMask((mind, mindComp), troupe, out var mask), $"Failed to get mask for session {player} on troupe {troupe.ID}");
+            if (!_mind.TryGetMind(player, out var mind, out var mindComp))
+            {
+                Log.Warning($"Failed to get mind for session {player}");
+                continue;
+            }
+
+            if (!TryGetMask((mind, mindComp), troupe, out var mask))
+            {
+                Log.Warning($"Failed to get mask for session {player} on troupe {troupe.ID} ({ToPrettyString(ent)}");
+                continue;
+            }
 
             ApplyMask(ent, (mind, mindComp), mask.Value);
         }

--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -1,16 +1,21 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Content.Server._ES.Arrivals;
+using System.Linq;
+using Content.Server._ES.Auditions;
 using Content.Server._ES.Masks.Components;
 using Content.Server.Chat.Managers;
+using Content.Server.GameTicking;
 using Content.Server.Mind;
 using Content.Server.Roles;
+using Content.Server.Roles.Jobs;
 using Content.Shared._ES.Masks;
 using Content.Shared.Chat;
 using Content.Shared.EntityTable;
+using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Random.Helpers;
-using Content.Shared.Roles.Components;
 using Robust.Server.Player;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
@@ -22,7 +27,10 @@ public sealed class ESMaskSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ESAuditionsSystem _esAuditions = default!;
     [Dependency] private readonly EntityTableSystem _entityTable = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly JobSystem _job = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly RoleSystem _role = default!;
 
@@ -31,24 +39,101 @@ public sealed class ESMaskSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<ESPlayersArrivedEvent>(OnPlayersArrived);
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<RulePlayerJobsAssignedEvent>(OnRulePlayerJobsAssigned);
     }
 
-    private void OnPlayersArrived(ref ESPlayersArrivedEvent ev)
+    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
     {
-        foreach (var player in ev.Players)
+        if (!ev.LateJoin)
+            return;
+        AssignPlayersToTroupe([ev.Player]);
+    }
+
+    private void OnRulePlayerJobsAssigned(RulePlayerJobsAssignedEvent args)
+    {
+        AssignPlayersToTroupe(args.Players.ToList());
+    }
+
+    public void AssignPlayersToTroupe(List<ICommonSession> players)
+    {
+        foreach (var troupe in GetOrderedTroupes())
         {
-            if (!_mind.TryGetMind(player, out var mindUid, out var mindComp))
-                continue;
+            if (players.Count == 0)
+                break;
+            TryAssignToTroupe(troupe, ref players);
+        }
 
-            if (!TryGetMask((mindUid, mindComp), out var mask))
-                continue;
-
-            ApplyMask((mindUid, mindComp), mask.Value);
+        if (players.Count > 0)
+        {
+            Log.Warning($"Failed to assign all players to troupes! Leftover count: {players.Count}");
         }
     }
 
-    public bool TryGetMask(Entity<MindComponent> mind, [NotNullWhen(true)] out ProtoId<ESMaskPrototype>? mask)
+    public bool TryAssignToTroupe(Entity<ESTroupeRuleComponent> ent, ref List<ICommonSession> players)
+    {
+        var troupe = _prototypeManager.Index(ent.Comp.Troupe);
+
+        var filteredPlayers = players.Where(s => IsPlayerValid(troupe, s)).ToList();
+
+        var playerCount = _esAuditions.GetPlayerCount();
+        var targetCount = Math.Clamp(playerCount / ent.Comp.PlayersPerTargetMember, ent.Comp.MinTargetMembers, ent.Comp.MaxTargetMembers);
+        var targetDiff = Math.Min(targetCount - ent.Comp.TroupeMemberMinds.Count, filteredPlayers.Count);
+        if (targetDiff <= 0)
+            return false;
+
+        for (var i = 0; i < targetDiff; i++)
+        {
+            var player = _random.PickAndTake(filteredPlayers);
+            players.Remove(player);
+
+            Debug.Assert(_mind.TryGetMind(player, out var mind, out var mindComp), $"Failed to get mind for session {player}");
+            Debug.Assert(TryGetMask((mind, mindComp), troupe, out var mask), $"Failed to get mask for session {player} on troupe {troupe.ID}");
+
+            ApplyMask(ent, (mind, mindComp), mask.Value);
+        }
+        return true;
+    }
+
+    public List<Entity<ESTroupeRuleComponent>> GetOrderedTroupes()
+    {
+        var troupes = new List<Entity<ESTroupeRuleComponent>>();
+        var query = EntityQueryEnumerator<ESTroupeRuleComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (!_gameTicker.IsGameRuleActive(uid))
+                continue;
+
+            troupes.Add((uid, comp));
+        }
+
+        troupes.Sort((a, b) =>
+        {
+            var c = a.Comp.Priority.CompareTo(b.Comp.Priority);
+            if (c != 0)
+                return c;
+            return _random.Next() % 2 == 0 ? -1 : 1; // For members of equal priority, sort them randomly.
+        });
+
+        return troupes;
+    }
+
+    public bool IsPlayerValid(ESTroupePrototype troupe, ICommonSession player)
+    {
+        if (!_mind.TryGetMind(player, out var mind, out _))
+            return false;
+
+        // BUG: MindTryGetJobId doesn't have a NotNullWhen attribute on the out param.
+        if (_job.MindTryGetJobId(mind, out var job) && troupe.ProhibitedJobs.Contains(job!.Value))
+            return false;
+
+        if (player.AttachedEntity is null)
+            return false;
+
+        return true;
+    }
+
+    public bool TryGetMask(Entity<MindComponent> mind, ESTroupePrototype troupe, [NotNullWhen(true)] out ProtoId<ESMaskPrototype>? mask)
     {
         mask = null;
 
@@ -58,15 +143,8 @@ public sealed class ESMaskSystem : EntitySystem
             if (maskProto.Abstract)
                 continue;
 
-            if (maskProto.BlockNonAntagJobs)
-            {
-                if (_role.MindHasRole<JobRoleComponent>(mind.AsNullable(), out var role) &&
-                    role.Value.Comp1.JobPrototype is { } job)
-                {
-                    if (!_prototypeManager.Index(job).CanBeAntag)
-                        continue;
-                }
-            }
+            if (maskProto.Troupe != troupe)
+                continue;
 
             weights.Add(maskProto, maskProto.Weight);
         }
@@ -78,7 +156,7 @@ public sealed class ESMaskSystem : EntitySystem
         return true;
     }
 
-    public void ApplyMask(Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId)
+    public void ApplyMask(Entity<ESTroupeRuleComponent> troupe, Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId)
     {
         var mask = _prototypeManager.Index(maskId);
         _role.MindAddRole(mind, MindRole, mind, true);
@@ -97,5 +175,7 @@ public sealed class ESMaskSystem : EntitySystem
         {
             _chat.ChatMessageToOne(ChatChannel.Server, msg, msg, default, false, session.Channel, Color.Plum);
         }
+
+        troupe.Comp.TroupeMemberMinds.Add(mind);
     }
 }

--- a/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.cs
+++ b/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.cs
@@ -141,4 +141,21 @@ public abstract partial class ESSharedAuditionsSystem : EntitySystem
 
         return (newCrew, component);
     }
+
+    /// <summary>
+    /// Returns the number of characters on the station.
+    /// Only counts the number of people that have been spawned across the round,
+    /// does not account for people leaving or disconnecting.
+    /// </summary>
+    public int GetPlayerCount()
+    {
+        var count = 0;
+        var query = EntityQueryEnumerator<ESProducerComponent>();
+        while (query.MoveNext(out var comp))
+        {
+            count += comp.Characters.Count - comp.UnusedCharacterPool.Count;
+        }
+
+        return count;
+    }
 }

--- a/Content.Shared/_ES/Masks/ESMaskPrototype.cs
+++ b/Content.Shared/_ES/Masks/ESMaskPrototype.cs
@@ -33,6 +33,9 @@ public sealed partial class ESMaskPrototype : IPrototype, IInheritingPrototype
     [DataField]
     public LocId Name;
 
+    [DataField]
+    public ProtoId<ESTroupePrototype> Troupe;
+
     /// <summary>
     /// Description of what this role does.
     /// </summary>
@@ -44,10 +47,4 @@ public sealed partial class ESMaskPrototype : IPrototype, IInheritingPrototype
     /// </summary>
     [DataField]
     public EntityTableSelector Objectives = new NoneSelector();
-
-    /// <summary>
-    /// Whether crew that aren't allowed to be antags (command, sec) can play this role
-    /// </summary>
-    [DataField]
-    public bool BlockNonAntagJobs;
 }

--- a/Content.Shared/_ES/Masks/ESTroupePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESTroupePrototype.cs
@@ -18,6 +18,12 @@ public sealed partial class ESTroupePrototype : IPrototype, IInheritingPrototype
     public bool Abstract { get; }
 
     /// <summary>
+    /// Name of the troupe, in plain text.
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name;
+
+    /// <summary>
     /// Players with any of these jobs will be ineligible for being members of this troupe
     /// </summary>
     [DataField]

--- a/Content.Shared/_ES/Masks/ESTroupePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESTroupePrototype.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
+
+namespace Content.Shared._ES.Masks;
+
+[Prototype("esTroupe")]
+public sealed partial class ESTroupePrototype : IPrototype, IInheritingPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<ESTroupePrototype>))]
+    public string[]? Parents { get; }
+
+    [AbstractDataField]
+    public bool Abstract { get; }
+
+    /// <summary>
+    /// Players with any of these jobs will be ineligible for being members of this troupe
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<JobPrototype>> ProhibitedJobs = new();
+}

--- a/Resources/Locale/en-US/_ES/gameticking/presets.ftl
+++ b/Resources/Locale/en-US/_ES/gameticking/presets.ftl
@@ -1,0 +1,2 @@
+es-preset-traitor-title = Traitors
+es-preset-traitor-desc = Uncover the traitors among the crew and stop them from destroying the station and everyone on it.

--- a/Resources/Locale/en-US/_ES/masks/troupes.ftl
+++ b/Resources/Locale/en-US/_ES/masks/troupes.ftl
@@ -1,0 +1,2 @@
+es-troupe-crew-name = Crew
+es-troupe-traitor-name = Traitor

--- a/Resources/Prototypes/_ES/GameRules/presets.yml
+++ b/Resources/Prototypes/_ES/GameRules/presets.yml
@@ -1,0 +1,11 @@
+- type: gamePreset
+  id: ESTraitors
+  name: es-preset-traitor-title
+  description: es-preset-traitor-desc
+  showInVote: true
+  rules:
+  - ESTroupeRuleCrew
+  - ESTroupeRuleTraitor
+  - BasicStationEventScheduler # TODO: Create new event scheduler with more reasonable events.
+  - MeteorSwarmScheduler
+  - BasicRoundstartVariation

--- a/Resources/Prototypes/_ES/GameRules/troupes.yml
+++ b/Resources/Prototypes/_ES/GameRules/troupes.yml
@@ -1,0 +1,19 @@
+- type: entity
+  parent: BaseGameRule
+  id: ESTroupeRuleCrew
+  components:
+  - type: ESTroupeRule
+    troupe: ESCrew
+    priority: 10 # Highest priority: serves as fallback troupe.
+    minTargetMembers: 1
+    playersPerTargetMember: 1
+
+- type: entity
+  parent: BaseGameRule
+  id: ESTroupeRuleTraitor
+  components:
+  - type: ESTroupeRule
+    troupe: ESTraitor
+    minTargetMembers: 1
+    maxTargetMembers: 5
+    playersPerTargetMember: 6 # 1/6 Players

--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -5,7 +5,6 @@
   name: es-mask-traitor-name
   troupe: ESTraitor
   description: es-mask-traitor-desc
-  blockNonAntagJobs: true
   weight: 1
   objectives:
     id: ESMaskObjectiveRandomStationKill

--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -3,6 +3,7 @@
 - type: esMask
   id: ESTraitor # This isn't your mama's traitor
   name: es-mask-traitor-name
+  troupe: ESTraitor
   description: es-mask-traitor-desc
   blockNonAntagJobs: true
   weight: 1
@@ -12,6 +13,7 @@
 - type: esMask
   id: ESGuardian
   name: es-mask-guardian-name
+  troupe: ESCrew
   description: es-mask-guardian-desc
   weight: 1
   objectives:

--- a/Resources/Prototypes/_ES/Masks/troupes.yml
+++ b/Resources/Prototypes/_ES/Masks/troupes.yml
@@ -1,8 +1,10 @@
 - type: esTroupe
   id: ESCrew
+  name: es-troupe-crew-name
 
 - type: esTroupe
   id: ESTraitor
+  name: es-troupe-traitor-name
   prohibitedJobs:
   # Command
   - Captain

--- a/Resources/Prototypes/_ES/Masks/troupes.yml
+++ b/Resources/Prototypes/_ES/Masks/troupes.yml
@@ -1,0 +1,14 @@
+- type: esTroupe
+  id: ESCrew
+
+- type: esTroupe
+  id: ESTraitor
+  prohibitedJobs:
+  # Command
+  - Captain
+  - HeadOfPersonnel
+  - HeadOfSecurity
+  # Security
+  - Warden
+  - SecurityOfficer
+  - Detective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Creates generalized gamerules that handle the assignment of masks to players, now with additional troupe functionality as outlined in the [masks doc](https://ephemeralspace.github.io/docs/design/masks/masks.html). Additionally includes placeholder crew and traitor troupes 

The old system was nowhere near extensible enough and essentially just did simple weighted assignment.

Q: SHOULD THIS BE ANTAG SELECTION CODE?
A: NO! PLEASE NO!

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
