### PR TITLE
Remove PDA flashlights

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -61,12 +61,12 @@
     slots:
     - idcard
     - Belt
-  - type: UnpoweredFlashlight
-  - type: PointLight
-    enabled: false
-    radius: 1.5
-    softness: 5
-    autoRot: true
+  # - type: UnpoweredFlashlight # ES
+  # - type: PointLight
+  #   enabled: false
+  #   radius: 1.5
+  #   softness: 5
+  #   autoRot: true
   - type: Ringer
   - type: RingerUplink
   - type: DeviceNetwork


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- Remove flashlight and flashlight action from PDAs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Takes up an action slot for an extremely weak light. We also have mob lights https://github.com/EphemeralSpace/ephemeral-space/pull/137 so this feature is arguably redundant.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/EphemeralSpace/ephemeral-space/commit/094109fe73d955c4b41ff8674ec99d86740ccd1f
<img width="648" height="702" alt="image" src="https://github.com/user-attachments/assets/76472340-32e2-4a6e-a2fa-ed4703a0c084" />
Note: Lack of PDA action in the action bar

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed PDA flashlights.