### PR TITLE
Remove sprite offset from potted plants

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -22,7 +22,9 @@
         - HighImpassable
   - type: Sprite
     drawdepth: Overdoors
-    offset: "0.0,0.3"
+# ES START
+    #offset: "0.0,0.3"
+# ES END
     sprite: Structures/Furniture/potted_plants.rsi
     noRot: true
   - type: Speech


### PR DESCRIPTION
Plants have an inexplicable wallening-style sprite offset which makes them always clip into the tile above. This looks pretty terrible and I would like it gone, hence this PR.