### PR TITLE
Add generic pointlight visualizer component

### DIFF
--- a/Content.Client/_ES/Lighting/Components/ESGenericPointLightVisualizerComponent.cs
+++ b/Content.Client/_ES/Lighting/Components/ESGenericPointLightVisualizerComponent.cs
@@ -1,0 +1,60 @@
+using System.Numerics;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._ES.Lighting.Components;
+
+/// <summary>
+/// Used to control properties of <see cref="SharedPointLightComponent"/> via appearance data on <see cref="AppearanceComponent"/>.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ESGenericPointLightVisualizerSystem))]
+public sealed partial class ESGenericPointLightVisualizerComponent : Component
+{
+    /// <summary>
+    /// Nested dictionary that maps appearance data keys -> appearance data values -> light data
+    /// </summary>
+    [DataField(required:true)]
+    public Dictionary<Enum, Dictionary<string, ESPointLightData>> Visuals = new();
+}
+
+/// <summary>
+/// Corresponds with fields on <see cref="SharedPointLightComponent"/>
+/// </summary>
+[DataDefinition]
+public partial record struct ESPointLightData
+{
+    [DataField] public Color? Color;
+    [DataField] public Vector2? Offset;
+    [DataField] public float? Energy;
+    [DataField] public float? Softness;
+    [DataField] public float? Falloff;
+    [DataField] public float? CurveFactor;
+    [DataField] public bool? CastShadows;
+    [DataField] public bool? Enabled;
+    [DataField] public float? Radius;
+    // BUG: No public setters on current engine version
+    // [DataField] public bool? MaskAutoRotate;
+    // [DataField] public string? MaskPath;
+
+    public void Apply(Entity<PointLightComponent> ent, SharedPointLightSystem system)
+    {
+        if (Color.HasValue)
+            system.SetColor(ent, Color.Value, ent);
+        if (Offset.HasValue)
+            ent.Comp.Offset = Offset.Value;
+        if (Energy.HasValue)
+            system.SetEnergy(ent, Energy.Value, ent);
+        if (Softness.HasValue)
+            system.SetSoftness(ent, Softness.Value, ent);
+        if (Falloff.HasValue)
+            system.SetFalloff(ent, Falloff.Value, ent);
+        if (CurveFactor.HasValue)
+            system.SetCurveFactor(ent, CurveFactor.Value, ent);
+        if (CastShadows.HasValue)
+            system.SetCastShadows(ent, CastShadows.Value, ent);
+        if (Enabled.HasValue)
+            system.SetEnabled(ent, Enabled.Value, ent);
+        if (Radius.HasValue)
+            system.SetRadius(ent, Radius.Value, ent);
+    }
+}

--- a/Content.Client/_ES/Lighting/ESGenericPointLightVisualizerSystem.cs
+++ b/Content.Client/_ES/Lighting/ESGenericPointLightVisualizerSystem.cs
@@ -1,0 +1,34 @@
+using Content.Client._ES.Lighting.Components;
+using Robust.Client.GameObjects;
+using Robust.Shared.Utility;
+
+namespace Content.Client._ES.Lighting;
+
+public sealed class ESGenericPointLightVisualizerSystem : VisualizerSystem<ESGenericPointLightVisualizerComponent>
+{
+    [Dependency] private readonly PointLightSystem _pointLight = default!;
+
+    protected override void OnAppearanceChange(EntityUid uid, ESGenericPointLightVisualizerComponent component, ref AppearanceChangeEvent args)
+    {
+        if (!TryComp<PointLightComponent>(uid, out var pointLight))
+        {
+            throw new Exception($"Entity {ToPrettyString(uid)} with {nameof(ESGenericPointLightVisualizerComponent)} does not have {nameof(PointLightComponent)}!");
+        }
+        DebugTools.Assert(!pointLight.NetSyncEnabled, $"Entity {ToPrettyString(uid)} uses point light visuals with a netsync'd pointlight! (Did you forget to set netsync: false?)");
+
+        foreach (var (appearanceKey, layerDataDict) in component.Visuals)
+        {
+            if (!AppearanceSystem.TryGetData(uid, appearanceKey, out var obj, args.Component))
+                continue;
+
+            var appearanceValue = obj.ToString();
+            if (string.IsNullOrEmpty(appearanceValue))
+                continue;
+
+            if (!layerDataDict.TryGetValue(appearanceValue, out var layerData))
+                continue;
+
+            layerData.Apply((uid, pointLight), _pointLight);
+        }
+    }
+}

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -13,6 +13,7 @@ namespace Content.Server.Entry
         public static string[] List => new[] {
             // ES START
             "ESInherentLight",
+            "ESGenericPointLightVisualizer",
             // ES END
             "ConstructionGhost",
             "IconSmooth",


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A simple component that integrates pointlights with appearance data for more interesting visual elements.

Note: all pointlights using this need to have netsync set to false since the component handles everything on the client.