### PR TITLE
cone man 2 (clown man 2 reference)

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -49,6 +49,10 @@ namespace Content.Client.Input
             // Not in engine so that the RCD can rotate objects
             common.AddFunction(EngineKeyFunctions.EditorRotateObject);
 
+            // ES START
+            common.AddFunction(ContentKeyFunctions.ESHoldToFace);
+            // ES END
+
             var human = contexts.GetContext("human");
             human.AddFunction(EngineKeyFunctions.MoveUp);
             human.AddFunction(EngineKeyFunctions.MoveDown);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -162,6 +162,9 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(EngineKeyFunctions.Walk);
             AddCheckBox("ui-options-hotkey-toggle-walk", _cfg.GetCVar(CCVars.ToggleWalk), HandleToggleWalk);
             InitToggleWalk();
+            // ES START
+            AddButton(ContentKeyFunctions.ESHoldToFace);
+            // ES END
             AddButton(ContentKeyFunctions.ToggleKnockdown);
 
             AddHeader("ui-options-header-camera");

--- a/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
@@ -14,7 +14,7 @@ namespace Content.Client._ES.Viewcone;
 
 /// <summary>
 ///     Handles adding and removing the viewcone overlays, as well as ferrying data between them
-///     Also handles calculating
+///     Also handles calculating desired view angle for active viewcones so overlays can use it
 /// </summary>
 public sealed class ESViewconeOverlayManagementSystem : EntitySystem
 {

--- a/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
@@ -1,8 +1,12 @@
 using Content.Client._ES.Viewcone.Overlays;
+using Content.Client.Eye;
 using Content.Shared._ES.Viewcone;
+using Content.Shared.MouseRotator;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
+using Robust.Client.Input;
 using Robust.Client.Player;
+using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Player;
 
@@ -10,14 +14,20 @@ namespace Content.Client._ES.Viewcone;
 
 /// <summary>
 ///     Handles adding and removing the viewcone overlays, as well as ferrying data between them
+///     Also handles calculating
 /// </summary>
 public sealed class ESViewconeOverlayManagementSystem : EntitySystem
 {
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
+    [Dependency] private readonly IInputManager _input = default!;
+    [Dependency] private readonly IEyeManager _eye = default!;
+    [Dependency] private readonly SharedTransformSystem _xform = default!;
     private ESViewconeConeOverlay _coneOverlay = default!;
     private ESViewconeSetAlphaOverlay _setAlphaOverlay = default!;
     private ESViewconeResetAlphaOverlay _resetAlphaOverlay = default!;
+
+    private const float LerpHalfLife = 0.05f;
 
     // slightly balls state management, but
     // done so we don't have to requery within the same frame
@@ -41,6 +51,63 @@ public sealed class ESViewconeOverlayManagementSystem : EntitySystem
         _coneOverlay = new();
         _setAlphaOverlay = new();
         _resetAlphaOverlay = new();
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        base.FrameUpdate(frameTime);
+
+        // the reason we use lerpingeye here in the query first is to
+        // specifically check for eyes that we are actually rendering (lerpingeye already handles this sort of
+        // its like jank as fuck in that system but whatever thats like not my problem )
+        var enumerator = AllEntityQuery<LerpingEyeComponent, EyeComponent, ESViewconeComponent, TransformComponent>();
+        while (enumerator.MoveNext(out var uid, out _, out var eye, out var viewcone, out var xform))
+        {
+            var eyeAngle = eye.Rotation;
+            var rotation = _xform.GetWorldRotation(xform);
+            var playerAngle = rotation;
+            var desiredWasNull = viewcone.DesiredViewAngle == null;
+
+            if (HasComp<MouseRotatorComponent>(uid))
+            {
+                var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
+                if (mousePos.MapId != MapId.Nullspace)
+                    playerAngle = (mousePos.Position - _xform.GetMapCoordinates(xform).Position).ToAngle() + Angle.FromDegrees(90);
+
+                viewcone.LastMouseRotationAngle = playerAngle;
+            }
+            else if (viewcone.LastMouseRotationAngle != 0f)
+            {
+                // if last frame we had a mouse rotation angle, but now we dont,
+                // that means it was disabled
+                // but, we should keep the old mouse angle for viewcone, at least until the real angle actually changes
+                if (MathHelper.CloseToPercent(viewcone.LastWorldRotationAngle, playerAngle, .000001d))
+                {
+                    playerAngle = viewcone.LastMouseRotationAngle;
+                }
+                else
+                {
+                    viewcone.LastMouseRotationAngle = 0f;
+                }
+            }
+
+            viewcone.LastWorldRotationAngle = rotation;
+            viewcone.DesiredViewAngle = playerAngle + eyeAngle;
+
+            // if desired angle was null before we set it
+            // then just set viewangle to it immediately
+            // (assume it was first frame)
+            if (desiredWasNull)
+            {
+                viewcone.ViewAngle = viewcone.DesiredViewAngle.Value;
+                continue;
+            }
+
+            // framerate-independent lerp
+            // https://twitter.com/FreyaHolmer/status/1757836988495847568
+            // convert to angle first so we lerp thru shortestdistance
+            viewcone.ViewAngle = Angle.Lerp(viewcone.ViewAngle, viewcone.DesiredViewAngle.Value, 1f - MathF.Pow(2f, -(frameTime / LerpHalfLife)));
+        }
     }
 
     private void OnPlayerAttached(Entity<ESViewconeComponent> entity, ref LocalPlayerAttachedEvent args)

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
@@ -6,6 +6,7 @@ using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
 
 namespace Content.Client._ES.Viewcone.Overlays;
 
@@ -15,6 +16,7 @@ namespace Content.Client._ES.Viewcone.Overlays;
 public sealed class ESViewconeConeOverlay : Overlay
 {
     [Dependency] private readonly IEntityManager _ent = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IInputManager _input = default!;
     [Dependency] private readonly IEyeManager _eye = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
@@ -31,6 +33,14 @@ public sealed class ESViewconeConeOverlay : Overlay
     private float _coneFeather;
     private float _coneIgnoreRadius;
     private float _coneIgnoreFeather;
+
+    private float _viewAngle;
+    private float _desiredViewAngle;
+    private float _lastMouseRotationAngle;
+    private float _lastWorldRotationAngle;
+    private TimeSpan _lastFrame = TimeSpan.Zero;
+
+    private const float LerpHalfLife = 0.05f;
 
     public ESViewconeConeOverlay()
     {
@@ -73,19 +83,51 @@ public sealed class ESViewconeConeOverlay : Overlay
         var zoom = _eyeEntity.Value.Comp1.Zoom.X;
         var eyeAngle = (float) _eyeEntity.Value.Comp1.Rotation.Theta;
         var playerAngle = (float) _xform.GetWorldRotation(_eyeEntity.Value.Comp2).Theta;
+        _lastWorldRotationAngle = playerAngle;
 
         if (_ent.HasComponent<MouseRotatorComponent>(_eyeEntity))
         {
             var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
             if (mousePos.MapId != MapId.Nullspace)
                 playerAngle = (float) (mousePos.Position - _xform.GetMapCoordinates(_eyeEntity.Value).Position).ToAngle().Theta + MathHelper.DegreesToRadians(90f);
+
+            _lastMouseRotationAngle = playerAngle;
+        }
+        else if (_lastMouseRotationAngle != 0f)
+        {
+            // if last frame we had a mouse rotation angle, but now we dont,
+            // that means it was disabled
+            // but, we should keep the old mouse angle for viewcone, at least until the real angle actually changes
+            if (MathHelper.CloseToPercent(_lastWorldRotationAngle, playerAngle))
+            {
+                playerAngle = _lastMouseRotationAngle;
+            }
+            else
+            {
+                _lastMouseRotationAngle = 0f;
+            }
         }
 
-        var viewAngle = playerAngle + eyeAngle;
+        _desiredViewAngle = playerAngle + eyeAngle;
+
+        // lastframe zero means first frame, so just set it to desired immediately
+        if (_lastFrame == TimeSpan.Zero)
+        {
+            _viewAngle = _desiredViewAngle;
+        }
+        else
+        {
+            // otherwise, framerate-independent lerp
+            var dt = (float) (_timing.RealTime - _lastFrame).TotalSeconds;
+            // https://twitter.com/FreyaHolmer/status/1757836988495847568
+            _viewAngle = MathHelper.Lerp(_viewAngle, _desiredViewAngle, 1f - MathF.Pow(2f, -(dt / LerpHalfLife)));
+        }
+
+        _lastFrame = _timing.RealTime;
 
         _viewconeShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
         _viewconeShader.SetParameter("Zoom", zoom);
-        _viewconeShader.SetParameter("ViewAngle", viewAngle);
+        _viewconeShader.SetParameter("ViewAngle", _viewAngle);
         _viewconeShader.SetParameter("ConeAngle", _coneAngle);
         _viewconeShader.SetParameter("ConeFeather", _coneFeather);
         _viewconeShader.SetParameter("ConeIgnoreRadius", _coneIgnoreRadius);

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
@@ -1,3 +1,4 @@
+using Content.Client.Eye;
 using Content.Shared._ES.Viewcone;
 using Content.Shared.MouseRotator;
 using Robust.Client.Graphics;
@@ -16,11 +17,7 @@ namespace Content.Client._ES.Viewcone.Overlays;
 public sealed class ESViewconeConeOverlay : Overlay
 {
     [Dependency] private readonly IEntityManager _ent = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IInputManager _input = default!;
-    [Dependency] private readonly IEyeManager _eye = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
-    private readonly SharedTransformSystem _xform;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
@@ -28,24 +25,15 @@ public sealed class ESViewconeConeOverlay : Overlay
     public static ProtoId<ShaderPrototype> ShaderPrototype = "Viewcone";
     private readonly ShaderInstance _viewconeShader;
 
-    private Entity<EyeComponent, TransformComponent>? _eyeEntity;
+    private Entity<EyeComponent, ESViewconeComponent, TransformComponent>? _eyeEntity;
     private float _coneAngle;
     private float _coneFeather;
     private float _coneIgnoreRadius;
     private float _coneIgnoreFeather;
 
-    private float _viewAngle;
-    private float _desiredViewAngle;
-    private float _lastMouseRotationAngle;
-    private float _lastWorldRotationAngle;
-    private TimeSpan _lastFrame = TimeSpan.Zero;
-
-    private const float LerpHalfLife = 0.05f;
-
     public ESViewconeConeOverlay()
     {
         IoCManager.InjectDependencies(this);
-        _xform = _ent.System<SharedTransformSystem>();
         _viewconeShader = _proto.Index(ShaderPrototype).InstanceUnique();
     }
 
@@ -54,9 +42,11 @@ public sealed class ESViewconeConeOverlay : Overlay
         _eyeEntity = null;
 
         // This is really stupid but there isn't another way to reverse an eye entity from just an IEye afaict
-        // It's not really inefficient though. theres barely any of those fuckin things anyway (? verify that) (maybe this scales with players in view) (shit)
-        var enumerator = _ent.AllEntityQueryEnumerator<EyeComponent, ESViewconeComponent, TransformComponent>();
-        while (enumerator.MoveNext(out var uid, out var eye, out var viewcone, out var xform))
+        // It's not really inefficient though. theres barely any of those fuckin things anyway
+        // lerpingeye used because that system already does the busywork of figuring out which eyes are 'rendering' sort of
+        // so we dont have to query other players eyes (probably barely makes a difference anyway)
+        var enumerator = _ent.AllEntityQueryEnumerator<LerpingEyeComponent, EyeComponent, ESViewconeComponent, TransformComponent>();
+        while (enumerator.MoveNext(out var uid, out var _, out var eye, out var viewcone, out var xform))
         {
             if (args.Viewport.Eye != eye.Eye)
                 continue;
@@ -65,7 +55,7 @@ public sealed class ESViewconeConeOverlay : Overlay
             _coneFeather = viewcone.ConeFeather;
             _coneIgnoreRadius = (viewcone.ConeIgnoreRadius - viewcone.ConeIgnoreFeather) * 50f;
             _coneIgnoreFeather = Math.Max(viewcone.ConeIgnoreFeather * 200f, 8f);
-            _eyeEntity = (uid, eye, xform);
+            _eyeEntity = (uid, eye, viewcone, xform);
             break;
         }
 
@@ -80,54 +70,9 @@ public sealed class ESViewconeConeOverlay : Overlay
         var worldHandle = args.WorldHandle;
         var viewport = args.WorldBounds;
 
-        var zoom = _eyeEntity.Value.Comp1.Zoom.X;
-        var eyeAngle = (float) _eyeEntity.Value.Comp1.Rotation.Theta;
-        var playerAngle = (float) _xform.GetWorldRotation(_eyeEntity.Value.Comp2).Theta;
-        _lastWorldRotationAngle = playerAngle;
-
-        if (_ent.HasComponent<MouseRotatorComponent>(_eyeEntity))
-        {
-            var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
-            if (mousePos.MapId != MapId.Nullspace)
-                playerAngle = (float) (mousePos.Position - _xform.GetMapCoordinates(_eyeEntity.Value).Position).ToAngle().Theta + MathHelper.DegreesToRadians(90f);
-
-            _lastMouseRotationAngle = playerAngle;
-        }
-        else if (_lastMouseRotationAngle != 0f)
-        {
-            // if last frame we had a mouse rotation angle, but now we dont,
-            // that means it was disabled
-            // but, we should keep the old mouse angle for viewcone, at least until the real angle actually changes
-            if (MathHelper.CloseToPercent(_lastWorldRotationAngle, playerAngle))
-            {
-                playerAngle = _lastMouseRotationAngle;
-            }
-            else
-            {
-                _lastMouseRotationAngle = 0f;
-            }
-        }
-
-        _desiredViewAngle = playerAngle + eyeAngle;
-
-        // lastframe zero means first frame, so just set it to desired immediately
-        if (_lastFrame == TimeSpan.Zero)
-        {
-            _viewAngle = _desiredViewAngle;
-        }
-        else
-        {
-            // otherwise, framerate-independent lerp
-            var dt = (float) (_timing.RealTime - _lastFrame).TotalSeconds;
-            // https://twitter.com/FreyaHolmer/status/1757836988495847568
-            _viewAngle = MathHelper.Lerp(_viewAngle, _desiredViewAngle, 1f - MathF.Pow(2f, -(dt / LerpHalfLife)));
-        }
-
-        _lastFrame = _timing.RealTime;
-
         _viewconeShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-        _viewconeShader.SetParameter("Zoom", zoom);
-        _viewconeShader.SetParameter("ViewAngle", _viewAngle);
+        _viewconeShader.SetParameter("Zoom", _eyeEntity.Value.Comp1.Zoom.X);
+        _viewconeShader.SetParameter("ViewAngle", (float) _eyeEntity.Value.Comp2.ViewAngle.Theta);
         _viewconeShader.SetParameter("ConeAngle", _coneAngle);
         _viewconeShader.SetParameter("ConeFeather", _coneFeather);
         _viewconeShader.SetParameter("ConeIgnoreRadius", _coneIgnoreRadius);

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
@@ -18,8 +18,6 @@ namespace Content.Client._ES.Viewcone.Overlays;
 public sealed class ESViewconeSetAlphaOverlay : Overlay
 {
     [Dependency] private readonly IEntityManager _ent = default!;
-    [Dependency] private readonly IEyeManager _eye = default!;
-    [Dependency] private readonly IInputManager _input = default!;
     private readonly ESViewconeOverlayManagementSystem _cone;
     private readonly ESViewconeOccludableTreeSystem _tree;
     private readonly TransformSystem _xform;
@@ -70,26 +68,12 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
         var (ent, eye, cone) = _nextEye.Value;
 
         var eyeTransform = _ent.GetComponent<TransformComponent>(ent);
-        var (eyePos, eyeRot) = _xform.GetWorldPositionRotation(eyeTransform);
+        var eyePos = _xform.GetWorldPosition(eyeTransform);
+        var eyeRot = cone.ViewAngle - eye.Rotation; // subtract rotation cuz idk. the lerp adds it but this doesnt want it for some reason idk.
 
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // !! Thank You Bhijn God (TYBG) for 95% of the rest of this methods code !!
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-        if (_ent.HasComponent<MouseRotatorComponent>(ent))
-        {
-            // this should work for multiviewport. at least, about as well as people will expect
-            // this wont run for other eye entities that have viewcones
-            // (if any even end up existing.. I probably made all this code viewport agnostic for no reason)
-            // (but it'd be nice to have cameras that have viewcones. right. right)
-            // (Withers )
-            // but for a separate viewport following the same mouserotator entity, idk, it probably works fine.
-            // when is that even going to happen.
-            var mousePos = _eye.PixelToMap(_input.MouseScreenPosition);
-            if (mousePos.MapId == eyeTransform.MapID)
-                eyeRot = (mousePos.Position - _xform.GetMapCoordinates(eyeTransform).Position).ToWorldAngle();
-        }
-
         var radConeAngle = MathHelper.DegreesToRadians(cone.ConeAngle);
         var radConeFeather = MathHelper.DegreesToRadians(cone.ConeFeather);
 

--- a/Content.Shared/CombatMode/CombatModeComponent.cs
+++ b/Content.Shared/CombatMode/CombatModeComponent.cs
@@ -47,6 +47,6 @@ namespace Content.Shared.CombatMode
         ///     to entities with this flag enabled that enter combat mode, and vice versa for removal.
         /// </summary>
         [DataField, AutoNetworkedField]
-        public bool ToggleMouseRotator = false;
+        public bool ToggleMouseRotator = true;
     }
 }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -83,7 +83,9 @@ public abstract class SharedCombatModeSystem : EntitySystem
         SetMouseRotatorComponents(entity, value);
     }
 
-    private void SetMouseRotatorComponents(EntityUid uid, bool value)
+    // ES START
+    public void SetMouseRotatorComponents(EntityUid uid, bool value)
+    // ES END
     {
         if (value)
         {

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -5,6 +5,9 @@ namespace Content.Shared.Input
     [KeyFunctions]
     public static class ContentKeyFunctions
     {
+        // ES START
+        public static readonly BoundKeyFunction ESHoldToFace = "ESHoldToFace";
+        // ES END
         public static readonly BoundKeyFunction ToggleKnockdown = "ToggleKnockdown";
         public static readonly BoundKeyFunction UseItemInHand = "ActivateItemInHand";
         public static readonly BoundKeyFunction AltUseItemInHand = "AltActivateItemInHand";

--- a/Content.Shared/_ES/Interaction/HoldToFace/ESHoldToFaceComponent.cs
+++ b/Content.Shared/_ES/Interaction/HoldToFace/ESHoldToFaceComponent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.MouseRotator;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Interaction.HoldToFace;
+
+/// <summary>
+///     Marks an entity as being able to hold a key to face a certain direction while that key is held.
+///     Just adds <see cref="MouseRotatorComponent"/> for the duration of the key being held.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESHoldToFaceComponent : Component
+{
+}

--- a/Content.Shared/_ES/Interaction/HoldToFace/ESHoldToFaceSystem.cs
+++ b/Content.Shared/_ES/Interaction/HoldToFace/ESHoldToFaceSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared.CombatMode;
+using Content.Shared.Input;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+
+namespace Content.Shared._ES.Interaction.HoldToFace;
+
+public sealed class ESHoldToFaceSystem : EntitySystem
+{
+    [Dependency] private readonly SharedCombatModeSystem _combat = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.ESHoldToFace,
+                InputCmdHandler.FromDelegate(args => ToggleRotator(args, true), args => ToggleRotator(args, false), false, false))
+            .Register<ESHoldToFaceSystem>();
+    }
+
+    private void ToggleRotator(ICommonSession? session, bool value)
+    {
+        if (session?.AttachedEntity is not { } ent || !HasComp<ESHoldToFaceComponent>(ent))
+            return;
+
+        // Don't try and override combat mode doing the same thing
+        if (TryComp<CombatModeComponent>(ent, out var combat) && combat is { ToggleMouseRotator: true, IsInCombatMode: true })
+            return;
+
+        _combat.SetMouseRotatorComponents(ent, value);
+    }
+}

--- a/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
@@ -42,4 +42,11 @@ public sealed partial class ESViewconeComponent : Component
 
     [DataField, AutoNetworkedField]
     public float ConeIgnoreFeather = 0.25f;
+
+    // Clientside, used for lerping view angle
+    // and keeping it consistent across all overlays
+    public Angle ViewAngle;
+    public Angle? DesiredViewAngle = null;
+    public Angle LastMouseRotationAngle;
+    public Angle LastWorldRotationAngle;
 }

--- a/Resources/Prototypes/_ES/Entities/Mobs/Player/base.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Player/base.yml
@@ -6,5 +6,4 @@
   - type: ESInherentLight
   - type: ESViewcone
   - type: ESViewconeOccludable
-  - type: MouseRotator
-  - type: NoRotateOnMove
+  - type: ESHoldToFace

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -1,5 +1,10 @@
 ﻿version: 1 # Not used right now, whatever.
 binds:
+# ES START
+- function: ESHoldToFace
+  type: State
+  key: Shift
+# ES END
 - function: UIClick
   type: State
   key: MouseLeft


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- no more mouserotator by default (sadiefei didnt like it and i agreed eventually)
- now moves regular rotation style but combatmode still mosuerotators
- but also now you can hold shift (walk/examine) to face the direction youre looking (makes sense cuz if u wanna examine something u wanna look at it. and walking examine is like. looking closely. you know)
- also it lerps the view angle so its smooth and nice and doesnt update immediately

technical
- use lerpingeye in the query first to check for eyes we are actually in control of (the lerpingeye code itself is really jank but it works for our purposes)
- store viewangle stuff on the comp instead of recalculating it twice wrongly in the overlays. now shares and is better


https://github.com/user-attachments/assets/591878d3-dce5-42cc-b0b0-48063c5862bf

