### PR TITLE
Disable mob crawling + enable mob pushing + move cvar changes to preset

### DIFF
--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -163,9 +163,10 @@ namespace Content.Client.Options.UI.Tabs
             AddCheckBox("ui-options-hotkey-toggle-walk", _cfg.GetCVar(CCVars.ToggleWalk), HandleToggleWalk);
             InitToggleWalk();
             // ES START
+            // hold to face + comment out knockdown keybind
             AddButton(ContentKeyFunctions.ESHoldToFace);
+            // AddButton(ContentKeyFunctions.ToggleKnockdown);
             // ES END
-            AddButton(ContentKeyFunctions.ToggleKnockdown);
 
             AddHeader("ui-options-header-camera");
             AddButton(EngineKeyFunctions.CameraRotateLeft);

--- a/Content.IntegrationTests/PoolManager.Cvars.cs
+++ b/Content.IntegrationTests/PoolManager.Cvars.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Content.Shared._ES.CCVar;
 using Content.Shared.CCVar;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -12,6 +13,9 @@ public static partial class PoolManager
     private static readonly (string cvar, string value)[] TestCvars =
     {
         // @formatter:off
+        // ES START
+        (ESCVars.ESStationEnabled.Name,       "false"),
+        // ES END
         (CCVars.DatabaseSynchronous.Name,     "true"),
         (CCVars.DatabaseSqliteDelay.Name,     "0"),
         (CCVars.HolidaysEnabled.Name,         "false"),

--- a/Content.Shared/CCVar/CCVars.Config.cs
+++ b/Content.Shared/CCVar/CCVars.Config.cs
@@ -15,8 +15,12 @@ public sealed partial class CCVars
     ///     Loaded presets must be located under the <c>ConfigPresets/</c> resource directory and end with the <c>.toml</c> extension.
     ///     Only the file name (without extension) must be given for this variable.
     /// </remarks>
+    // ES START
+    // this must be changed here and not in a config preset, because, uh
+    // this is the config preset
     public static readonly CVarDef<string> ConfigPresets =
-        CVarDef.Create("config.presets", "", CVar.SERVERONLY);
+        CVarDef.Create("config.presets", "_ES/base", CVar.SERVERONLY);
+    // ES END
 
     /// <summary>
     ///     Whether to load the preset development CVars.

--- a/Content.Shared/_ES/CCVar/ESCVars.cs
+++ b/Content.Shared/_ES/CCVar/ESCVars.cs
@@ -36,7 +36,7 @@ public sealed partial class ESCVars : CVars
 
     // ES-SPECIFIC STATION HANDLING
     public static readonly CVarDef<bool> ESStationEnabled =
-        CVarDef.Create("es_station.enabled", false, CVar.SERVER);
+        CVarDef.Create("es_station.enabled", true, CVar.SERVER);
 
     public static readonly CVarDef<string> ESStationCurrentConfig =
         CVarDef.Create("es_station.current_config", "ESDefault", CVar.SERVER);

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -45,12 +45,3 @@ see_own_notes = true
 random_characters = true
 random_species_weights = ""
 ssd_sleep_time = 3600
-
-# ES START
-[es_station]
-enabled = true
-
-[audio]
-attenuation = 4 # inversedistanceclamped 1 << 2, see audioparams.cs
-z_offset = -2
-# ES END

--- a/Resources/ConfigPresets/_ES/base.toml
+++ b/Resources/ConfigPresets/_ES/base.toml
@@ -1,0 +1,15 @@
+# Base config for ES
+# aka "replicated/server cvar changes from upstream so we dont modify ccvars"
+# Loaded in both dev and regular server, after dev config preset
+# These don't work for client cvars, so those must be changed in ccvars
+
+[audio]
+attenuation = 4 # inversedistanceclamped 1 << 2, see audioparams.cs
+z_offset = -2
+
+# No mob crawling + mob push tweaks
+[movement]
+crawling = false
+mob_pushing = true
+penetration_cap = 0.35
+push_mass_cap = 1.2

--- a/Resources/ConfigPresets/_ES/ephemeralSpace.toml
+++ b/Resources/ConfigPresets/_ES/ephemeralSpace.toml
@@ -1,7 +1,0 @@
-[game]
-desc             = "WIP"
-lobbyenabled     = true
-
-[audio]
-attenuation = 4 # inversedistanceclamped 1 << 2, see audioparams.cs
-z_offset = -2

--- a/Resources/ConfigPresets/_ES/server.toml
+++ b/Resources/ConfigPresets/_ES/server.toml
@@ -1,0 +1,3 @@
+[game]
+desc             = "WIP"
+lobbyenabled     = true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

also tweaked pushing a bit to be stronger. i like it that way. can tweak it later if we want
removes crawling from the key rebinding menu too, doesnt change the actual key existing though. shouldnt affect anything

cvars that are base ES changes (i.e. should apply in both a server env and dev env) moved to a new base preset which is always loaded

i initially thought presets didnt work for replicated cvars, but they do, so this i shall do