### PR TITLE
Create ES station event table, brush up some existing station events.

### DIFF
--- a/Content.Server/Mining/MeteorComponent.cs
+++ b/Content.Server/Mining/MeteorComponent.cs
@@ -22,4 +22,12 @@ public sealed partial class MeteorComponent : Component
     /// </summary>
     [DataField]
     public HashSet<EntityUid> HitList = new();
+
+// ES START
+    /// <summary>
+    /// Chance to break a tile per second, scaled with frametime.
+    /// </summary>
+    [DataField]
+    public float TileBreakChance = 15f;
+// ES END
 }

--- a/Content.Server/_ES/Masks/Traitor/ESMaskCacheSystem.cs
+++ b/Content.Server/_ES/Masks/Traitor/ESMaskCacheSystem.cs
@@ -4,7 +4,6 @@ using Content.Shared._ES.Auditions.Components;
 using Content.Shared._ES.Masks.Traitor;
 using Content.Shared._ES.Masks.Traitor.Components;
 using Content.Shared._ES.SpawnRegion;
-using Content.Shared.Physics;
 using Robust.Shared.Utility;
 
 namespace Content.Server._ES.Masks.Traitor;
@@ -28,7 +27,12 @@ public sealed class ESMaskCacheSystem : ESSharedMaskCacheSystem
         if (!TryComp<ESCharacterComponent>(ent, out var character))
             return;
 
-        if (!_spawnRegion.TryGetRandomAreaCoords(ent.Comp.Region, character.Station, out var coords, CollisionGroup.MachineLayer))
+        if (!_spawnRegion.TryGetRandomCoordsInRegion(
+                ent.Comp.Region,
+                character.Station,
+                out var coords,
+                checkPlayerLOS: false,
+                minPlayerDistance: 0f))
         {
             Log.Debug("Failed to find spawn region!");
             return;

--- a/Content.Server/_ES/SpawnRegion/ESSpawnRegionSystem.cs
+++ b/Content.Server/_ES/SpawnRegion/ESSpawnRegionSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared._ES.SpawnRegion;
-using Content.Shared._ES.SpawnRegion.Components;
 using Content.Shared.Atmos;
 
 namespace Content.Server._ES.SpawnRegion;
@@ -9,9 +8,9 @@ public sealed class ESSpawnRegionSystem : ESSharedSpawnRegionSystem
 {
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
 
-    protected override bool IsMarkerPressureSafe(Entity<ESSpawnRegionMarkerComponent, TransformComponent> ent)
+    protected override bool IsMarkerPressureSafe(EntityUid grid, EntityUid? map, Vector2i indices)
     {
-        if (_atmosphere.GetTileMixture((ent, ent)) is not { } tileMixture)
+        if (_atmosphere.GetTileMixture(grid, map, indices) is not { } tileMixture)
             return false;
 
         switch (tileMixture.Pressure)
@@ -24,9 +23,9 @@ public sealed class ESSpawnRegionSystem : ESSharedSpawnRegionSystem
         return true;
     }
 
-    protected override bool IsMarkerTemperatureSafe(Entity<ESSpawnRegionMarkerComponent, TransformComponent> ent)
+    protected override bool IsMarkerTemperatureSafe(EntityUid grid, EntityUid? map, Vector2i indices)
     {
-        if (_atmosphere.GetTileMixture((ent, ent)) is not { } tileMixture)
+        if (_atmosphere.GetTileMixture(grid, map, indices) is not { } tileMixture)
             return false;
 
         switch (tileMixture.Temperature) // Arbitrary constants taken from AtmosphereSystem.IsMixtureProbablySafe

--- a/Content.Server/_ES/StationEvents/GasLeak/Components/ESGasLeakRuleComponent.cs
+++ b/Content.Server/_ES/StationEvents/GasLeak/Components/ESGasLeakRuleComponent.cs
@@ -1,0 +1,45 @@
+using System.Numerics;
+using Content.Shared.Atmos;
+using Robust.Shared.Audio;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server._ES.StationEvents.GasLeak.Components;
+
+[RegisterComponent, AutoGenerateComponentPause]
+[Access(typeof(ESGasLeakRule))]
+public sealed partial class ESGasLeakRuleComponent : Component
+{
+    [DataField]
+    public List<Gas> Gasses =
+    [
+        Gas.Ammonia,
+        Gas.Plasma,
+        Gas.Tritium,
+        Gas.Frezon,
+        Gas.WaterVapor, // the fog
+    ];
+
+    [DataField]
+    public Gas LeakGas;
+
+    [DataField]
+    public float LeakRate;
+    [DataField]
+    public Vector2 LeakRateRange = new(80f, 200f);
+    [DataField]
+    public Vector2 LeakMolesRange = new(2000f, 4000f);
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan NextLeakTime;
+    [DataField]
+    public TimeSpan LeakDelay = TimeSpan.FromSeconds(1.5f);
+
+    [DataField]
+    public EntityUid LeakOrigin;
+
+    // TODO: replace with real sparks
+    [DataField]
+    public SoundSpecifier? SparkSound = new SoundCollectionSpecifier("sparks");
+    [DataField]
+    public float SparkChance = 0.05f;
+}

--- a/Content.Server/_ES/StationEvents/GasLeak/ESGasLeakRule.cs
+++ b/Content.Server/_ES/StationEvents/GasLeak/ESGasLeakRule.cs
@@ -1,0 +1,79 @@
+using Content.Server._ES.StationEvents.GasLeak.Components;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Atmos.Piping.Unary.Components;
+using Content.Server.Station.Systems;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Collections;
+using Robust.Shared.Random;
+
+namespace Content.Server._ES.StationEvents.GasLeak;
+
+public sealed class ESGasLeakRule : StationEventSystem<ESGasLeakRuleComponent>
+{
+    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
+    [Dependency] private readonly StationSystem _station = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
+
+    protected override void Started(EntityUid uid, ESGasLeakRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        component.NextLeakTime = Timing.CurTime;
+        component.LeakGas = RobustRandom.Pick(component.Gasses);
+        component.LeakRate = RobustRandom.NextFloat(component.LeakRateRange.X, component.LeakRateRange.Y);
+        var moles = RobustRandom.NextFloat(component.LeakMolesRange.X, component.LeakMolesRange.Y);
+        Comp<StationEventComponent>(uid).EndTime = Timing.CurTime + TimeSpan.FromSeconds(moles / component.LeakRate) + TimeSpan.FromSeconds(1);
+
+        if (!TryGetRandomStation(out var station))
+            return;
+
+        var ventList = new ValueList<Entity<TransformComponent>>();
+        var query = EntityQueryEnumerator<GasVentPumpComponent, TransformComponent>();
+        while (query.MoveNext(out var ventUid, out _, out var xform))
+        {
+            if (_station.GetOwningStation(ventUid, xform) == station)
+                ventList.Add((ventUid, xform));
+        }
+
+        if (ventList.Count == 0)
+            return;
+
+        component.LeakOrigin = RobustRandom.Pick(ventList);
+    }
+
+    protected override void ActiveTick(EntityUid uid, ESGasLeakRuleComponent component, GameRuleComponent gameRule, float frameTime)
+    {
+        base.ActiveTick(uid, component, gameRule, frameTime);
+
+        if (!Exists(component.LeakOrigin) || TerminatingOrDeleted(component.LeakOrigin))
+            return;
+
+        if (Timing.CurTime < component.NextLeakTime)
+            return;
+        component.NextLeakTime += component.LeakDelay;
+
+        var mixture = _atmosphere.GetTileMixture(component.LeakOrigin);
+        mixture?.AdjustMoles(component.LeakGas, (float) (component.LeakRate * component.LeakDelay).TotalSeconds);
+    }
+
+    protected override void Ended(EntityUid uid, ESGasLeakRuleComponent component, GameRuleComponent gameRule, GameRuleEndedEvent args)
+    {
+        base.Ended(uid, component, gameRule, args);
+
+        if (!RobustRandom.Prob(component.SparkChance))
+            return;
+
+        if (!Exists(component.LeakOrigin) || TerminatingOrDeleted(component.LeakOrigin))
+            return;
+
+        if (Transform(component.LeakOrigin).GridUid is not { } grid)
+            return;
+
+        var indices = _transform.GetGridTilePositionOrDefault(component.LeakOrigin);
+        _atmosphere.HotspotExpose(grid, indices, 700f, 50f, null, true);
+        Audio.PlayPvs(component.SparkSound, uid);
+    }
+}

--- a/Content.Shared/_ES/SpawnRegion/ESSharedSpawnRegionSystem.cs
+++ b/Content.Shared/_ES/SpawnRegion/ESSharedSpawnRegionSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Numerics;
 using Content.Shared._ES.SpawnRegion.Components;
 using Content.Shared.Examine;
@@ -6,6 +7,7 @@ using Content.Shared.Ghost;
 using Content.Shared.Maps;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Physics;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Station.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -58,7 +60,7 @@ public abstract class ESSharedSpawnRegionSystem : EntitySystem
     /// <param name="checkAtmosTemperature">If true, unsafe atmospheric temperature will invalidate a coordinate</param>
     /// <param name="pred">Generic predicate for determining if a coordinate is valid</param>
     /// <returns>If <see cref="outCoords"/> was successfully found in a reasonable amount of time.</returns>
-    public bool TryGetRandomAreaCoords(ProtoId<ESSpawnRegionPrototype> region,
+    public bool TryGetRandomCoordsInRegion(ProtoId<ESSpawnRegionPrototype> region,
         Entity<StationDataComponent?> station,
         [NotNullWhen(true)] out EntityCoordinates? outCoords,
         CollisionGroup blockLayer = CollisionGroup.MobMask | CollisionGroup.Opaque,
@@ -66,14 +68,14 @@ public abstract class ESSharedSpawnRegionSystem : EntitySystem
         float minPlayerDistance = 3.5f,
         bool checkAtmosPressure = true,
         bool checkAtmosTemperature = true,
-        Func<Entity<TransformComponent>, bool>? pred = null
+        Func<EntityCoordinates, bool>? pred = null
         )
     {
         outCoords = null;
         if (!Resolve(station, ref station.Comp))
             return false;
 
-        return TryGetRandomAreaCoords(region,
+        return TryGetRandomCoordsInRegion(region,
             station.Comp.Grids,
             out outCoords,
             blockLayer,
@@ -97,7 +99,7 @@ public abstract class ESSharedSpawnRegionSystem : EntitySystem
     /// <param name="checkAtmosTemperature">If true, unsafe atmospheric temperature will invalidate a coordinate</param>
     /// <param name="pred">Generic predicate for determining if a coordinate is valid</param>
     /// <returns>If <see cref="outCoords"/> was successfully found in a reasonable amount of time.</returns>
-    public bool TryGetRandomAreaCoords(ProtoId<ESSpawnRegionPrototype> region,
+    public bool TryGetRandomCoordsInRegion(ProtoId<ESSpawnRegionPrototype> region,
         HashSet<EntityUid> gridSet,
         [NotNullWhen(true)] out EntityCoordinates? outCoords,
         CollisionGroup blockLayer = CollisionGroup.MobMask | CollisionGroup.Opaque,
@@ -105,7 +107,7 @@ public abstract class ESSharedSpawnRegionSystem : EntitySystem
         float minPlayerDistance = 3.5f,
         bool checkAtmosPressure = true,
         bool checkAtmosTemperature = true,
-        Func<Entity<TransformComponent>, bool>? pred = null
+        Func<EntityCoordinates, bool>? pred = null
         )
     {
         outCoords = null;
@@ -121,97 +123,215 @@ public abstract class ESSharedSpawnRegionSystem : EntitySystem
         for (var i = 0; i < attempts; i++)
         {
             var marker = _random.PickAndTake(_markers);
-            if (!IsMarkerValid(marker))
+            if (marker.Comp.Area != region)
                 continue;
 
-            outCoords = Transform(marker).Coordinates;
+            var xform = Transform(marker);
+            if (!xform.Anchored)
+                continue;
+
+            var coords = xform.Coordinates;
+
+            if (!IsCoordinateValid(coords,
+                    gridSet,
+                    blockLayer,
+                    checkPlayerLOS,
+                    minPlayerDistance,
+                    checkAtmosPressure,
+                    checkAtmosTemperature,
+                    pred))
+            {
+                continue;
+            }
+
+            outCoords = coords;
             return true;
         }
         return false;
-
-        bool IsMarkerValid(Entity<ESSpawnRegionMarkerComponent> ent)
-        {
-            if (ent.Comp.Area != region)
-                return false;
-
-            var xform = Transform(ent);
-            var mapId = xform.MapID;
-
-            if (!xform.Anchored ||
-                _transform.GetGrid((ent, xform)) is not { } grid ||
-                !gridSet.Contains(grid) ||
-                !_gridQuery.TryComp(grid, out var gridComp))
-                return false;
-
-            if (pred != null)
-            {
-                if (!pred.Invoke((ent, xform)))
-                    return false;
-            }
-
-            var gridIndices = _transform.GetGridOrMapTilePosition(ent, xform);
-            var tileRef = _map.GetTileRef((grid, gridComp), gridIndices);
-
-            _lookupSet.Clear();
-            _entityLookup.GetEntitiesInTile(tileRef, _lookupSet, LookupFlags.Dynamic | LookupFlags.Static);
-            foreach (var lookupEnt in _lookupSet)
-            {
-                if (_bodyQuery.TryComp(lookupEnt, out var body) &&
-                    body.Hard &&
-                    (body.CollisionMask & (int) blockLayer) != 0)
-                    return false;
-            }
-
-            if (checkPlayerLOS)
-            {
-                _actors.Clear();
-                var box = Box2.CenteredAround(_transform.GetWorldPosition(xform), PlayerViewRadius * Vector2.One * 2);
-                _entityLookup.GetEntitiesIntersecting(mapId, box, _actors, LookupFlags.Dynamic | LookupFlags.Static);
-                foreach (var actor in _actors)
-                {
-                    if (_ghostQuery.HasComp(actor) || !_mobState.IsAlive(actor) || !_mobState.IsCritical(actor))
-                        continue;
-
-                    if (_examine.InRangeUnOccluded(ent, actor.Owner))
-                        return false;
-                }
-            }
-
-            if (minPlayerDistance > 0.0f)
-            {
-                _actors.Clear();
-                _entityLookup.GetEntitiesInRange(xform.Coordinates, minPlayerDistance, _actors);
-                foreach (var actor in _actors)
-                {
-                    if (_ghostQuery.HasComp(actor) || !_mobState.IsAlive(actor) || !_mobState.IsCritical(actor))
-                        continue;
-
-                    return false;
-                }
-            }
-
-            if (checkAtmosPressure)
-            {
-                if (!IsMarkerPressureSafe((ent, ent, xform)))
-                    return false;
-            }
-
-            if (checkAtmosTemperature)
-            {
-                if (!IsMarkerTemperatureSafe((ent, ent, xform)))
-                    return false;
-            }
-
-            return true;
-        }
     }
 
-    protected virtual bool IsMarkerPressureSafe(Entity<ESSpawnRegionMarkerComponent, TransformComponent> ent)
+    /// <summary>
+    /// Selects a random coordinate inside a set of grids, filtering primarily by station
+    /// </summary>
+    /// <param name="station">The station that the area must be on</param>
+    /// <param name="outCoords">The randomly selected coordinate. May be null</param>
+    /// <param name="blockLayer"><see cref="CollisionGroup"/> used for determining if a given coordinate is "blocked"</param>
+    /// <param name="checkPlayerLOS">If true, a coordinate being in player Line of Sight will invalidate it</param>
+    /// <param name="minPlayerDistance">Minimum distance from players that a point must be to be valid</param>
+    /// <param name="checkAtmosPressure">If true, unsafe atmospheric pressure will invalidate a coordinate</param>
+    /// <param name="checkAtmosTemperature">If true, unsafe atmospheric temperature will invalidate a coordinate</param>
+    /// <param name="pred">Generic predicate for determining if a coordinate is valid</param>
+    /// <returns>If <see cref="outCoords"/> was successfully found in a reasonable amount of time.</returns>
+    public bool TryGetRandomCoords(Entity<StationDataComponent?> station,
+        [NotNullWhen(true)] out EntityCoordinates? outCoords,
+        CollisionGroup blockLayer = CollisionGroup.MobMask | CollisionGroup.Opaque,
+        bool checkPlayerLOS = true,
+        float minPlayerDistance = 3.5f,
+        bool checkAtmosPressure = true,
+        bool checkAtmosTemperature = true,
+        Func<EntityCoordinates, bool>? pred = null
+        )
+    {
+        outCoords = null;
+        if (!Resolve(station, ref station.Comp))
+            return false;
+
+        return TryGetRandomCoords(station.Comp.Grids,
+            out outCoords,
+            blockLayer,
+            checkPlayerLOS,
+            minPlayerDistance,
+            checkAtmosPressure,
+            checkAtmosTemperature,
+            pred);
+    }
+
+    /// <summary>
+    /// Selects a random coordinate inside a set of grids
+    /// </summary>
+    /// <param name="gridSet">A set of grids that the area must be located on</param>
+    /// <param name="outCoords">The randomly selected coordinate. May be null</param>
+    /// <param name="blockLayer"><see cref="CollisionGroup"/> used for determining if a given coordinate is "blocked"</param>
+    /// <param name="checkPlayerLOS">If true, a coordinate being in player Line of Sight will invalidate it</param>
+    /// <param name="minPlayerDistance">Minimum distance from players that a point must be to be valid</param>
+    /// <param name="checkAtmosPressure">If true, unsafe atmospheric pressure will invalidate a coordinate</param>
+    /// <param name="checkAtmosTemperature">If true, unsafe atmospheric temperature will invalidate a coordinate</param>
+    /// <param name="pred">Generic predicate for determining if a coordinate is valid</param>
+    /// <returns>If <see cref="outCoords"/> was successfully found in a reasonable amount of time.</returns>
+    public bool TryGetRandomCoords(HashSet<EntityUid> gridSet,
+        [NotNullWhen(true)] out EntityCoordinates? outCoords,
+        CollisionGroup blockLayer = CollisionGroup.MobMask | CollisionGroup.Opaque,
+        bool checkPlayerLOS = true,
+        float minPlayerDistance = 3.5f,
+        bool checkAtmosPressure = true,
+        bool checkAtmosTemperature = true,
+        Func<EntityCoordinates, bool>? pred = null
+        )
+    {
+        var dict = new Dictionary<(Entity<MapGridComponent> grid, List<TileRef> refs), float>();
+        foreach (var grid in gridSet)
+        {
+            var comp = _gridQuery.Comp(grid);
+            var tiles = _map.GetAllTiles(grid, comp).ToList();
+            dict.Add(((grid, comp), tiles), tiles.Count);
+        }
+
+        for (var i = 0; i < RandomAttempts; i++)
+        {
+            var (grid, tiles) = _random.Pick(dict);
+            var tile = _random.Pick(tiles);
+            var coords = _map.ToCoordinates(tile, grid);
+
+            if (!IsCoordinateValid(coords,
+                    gridSet,
+                    blockLayer,
+                    checkPlayerLOS,
+                    minPlayerDistance,
+                    checkAtmosPressure,
+                    checkAtmosTemperature,
+                    pred))
+            {
+                continue;
+            }
+
+            outCoords = coords;
+            return true;
+        }
+
+        outCoords = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a given coordinate is valid according to specified conditions.
+    /// </summary>
+    private bool IsCoordinateValid(EntityCoordinates coords,
+        HashSet<EntityUid> gridSet,
+        CollisionGroup blockLayer = CollisionGroup.MobMask | CollisionGroup.Opaque,
+        bool checkPlayerLOS = true,
+        float minPlayerDistance = 3.5f,
+        bool checkAtmosPressure = true,
+        bool checkAtmosTemperature = true,
+        Func<EntityCoordinates, bool>? pred = null
+        )
+    {
+        if (_transform.GetGrid(coords) is not { } grid ||
+            !gridSet.Contains(grid) ||
+            !_gridQuery.TryComp(grid, out var gridComp))
+            return false;
+
+        if (pred != null)
+        {
+            if (!pred.Invoke(coords))
+                return false;
+        }
+
+        var mapId = _transform.GetMapId(coords);
+        var map = _transform.GetMap(coords);
+        var worldPos = _transform.ToWorldPosition(coords);
+
+        var gridIndices = _map.CoordinatesToTile(grid, gridComp, coords);
+        var tileRef = _map.GetTileRef((grid, gridComp), gridIndices);
+
+        _lookupSet.Clear();
+        _entityLookup.GetEntitiesInTile(tileRef, _lookupSet, LookupFlags.Dynamic | LookupFlags.Static);
+        foreach (var lookupEnt in _lookupSet)
+        {
+            if (_bodyQuery.TryComp(lookupEnt, out var body) &&
+                body.Hard &&
+                (body.CollisionMask & (int) blockLayer) != 0)
+                return false;
+        }
+
+        if (checkPlayerLOS)
+        {
+            _actors.Clear();
+            var box = Box2.CenteredAround(worldPos, PlayerViewRadius * Vector2.One * 2);
+            _entityLookup.GetEntitiesIntersecting(mapId, box, _actors, LookupFlags.Dynamic | LookupFlags.Static);
+            foreach (var actor in _actors)
+            {
+                if (_ghostQuery.HasComp(actor) || !_mobState.IsAlive(actor) || !_mobState.IsCritical(actor))
+                    continue;
+
+                if (_examine.InRangeUnOccluded(actor.Owner, coords))
+                    return false;
+            }
+        }
+
+        if (minPlayerDistance > 0.0f)
+        {
+            _actors.Clear();
+            _entityLookup.GetEntitiesInRange(coords, minPlayerDistance, _actors);
+            foreach (var actor in _actors)
+            {
+                if (_ghostQuery.HasComp(actor) || !_mobState.IsAlive(actor) || !_mobState.IsCritical(actor))
+                    continue;
+
+                return false;
+            }
+        }
+
+        if (checkAtmosPressure)
+        {
+            if (!IsMarkerPressureSafe(grid, map, gridIndices))
+                return false;
+        }
+
+        if (checkAtmosTemperature)
+        {
+            if (!IsMarkerTemperatureSafe(grid, map, gridIndices))
+                return false;
+        }
+
+        return true;
+    }
+
+    protected virtual bool IsMarkerPressureSafe(EntityUid grid, EntityUid? map, Vector2i indices)
     {
         return true;
     }
 
-    protected virtual bool IsMarkerTemperatureSafe(Entity<ESSpawnRegionMarkerComponent, TransformComponent> ent)
+    protected virtual bool IsMarkerTemperatureSafe(EntityUid grid, EntityUid? map, Vector2i indices)
     {
         return true;
     }

--- a/Resources/Prototypes/_ES/Entities/Objects/Misc/meteors.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Misc/meteors.yml
@@ -1,0 +1,43 @@
+- type: entity
+  parent: BaseMeteor
+  id: ESMeteor
+  suffix: ES
+  components:
+  - type: Sprite
+    state: big
+    noRot: true
+  - type: Explosive
+    totalIntensity: 75
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.15
+        density: 100
+        hard: false
+        layer:
+        - LargeMobLayer
+        mask:
+        - Impassable
+        - BulletImpassable
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1250
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:ExplodeBehavior
+  - type: WarpPoint
+    follow: true
+    location: meteor
+    blacklist:
+      tags:
+      - GhostOnlyWarp
+  - type: Tag
+    tags: [ GhostOnlyWarp ]

--- a/Resources/Prototypes/_ES/GameRules/presets.yml
+++ b/Resources/Prototypes/_ES/GameRules/presets.yml
@@ -6,6 +6,5 @@
   rules:
   - ESTroupeRuleCrew
   - ESTroupeRuleTraitor
-  - BasicStationEventScheduler # TODO: Create new event scheduler with more reasonable events.
-  - MeteorSwarmScheduler
+  - ESSchedulerRuleStationEvent
   - BasicRoundstartVariation

--- a/Resources/Prototypes/_ES/GameRules/schedulers.yml
+++ b/Resources/Prototypes/_ES/GameRules/schedulers.yml
@@ -1,0 +1,19 @@
+- type: entity
+  parent: BaseGameRule
+  id: ESSchedulerRuleStationEvent
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules:
+      tableId: ESStationEvents
+
+- type: entityTable
+  id: ESStationEvents
+  table:
+    all:
+    - id: ESStationEventBreakerFlip
+    - id: ESStationEventGasLeak
+    - id: ESStationEventPowerGridCheck
+    - id: ESStationEventSolarFlare
+    - id: ESStationEventVentClog
+    - id: ESStationEventMeteorSwarm
+    - id: ESStationEventSpaceDust

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -1,0 +1,112 @@
+- type: entity
+  parent: BaseGameRule
+  id: ESBaseStationEvent
+  abstract: true
+  components:
+  - type: StationEvent
+    startAudio: /Audio/Announcements/attention.ogg # Station events should always have announcements
+    earliestStart: 0
+    weight: 10
+  - type: GameRule
+    delay:
+      min: 5
+      max: 15
+
+- type: entity # Variant for events which have a delay between announcing and starting effects
+  parent: ESBaseStationEvent
+  id: ESBaseStationEventDelayed
+  abstract: true
+  components:
+  - type: GameRule
+    delay:
+      min: 55
+      max: 65
+
+# Event Prototypes
+- type: entity
+  parent: ESBaseStationEvent
+  id: ESStationEventBreakerFlip
+  components:
+  - type: BreakerFlipRule
+
+- type: entity
+  parent: ESBaseStationEvent
+  id: ESStationEventGasLeak
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-gas-leak-start-announcement
+    endAnnouncement: station-event-gas-leak-end-announcement
+  - type: GasLeakRule
+
+- type: entity
+  parent: ESBaseStationEvent
+  id: ESStationEventPowerGridCheck
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-power-grid-check-start-announcement
+    endAnnouncement: station-event-power-grid-check-end-announcement
+    startAudio:
+      path: /Audio/Announcements/power_off.ogg
+      params:
+        volume: -4
+    duration: 60
+    maxDuration: 120
+  - type: PowerGridCheckRule
+
+- type: entity
+  parent: ESBaseStationEvent
+  id: ESStationEventSolarFlare
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-solar-flare-start-announcement
+    endAnnouncement: station-event-solar-flare-end-announcement
+    duration: 120
+    maxDuration: 240
+  - type: SolarFlareRule
+    onlyJamHeadsets: true
+    affectedChannels:
+    - Common
+    extraChannels:
+    - Command
+    - Engineering
+    - Medical
+    - Science
+    - Security
+    - Service
+    - Supply
+    extraCount: 2
+    lightBreakChancePerSecond: 0.0003
+    doorToggleChancePerSecond: 0.001
+
+- type: entity
+  parent: ESBaseStationEventDelayed
+  id: ESStationEventVentClog
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-vent-clog-start-announcement
+  - type: VentClogRule
+
+- type: entity
+  parent: ESBaseStationEvent #Delayed
+  id: ESStationEventMeteorSwarm
+  components:
+  - type: MeteorSwarm
+    meteors:
+      ESMeteor: 1
+
+- type: entity
+  parent: ESBaseStationEventDelayed
+  id: ESStationEventSpaceDust
+  components:
+  - type: MeteorSwarm
+    announcement: station-event-space-dust-start-announcement
+    announcementSound: null
+    nonDirectional: true
+    meteors:
+      MeteorSpaceDust: 1
+    waves:
+      min: 2
+      max: 3
+    meteorsPerWave:
+      min: 8
+      max: 12

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -36,7 +36,7 @@
   - type: StationEvent
     startAnnouncement: station-event-gas-leak-start-announcement
     endAnnouncement: station-event-gas-leak-end-announcement
-  - type: GasLeakRule
+  - type: ESGasLeakRule
 
 - type: entity
   parent: ESBaseStationEvent
@@ -87,7 +87,7 @@
   - type: VentClogRule
 
 - type: entity
-  parent: ESBaseStationEvent #Delayed
+  parent: ESBaseStationEventDelayed
   id: ESStationEventMeteorSwarm
   components:
   - type: MeteorSwarm

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -90,6 +90,9 @@
   parent: ESBaseStationEventDelayed
   id: ESStationEventMeteorSwarm
   components:
+  - type: StationEvent
+    startAudio: null
+    earliestStart: 30
   - type: MeteorSwarm
     meteors:
       ESMeteor: 1
@@ -98,6 +101,9 @@
   parent: ESBaseStationEventDelayed
   id: ESStationEventSpaceDust
   components:
+  - type: StationEvent
+    startAudio: null
+    earliestStart: 30
   - type: MeteorSwarm
     announcement: station-event-space-dust-start-announcement
     announcementSound: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a station event table with the following events:
- Breaker flip
- Gas leak
- Power grid check
- Solar flare
- Vent foam
- Space dust
- Meteor

Modifies the gas leak event to be based on a vent rather than an arbitrary set of coordinates. Does some yaml futzing for meteors, making them generally less destructive. Also adds tile destruction to meteors.

all the event weights are kinda fucked but i dont think it matters too much + i know mirror will balance it some day.