### PR TITLE
Cleanup RandomSentience targets

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -1175,9 +1175,11 @@
     - Recyclable
     - WhitelistChameleon
     - HamsterWearable
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-inanimate
-    weight: 0.0002 # 5,000 times less likely than 1 regular animal
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-inanimate
+    # weight: 0.0002 # 5,000 times less likely than 1 regular animal
+# ES End
   - type: BlockMovement
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -47,8 +47,10 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/Animals/fox_squeak.ogg
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-organic
+# ES End
   - type: Bloodstream
     bloodMaxVolume: 50
   - type: ReplacementAccent
@@ -268,8 +270,10 @@
   - type: ExaminableHunger
   - type: ReplacementAccent
     accent: chicken
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-organic
+# ES End
   - type: NpcFactionMember
     factions:
     - Passive
@@ -711,8 +715,10 @@
   - type: ExaminableHunger
   - type: ReplacementAccent
     accent: duck
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-organic
+# ES End
   - type: NpcFactionMember
     factions:
     - Passive
@@ -3586,8 +3592,10 @@
       path: /Audio/Animals/pig_oink.ogg
   - type: ReplacementAccent
     accent: pig
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-organic
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-organic
+# ES End
   - type: NpcFactionMember
     factions:
     - Passive

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -113,9 +113,11 @@
     - WhitelistChameleonPDA
   - type: Input
     context: "human"
-  - type: SentienceTarget # sentient PDA = pAI lite
-    flavorKind: station-event-random-sentience-flavor-mechanical
-    weight: 0.001 # 1,000 PDAs = as likely to be picked as 1 regular animal
+# ES Start
+  # - type: SentienceTarget # sentient PDA = pAI lite
+    # flavorKind: station-event-random-sentience-flavor-mechanical
+    # weight: 0.001 # 1,000 PDAs = as likely to be picked as 1 regular animal
+# ES End
   - type: BlockMovement
     blockInteraction: false # lets the PDA toggle its own flashlight
   - type: TypingIndicator

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -678,10 +678,12 @@
     price: 750
   - type: StealTarget
     stealGroup: WeaponAntiqueLaser
-  - type: SentienceTarget # I hope this is only the captain's gun
-    flavorKind: station-event-random-sentience-flavor-inanimate
-    weight: 0.0002 # 5,000 times less likely than 1 regular animal
+# ES Start
+  # - type: SentienceTarget # I hope this is only the captain's gun
+    # flavorKind: station-event-random-sentience-flavor-inanimate
+    # weight: 0.0002 # 5,000 times less likely than 1 regular animal
     # not putting a BlockMovement component here cause that's funny.
+# ES End
 
 - type: entity
   name: advanced laser pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -102,9 +102,11 @@
     tags:
     - CaptainSabre
   - type: DisarmMalus
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-inanimate
-    weight: 0.0002 # 5,000 times less likely than 1 regular animal
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-inanimate
+    # weight: 0.0002 # 5,000 times less likely than 1 regular animal
+# ES End
   - type: PirateAccent
     # not putting a BlockMovement component here cause that's funny.
   - type: StealTarget

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -101,9 +101,11 @@
   - type: ApcPowerReceiver
     powerLoad: 200
   - type: Actions
-  - type: SentienceTarget
-    flavorKind: station-event-random-sentience-flavor-mechanical
-    weight: 0.025 # fuck you in particular (it now needs 40 vending machines to be as likely as 1 interesting animal)
+# ES Start
+  # - type: SentienceTarget
+    # flavorKind: station-event-random-sentience-flavor-mechanical
+    # weight: 0.025 # fuck you in particular (it now needs 40 vending machines to be as likely as 1 interesting animal)
+# ES End
   - type: StaticPrice
     price: 100
   - type: Appearance


### PR DESCRIPTION
## About the PR
This PR removes a bunch of unnecessary RandomSentience targets, leaving only the ancestor mobs untouched.

## Why / Balance
The removed targets were not very fun or interesting to play as. Once you've seen one talking BODA, you've seen 'em all.
There's also not really much point in having targets for a bunch of objects at extreme rarities. I've never even seen half of them.
Resolves https://github.com/EphemeralSpace/ephemeral-space/issues/201

## Media
<img width="917" height="804" alt="image" src="https://github.com/user-attachments/assets/a0667ca4-0004-4830-ac18-7216a53fae80" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

