### PR TITLE
Miscellaneous Troupe Features

### DIFF
--- a/Content.Client/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Client/_ES/Masks/ESMaskSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared._ES.Masks;
+using Content.Shared._ES.Masks.Components;
 using Content.Shared.Administration;
+using Content.Shared.StatusIcon.Components;
 using Content.Shared.Verbs;
 
 namespace Content.Client._ES.Masks;
@@ -10,7 +12,13 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ESTroupeFactionIconComponent, GetStatusIconsEvent>(OnGetStatusIcons);
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(OnGetVerbs);
+    }
+
+    private void OnGetStatusIcons(Entity<ESTroupeFactionIconComponent> ent, ref GetStatusIconsEvent args)
+    {
+        args.StatusIcons.Add(PrototypeManager.Index(ent.Comp.Icon));
     }
 
     private void OnGetVerbs(GetVerbsEvent<Verb> args)

--- a/Content.Server/_ES/Masks/Components/ESTroupeRuleComponent.cs
+++ b/Content.Server/_ES/Masks/Components/ESTroupeRuleComponent.cs
@@ -47,4 +47,10 @@ public sealed partial class ESTroupeRuleComponent : Component
     /// </summary>
     [DataField]
     public List<EntityUid> TroupeMemberMinds = new();
+
+    /// <summary>
+    /// Objective entities this troupe has spawned
+    /// </summary>
+    [DataField]
+    public List<EntityUid> AssociatedObjectives = new();
 }

--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -28,7 +28,6 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
 {
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
-    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ESAuditionsSystem _esAuditions = default!;
     [Dependency] private readonly EntityTableSystem _entityTable = default!;
@@ -54,7 +53,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
 
     private void OnMapInit(Entity<ESTroupeRuleComponent> ent, ref MapInitEvent args)
     {
-        var troupe = _prototypeManager.Index(ent.Comp.Troupe);
+        var troupe = PrototypeManager.Index(ent.Comp.Troupe);
         var objectives = _entityTable.GetSpawns(troupe.Objectives);
 
         var dummyMind = _mind.CreateMind(null);
@@ -94,7 +93,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
             !TryComp<ActorComponent>(args.Target, out var actorComp))
             return;
 
-        foreach (var mask in _prototypeManager.EnumeratePrototypes<ESMaskPrototype>())
+        foreach (var mask in PrototypeManager.EnumeratePrototypes<ESMaskPrototype>())
         {
             if (mask.Abstract)
                 continue;
@@ -104,7 +103,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
                 Category = ESMask,
                 Text = Loc.GetString("es-verb-apply-mask-name",
                     ("name", Loc.GetString(mask.Name)),
-                    ("troupe", Loc.GetString(_prototypeManager.Index(mask.Troupe).Name))),
+                    ("troupe", Loc.GetString(PrototypeManager.Index(mask.Troupe).Name))),
                 Message = Loc.GetString("es-verb-apply-mask-desc", ("mask", Loc.GetString(mask.Name))),
                 Priority = HashCode.Combine(mask.Troupe, mask.Name),
                 ConfirmationPopup = true,
@@ -140,7 +139,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
 
     public bool TryAssignToTroupe(Entity<ESTroupeRuleComponent> ent, ref List<ICommonSession> players)
     {
-        var troupe = _prototypeManager.Index(ent.Comp.Troupe);
+        var troupe = PrototypeManager.Index(ent.Comp.Troupe);
 
         var filteredPlayers = players.Where(s => IsPlayerValid(troupe, s)).ToList();
 
@@ -215,7 +214,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         mask = null;
 
         var weights = new Dictionary<ESMaskPrototype, float>();
-        foreach (var maskProto in _prototypeManager.EnumeratePrototypes<ESMaskPrototype>())
+        foreach (var maskProto in PrototypeManager.EnumeratePrototypes<ESMaskPrototype>())
         {
             if (maskProto.Abstract)
                 continue;
@@ -235,7 +234,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
 
     public void ApplyMask(Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId, Entity<ESTroupeRuleComponent>? troupe)
     {
-        var mask = _prototypeManager.Index(maskId);
+        var mask = PrototypeManager.Index(maskId);
 
         _role.MindAddRole(mind, MindRole, mind, true);
 
@@ -254,6 +253,8 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
             _chat.ChatMessageToOne(ChatChannel.Server, msg, msg, default, false, session.Channel, Color.Plum);
         }
 
+        if (mind.Comp.OwnedEntity is { } ownedEntity)
+            EntityManager.AddComponents(ownedEntity, mask.Components);
         EntityManager.AddComponents(mind, mask.MindComponents);
 
         // TODO: eventually, this should be required.

--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -5,6 +5,7 @@ using Content.Server._ES.Masks.Components;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
+using Content.Server.Objectives;
 using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
 using Content.Shared._ES.Masks;
@@ -34,6 +35,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly JobSystem _job = default!;
     [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly ObjectivesSystem _objectives = default!;
     [Dependency] private readonly RoleSystem _role = default!;
 
     private static readonly EntProtoId<ESMaskRoleComponent> MindRole = "ESMindRoleMask";
@@ -43,9 +45,27 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ESTroupeRuleComponent, MapInitEvent>(OnMapInit);
+
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
         SubscribeLocalEvent<RulePlayerJobsAssignedEvent>(OnRulePlayerJobsAssigned);
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(GetVerbs);
+    }
+
+    private void OnMapInit(Entity<ESTroupeRuleComponent> ent, ref MapInitEvent args)
+    {
+        var troupe = _prototypeManager.Index(ent.Comp.Troupe);
+        var objectives = _entityTable.GetSpawns(troupe.Objectives);
+
+        var dummyMind = _mind.CreateMind(null);
+
+        foreach (var objective in objectives)
+        {
+            if (!_objectives.TryCreateObjective(dummyMind, objective, out var objectiveUid))
+                continue;
+            ent.Comp.AssociatedObjectives.Add(objectiveUid.Value);
+        }
+        Del(dummyMind);
     }
 
     private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
@@ -96,7 +116,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
                     // For now, this is just for testing and doesn't need to necessarily support everything
                     // In a future ideal implementation, every troupe should have an associated "minimum viable rule"
                     // such that if a given troupe does not have a corresponding rule, one can be created.
-                    ApplyMask((mind, mindComp), mask);
+                    ApplyMask((mind, mindComp), mask, null);
                 },
             };
             args.Verbs.Add(verb);
@@ -147,8 +167,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
                 continue;
             }
 
-            ent.Comp.TroupeMemberMinds.Add(mind);
-            ApplyMask((mind, mindComp), mask.Value);
+            ApplyMask((mind, mindComp), mask.Value, ent);
         }
         return true;
     }
@@ -214,7 +233,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         return true;
     }
 
-    public void ApplyMask(Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId)
+    public void ApplyMask(Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId, Entity<ESTroupeRuleComponent>? troupe)
     {
         var mask = _prototypeManager.Index(maskId);
 
@@ -236,5 +255,16 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         }
 
         EntityManager.AddComponents(mind, mask.MindComponents);
+
+        // TODO: eventually, this should be required.
+        if (troupe == null)
+            return;
+
+        troupe.Value.Comp.TroupeMemberMinds.Add(mind);
+
+        foreach (var objective in troupe.Value.Comp.AssociatedObjectives)
+        {
+            _mind.AddObjective(mind, mind, objective);
+        }
     }
 }

--- a/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
+++ b/Content.Shared/Objectives/Systems/SharedObjectivesSystem.cs
@@ -70,6 +70,9 @@ public abstract class SharedObjectivesSystem : EntitySystem
 
         if (!CanBeAssigned(uid, mindId, mind, comp))
         {
+// ES START
+            Del(uid);
+// ES END
             Log.Warning($"Objective {proto} did not match the requirements for {_mind.MindOwnerLoggingString(mind)}, deleted it");
             return null;
         }

--- a/Content.Shared/_ES/Masks/Components/ESTroupeFactionIconComponent.cs
+++ b/Content.Shared/_ES/Masks/Components/ESTroupeFactionIconComponent.cs
@@ -1,0 +1,33 @@
+using Content.Shared.StatusIcon;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Masks.Components;
+
+/// <summary>
+/// Used for members of a <see cref="ESTroupePrototype"/> that can see icons on each other
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(ESSharedMaskSystem))]
+public sealed partial class ESTroupeFactionIconComponent : Component
+{
+    /// <summary>
+    /// The status icon to show
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<FactionIconPrototype> Icon;
+
+    /// <summary>
+    /// The troupe that must be shared for this comp to be networked
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<ESTroupePrototype> Troupe;
+
+    /// <summary>
+    /// Field shown to members of the same troupe on examine.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public LocId? ExamineString;
+
+    public override bool SessionSpecific => true;
+}

--- a/Content.Shared/_ES/Masks/ESMaskPrototype.cs
+++ b/Content.Shared/_ES/Masks/ESMaskPrototype.cs
@@ -18,6 +18,7 @@ public sealed partial class ESMaskPrototype : IPrototype, IInheritingPrototype
     [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<ESMaskPrototype>))]
     public string[]? Parents { get; }
 
+    [NeverPushInheritance]
     [AbstractDataField]
     public bool Abstract { get; }
 
@@ -41,6 +42,9 @@ public sealed partial class ESMaskPrototype : IPrototype, IInheritingPrototype
     /// </summary>
     [DataField]
     public LocId Description;
+
+    [DataField]
+    public ComponentRegistry Components = new();
 
     [DataField]
     public ComponentRegistry MindComponents = new();

--- a/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
@@ -1,12 +1,54 @@
+using Content.Shared._ES.Masks.Components;
 using Content.Shared.Administration.Managers;
+using Content.Shared.Examine;
 using Content.Shared.Verbs;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared._ES.Masks;
 
 public abstract class ESSharedMaskSystem : EntitySystem
 {
     [Dependency] protected readonly ISharedAdminManager AdminManager = default!;
+    [Dependency] protected readonly IPrototypeManager PrototypeManager = default!;
 
     protected static readonly VerbCategory ESMask =
         new("es-verb-categories-mask", "/Textures/Interface/emotes.svg.192dpi.png");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESTroupeFactionIconComponent, ComponentGetStateAttemptEvent>(OnComponentGetStateAttempt);
+        SubscribeLocalEvent<ESTroupeFactionIconComponent, ExaminedEvent>(OnExaminedEvent);
+    }
+
+    private void OnComponentGetStateAttempt(Entity<ESTroupeFactionIconComponent> ent, ref ComponentGetStateAttemptEvent args)
+    {
+        args.Cancelled = true;
+
+        if (args.Player?.AttachedEntity is not { } attachedEntity)
+            return;
+        if (!TryComp<ESTroupeFactionIconComponent>(attachedEntity, out var component))
+            return;
+        if (ent.Comp.Troupe != component.Troupe)
+            return;
+        args.Cancelled = false;
+    }
+
+    private void OnExaminedEvent(Entity<ESTroupeFactionIconComponent> ent, ref ExaminedEvent args)
+    {
+        // Don't show for yourself
+        if (args.Examiner == ent.Owner)
+            return;
+
+        if (ent.Comp.ExamineString is not { } str)
+            return;
+
+        if (!TryComp<ESTroupeFactionIconComponent>(args.Examiner, out var component) ||
+            component.Troupe != ent.Comp.Troupe)
+            return;
+
+        args.PushMarkup(Loc.GetString(str));
+    }
 }

--- a/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._ES.Masks.Components;
 using Content.Shared.Administration.Managers;
+using Content.Shared.Antag;
 using Content.Shared.Examine;
 using Content.Shared.Verbs;
 using Robust.Shared.GameStates;
@@ -29,6 +30,13 @@ public abstract class ESSharedMaskSystem : EntitySystem
 
         if (args.Player?.AttachedEntity is not { } attachedEntity)
             return;
+
+        if (HasComp<ShowAntagIconsComponent>(attachedEntity))
+        {
+            args.Cancelled = false;
+            return;
+        }
+
         if (!TryComp<ESTroupeFactionIconComponent>(attachedEntity, out var component))
             return;
         if (ent.Comp.Troupe != component.Troupe)

--- a/Content.Shared/_ES/Masks/ESTroupePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESTroupePrototype.cs
@@ -1,3 +1,4 @@
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
@@ -28,4 +29,10 @@ public sealed partial class ESTroupePrototype : IPrototype, IInheritingPrototype
     /// </summary>
     [DataField]
     public HashSet<ProtoId<JobPrototype>> ProhibitedJobs = new();
+
+    /// <summary>
+    /// The objectives that this troupe gives to its members
+    /// </summary>
+    [DataField]
+    public EntityTableSelector Objectives = new NoneSelector();
 }

--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -7,6 +7,7 @@ es-mask-mercenary-desc = Utilize your dubiously-legal gear to aid in the complet
 
 
 # Traitor masks
+es-mask-troupe-traitor-examine = They're a fellow [bold][color=red]Traitor[/color][/bold] and a member of the [bold][color=red]Syndicate[/color][/bold]. Work together to complete the objectives.
 
 es-mask-assassin-name = Assassin
 es-mask-assassin-desc =  Aid your fellow traitors & complete your objectives to detonate the nuke. You have recieved been trained by the syndicate for stealthy assasinations.

--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -11,31 +11,39 @@
 
 # Traitor Masks
 - type: esMask
+  id: ESBaseTraitor
+  abstract: true
+  troupe: ESTraitor
+  weight: 1
+  components:
+  - type: ESTroupeFactionIcon
+    icon: ESTraitor
+    troupe: ESTraitor
+    examineString: es-mask-troupe-traitor-examine
+
+- type: esMask
+  parent: ESBaseTraitor
   id: ESMarauder
   name: es-mask-marauder-name
-  troupe: ESTraitor
   description: es-mask-marauder-desc
-  weight: 1
   mindComponents:
   - type: ESMaskCacheSpawner
     cacheProto: ESCrateCacheTraitorMarauder
 
 - type: esMask
+  parent: ESBaseTraitor
   id: ESAssassin
   name: es-mask-assassin-name
-  troupe: ESTraitor
   description: es-mask-assassin-desc
-  weight: 1
   mindComponents:
   - type: ESMaskCacheSpawner
     cacheProto: ESCrateCacheTraitorAssassin
 
 - type: esMask
+  parent: ESBaseTraitor
   id: ESInfiltrator
   name: es-mask-infiltrator-name
-  troupe: ESTraitor
   description: es-mask-infiltrator-desc
-  weight: 1
   mindComponents:
   - type: ESMaskCacheSpawner
     cacheProto: ESCrateCacheTraitorInfiltrator

--- a/Resources/Prototypes/_ES/StatusIcon/faction.yml
+++ b/Resources/Prototypes/_ES/StatusIcon/faction.yml
@@ -19,3 +19,14 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: Nanotrasen
+
+- type: factionIcon
+  id: ESTraitor
+  locationPreference: Right
+  showTo:
+    components:
+    - ShowAntagIcons
+    - ESTroupeFactionIcon
+  icon:
+    sprite: /Textures/Interface/Misc/job_icons.rsi
+    state: Syndicate


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- troupe members can now share objectives
- masks can apply components to their associated entities
- traitors can identify each other by sight (with anti-cheat support!!!!)

also changed the traitor masks to use some parenting for debloatery.
