### PR TITLE
Add secondary votes to events

### DIFF
--- a/Content.Server/_ES/StationEvents/GasLeak/Components/ESGasLeakRuleComponent.cs
+++ b/Content.Server/_ES/StationEvents/GasLeak/Components/ESGasLeakRuleComponent.cs
@@ -10,16 +10,6 @@ namespace Content.Server._ES.StationEvents.GasLeak.Components;
 public sealed partial class ESGasLeakRuleComponent : Component
 {
     [DataField]
-    public List<Gas> Gasses =
-    [
-        Gas.Ammonia,
-        Gas.Plasma,
-        Gas.Tritium,
-        Gas.Frezon,
-        Gas.WaterVapor, // the fog
-    ];
-
-    [DataField]
     public Gas LeakGas;
 
     [DataField]

--- a/Content.Server/_ES/StationEvents/GasLeak/Components/ESGasVentVoteComponent.cs
+++ b/Content.Server/_ES/StationEvents/GasLeak/Components/ESGasVentVoteComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared._ES.Voting.Components;
+
+namespace Content.Server._ES.StationEvents.GasLeak.Components;
+
+/// <summary>
+/// <see cref="ESVoteComponent"/> for a random gas vent on the station.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ESGasLeakRule))]
+public sealed partial class ESGasVentVoteComponent : Component
+{
+    [DataField]
+    public int Count = 6;
+}

--- a/Content.Server/_ES/StationEvents/Scheduler/ESEventVoteSchedulerSystem.cs
+++ b/Content.Server/_ES/StationEvents/Scheduler/ESEventVoteSchedulerSystem.cs
@@ -4,6 +4,7 @@ using Content.Server._ES.Voting;
 using Content.Server.GameTicking.Rules;
 using Content.Server.StationEvents;
 using Content.Shared._ES.Voting.Components;
+using Content.Shared._ES.Voting.Results;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Prototypes;

--- a/Content.Server/_ES/Voting/ESVoteSystem.cs
+++ b/Content.Server/_ES/Voting/ESVoteSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._ES.Voting.Components;
 using Content.Shared.Administration;
 using Content.Shared.Chat;
 using Content.Shared.Database;
+using Content.Shared.GameTicking.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Toolshed;
@@ -19,6 +20,22 @@ public sealed class ESVoteSystem : ESSharedVoteSystem
     [Dependency] private readonly IChatManager _chat = default!;
 
     private const string VoteSound = "/Audio/Effects/voteding.ogg";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GameRuleComponent, ESSynchronizedVotesPostCompletedEvent>(OnPostCompleted);
+    }
+
+    private void OnPostCompleted(Entity<GameRuleComponent> ent, ref ESSynchronizedVotesPostCompletedEvent args)
+    {
+        // We manually start this rule now that the votes have concluded.
+        // Is this kinda hacky? yes. I don't think it's that bad though
+        Comp<GameRuleComponent>(ent).Added = true;
+        var ev = new GameRuleAddedEvent(ent, Prototype(ent)!.ID);
+        RaiseLocalEvent(ent, ref ev, true);
+    }
 
     protected override void SendVoteResultAnnouncement(Entity<ESVoteComponent> ent, ESVoteOption result)
     {

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -11,6 +11,11 @@ namespace Content.Shared.GameTicking.Components;
 [RegisterComponent, EntityCategory("GameRules")]
 public sealed partial class GameRuleComponent : Component
 {
+// ES START
+    [DataField]
+    public bool Added;
+// ES END
+
     /// <summary>
     /// Game time when game rule was activated
     /// </summary>

--- a/Content.Shared/_ES/Voting/Components/ESEntityPrototypeVoteComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESEntityPrototypeVoteComponent.cs
@@ -1,7 +1,5 @@
 using Content.Shared.EntityTable.EntitySelectors;
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared._ES.Voting.Components;
 
@@ -14,27 +12,4 @@ public sealed partial class ESEntityPrototypeVoteComponent : Component
 {
     [DataField(required: true)]
     public EntityTableSelector Options = new NoneSelector();
-}
-
-[Serializable, NetSerializable]
-public sealed partial class ESEntityPrototypeVoteOption : ESVoteOption
-{
-    [DataField]
-    public EntProtoId Entity;
-
-    public override bool Equals(object? obj)
-    {
-        return obj is ESEntityPrototypeVoteOption other && Entity.Equals(other.Entity);
-    }
-
-    public override int GetHashCode()
-    {
-        return Entity.GetHashCode();
-    }
-
-    public ESEntityPrototypeVoteOption(EntityPrototype prototype)
-    {
-        DisplayString = prototype.Name;
-        Entity = prototype;
-    }
 }

--- a/Content.Shared/_ES/Voting/Components/ESGasVoteComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESGasVoteComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Atmos;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Voting.Components;
+
+/// <summary>
+/// A vote that uses a set of gases as options
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ESSharedVoteSystem))]
+public sealed partial class ESGasVoteComponent : Component
+{
+    /// <summary>
+    /// The gases that will be selected from
+    /// </summary>
+    [DataField]
+    public List<Gas> Gases = new();
+
+    /// <summary>
+    /// Number of options
+    /// </summary>
+    [DataField]
+    public int Count = 4;
+}

--- a/Content.Shared/_ES/Voting/Components/ESSynchronizedVoteManagerComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESSynchronizedVoteManagerComponent.cs
@@ -1,0 +1,65 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._ES.Voting.Components;
+
+/// <summary>
+/// This is used for an entity which spawns multiple child <see cref="ESVoteComponent"/> entities.
+/// These votes are run in tandem and, when completed,
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(ESSharedVoteSystem))]
+public sealed partial class ESSynchronizedVoteManagerComponent : Component
+{
+    [ViewVariables]
+    public bool Completed => !Results.Any(r => r is null);
+
+    /// <summary>
+    /// The vote prototypes that will be spawned
+    /// </summary>
+    [DataField]
+    public List<EntProtoId<ESVoteComponent>> Votes = new();
+
+    /// <summary>
+    /// Currently active votes that are being run
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<EntityUid> VoteEntities = new();
+
+    /// <summary>
+    /// The results for all the completed votes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public List<ESVoteOption?> Results = new();
+}
+
+/// <summary>
+/// Event raised on a synchronized vote entity when all of its votes are completed.
+/// </summary>
+/// <param name="Results"></param>
+[ByRefEvent]
+public readonly record struct ESSynchronizedVotesCompletedEvent(List<ESVoteOption> Results)
+{
+    public bool TryGetResult<T>(int idx, [NotNullWhen(true)] out T? result) where T : ESVoteOption
+    {
+        result = null;
+
+        if (!Results.TryGetValue(idx, out var value))
+            return false;
+
+        if (value is not T res)
+            return false;
+
+        result = res;
+        return true;
+    }
+}
+
+/// <summary>
+/// Event raised after <see cref="ESSynchronizedVotesCompletedEvent"/>
+/// </summary>
+[ByRefEvent]
+public readonly record struct ESSynchronizedVotesPostCompletedEvent;

--- a/Content.Shared/_ES/Voting/Components/ESSynchronizedVoteManagerComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESSynchronizedVoteManagerComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._ES.Voting.Components;
 
 /// <summary>
 /// This is used for an entity which spawns multiple child <see cref="ESVoteComponent"/> entities.
-/// These votes are run in tandem and, when completed,
+/// These votes are run in tandem and, when completed, raise an event to handle combined behavior.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 [Access(typeof(ESSharedVoteSystem))]

--- a/Content.Shared/_ES/Voting/Components/ESVoteComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESVoteComponent.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._ES.Voting.Components;
@@ -9,6 +10,7 @@ namespace Content.Shared._ES.Voting.Components;
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
 [Access(typeof(ESSharedVoteSystem))]
+[EntityCategory("ESVotes")]
 public sealed partial class ESVoteComponent : Component
 {
     /// <summary>
@@ -57,8 +59,9 @@ public record struct ESGetVoteOptionsEvent()
 }
 
 /// <summary>
-/// Event raised on a vote entity when the vote concludes.
+/// Event raised on a vote entity and broadcast when the vote concludes.
 /// </summary>
+/// <param name="Vote">The vote that was completed.</param>
 /// <param name="Result">The result of the vote</param>
 [ByRefEvent]
-public readonly record struct ESVoteCompletedEvent(ESVoteOption Result);
+public readonly record struct ESVoteCompletedEvent(Entity<ESVoteComponent> Vote, ESVoteOption Result);

--- a/Content.Shared/_ES/Voting/ESSharedVoteSystem.Options.cs
+++ b/Content.Shared/_ES/Voting/ESSharedVoteSystem.Options.cs
@@ -1,4 +1,7 @@
 using Content.Shared._ES.Voting.Components;
+using Content.Shared._ES.Voting.Results;
+using Content.Shared.Atmos;
+using Robust.Shared.Random;
 
 namespace Content.Shared._ES.Voting;
 
@@ -7,6 +10,7 @@ public abstract partial class ESSharedVoteSystem
     private void InitializeOptions()
     {
         SubscribeLocalEvent<ESEntityPrototypeVoteComponent, ESGetVoteOptionsEvent>(OnGetVoteOptions);
+        SubscribeLocalEvent<ESGasVoteComponent, ESGetVoteOptionsEvent>(OnGasGetVoteOptions);
     }
 
     private void OnGetVoteOptions(Entity<ESEntityPrototypeVoteComponent> ent, ref ESGetVoteOptionsEvent args)
@@ -19,6 +23,22 @@ public abstract partial class ESSharedVoteSystem
             {
                 DisplayString = entProto.Name,
                 Entity = entProto,
+            });
+        }
+    }
+
+    private void OnGasGetVoteOptions(Entity<ESGasVoteComponent> ent, ref ESGetVoteOptionsEvent args)
+    {
+        var gases = new List<Gas>(ent.Comp.Gases);
+        var count = Math.Min(ent.Comp.Gases.Count, ent.Comp.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var gas = _random.PickAndTake(gases);
+            var gasProto = _atmosphere.GetGas(gas);
+            args.Options.Add(new ESGasVoteOption
+            {
+                DisplayString = Loc.GetString(gasProto.Name),
+                Gas = gas,
             });
         }
     }

--- a/Content.Shared/_ES/Voting/ESSharedVoteSystem.Synchronized.cs
+++ b/Content.Shared/_ES/Voting/ESSharedVoteSystem.Synchronized.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using Content.Shared._ES.Voting.Components;
+
+namespace Content.Shared._ES.Voting;
+
+public abstract partial class ESSharedVoteSystem
+{
+    private void InitializeSynchronized()
+    {
+        SubscribeLocalEvent<ESSynchronizedVoteManagerComponent, MapInitEvent>(OnSynchronizedMapInit);
+        SubscribeLocalEvent<ESVoteCompletedEvent>(OnESVoteCompleted);
+    }
+
+    private void OnSynchronizedMapInit(Entity<ESSynchronizedVoteManagerComponent> ent, ref MapInitEvent args)
+    {
+        foreach (var proto in ent.Comp.Votes)
+        {
+            var voteEnt = Spawn(proto);
+            ent.Comp.VoteEntities.Add(voteEnt);
+            ent.Comp.Results.Add(null);
+        }
+    }
+
+    public void EndSynchronizedVotes(Entity<ESSynchronizedVoteManagerComponent> ent)
+    {
+        if (!ent.Comp.Completed)
+            return;
+
+        var results = ent.Comp.Results.Select(p => p!).ToList();
+        var ev = new ESSynchronizedVotesCompletedEvent(results);
+        RaiseLocalEvent(ent, ref ev);
+
+        var postEv = new ESSynchronizedVotesPostCompletedEvent();
+        RaiseLocalEvent(ent, ref postEv);
+    }
+
+    private void OnESVoteCompleted(ref ESVoteCompletedEvent args)
+    {
+        var query = EntityQueryEnumerator<ESSynchronizedVoteManagerComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.Completed)
+                continue;
+            if (!comp.VoteEntities.Contains(args.Vote))
+                continue;
+            var idx = comp.VoteEntities.IndexOf(args.Vote);
+            comp.VoteEntities[idx] = EntityUid.Invalid;
+            comp.Results[idx] = args.Result;
+            Dirty(uid, comp);
+
+            EndSynchronizedVotes((uid, comp));
+            break;
+        }
+    }
+}

--- a/Content.Shared/_ES/Voting/Results/ESEntityPrototypeVoteOption.cs
+++ b/Content.Shared/_ES/Voting/Results/ESEntityPrototypeVoteOption.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._ES.Voting.Results;
+
+[Serializable, NetSerializable]
+public sealed partial class ESEntityPrototypeVoteOption : ESVoteOption
+{
+    [DataField]
+    public EntProtoId Entity;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ESEntityPrototypeVoteOption other && Entity.Equals(other.Entity);
+    }
+
+    public override int GetHashCode()
+    {
+        return Entity.GetHashCode();
+    }
+
+    public ESEntityPrototypeVoteOption(EntityPrototype prototype)
+    {
+        DisplayString = prototype.Name;
+        Entity = prototype;
+    }
+}

--- a/Content.Shared/_ES/Voting/Results/ESEntityVoteOption.cs
+++ b/Content.Shared/_ES/Voting/Results/ESEntityVoteOption.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._ES.Voting.Results;
+
+[Serializable, NetSerializable]
+public sealed partial class ESEntityVoteOption : ESVoteOption
+{
+    // Weak Entity Ref Terrorist
+    [DataField]
+    public NetEntity Entity;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ESEntityVoteOption other && Entity.Equals(other.Entity);
+    }
+
+    public override int GetHashCode()
+    {
+        return Entity.GetHashCode();
+    }
+}

--- a/Content.Shared/_ES/Voting/Results/ESGasVoteOption.cs
+++ b/Content.Shared/_ES/Voting/Results/ESGasVoteOption.cs
@@ -1,0 +1,21 @@
+using Content.Shared.Atmos;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._ES.Voting.Results;
+
+[Serializable, NetSerializable]
+public sealed partial class ESGasVoteOption : ESVoteOption
+{
+    [DataField]
+    public Gas Gas;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ESGasVoteOption other && Gas.Equals(other.Gas);
+    }
+
+    public override int GetHashCode()
+    {
+        return Gas.GetHashCode();
+    }
+}

--- a/Resources/Locale/en-US/_ES/station-events/gas-leak.ftl
+++ b/Resources/Locale/en-US/_ES/station-events/gas-leak.ftl
@@ -1,0 +1,2 @@
+es-voter-query-string-gas-leak-gas = The gas that will be leaked is:
+es-voter-query-string-gas-leak-location = The gas will be leaked:

--- a/Resources/Locale/en-US/_ES/station-events/gas-leak.ftl
+++ b/Resources/Locale/en-US/_ES/station-events/gas-leak.ftl
@@ -1,2 +1,2 @@
-es-voter-query-string-gas-leak-gas = The gas that will be leaked is:
-es-voter-query-string-gas-leak-location = The gas will be leaked:
+es-voter-query-string-gas-leak-gas = The gas that should be leaked is:
+es-voter-query-string-gas-leak-location = The gas should be leaked:

--- a/Resources/Prototypes/_ES/Entities/categories.yml
+++ b/Resources/Prototypes/_ES/Entities/categories.yml
@@ -1,0 +1,4 @@
+- type: entityCategory
+  id: ESVotes
+  name: es-voter-ui-title
+  hideSpawnMenu: true

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -24,6 +24,8 @@
       max: 65
 
 # Event Prototypes
+
+## Breaker Flip
 - type: entity
   parent: ESBaseStationEvent
   id: ESStationEventBreakerFlip
@@ -31,6 +33,7 @@
   components:
   - type: BreakerFlipRule
 
+## Gas Leak
 - type: entity
   parent: ESBaseStationEvent
   id: ESStationEventGasLeak
@@ -40,7 +43,37 @@
     startAnnouncement: station-event-gas-leak-start-announcement
     endAnnouncement: station-event-gas-leak-end-announcement
   - type: ESGasLeakRule
+  - type: ESSynchronizedVoteManager
+    votes:
+    - ESVoteGasLeakGases
+    - ESVoteGasLeakLocation
 
+- type: entity
+  id: ESVoteGasLeakGases
+  name: Which Gas Will Leak?
+  components:
+  - type: ESVote
+    queryString: es-voter-query-string-gas-leak-gas
+    duration: 15
+  - type: ESGasVote
+    gases:
+    - Ammonia
+    - Plasma
+    - Tritium
+    - Frezon
+    - WaterVapor # The Fog...
+    count: 2
+
+- type: entity
+  id: ESVoteGasLeakLocation
+  name: Where Will the Gas Leak?
+  components:
+  - type: ESVote
+    queryString: es-voter-query-string-gas-leak-location
+    duration: 15
+  - type: ESGasVentVote
+
+## Power Grid Check
 - type: entity
   parent: ESBaseStationEvent
   id: ESStationEventPowerGridCheck
@@ -57,6 +90,7 @@
     maxDuration: 120
   - type: PowerGridCheckRule
 
+## Solar Flare
 - type: entity
   parent: ESBaseStationEvent
   id: ESStationEventSolarFlare
@@ -83,6 +117,7 @@
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
+## Vent Clog
 - type: entity
   parent: ESBaseStationEventDelayed
   id: ESStationEventVentClog
@@ -92,6 +127,7 @@
     startAnnouncement: station-event-vent-clog-start-announcement
   - type: VentClogRule
 
+## Meteor Swarm
 - type: entity
   parent: ESBaseStationEventDelayed
   id: ESStationEventMeteorSwarm
@@ -104,6 +140,7 @@
     meteors:
       ESMeteor: 1
 
+## Space Dust
 - type: entity
   parent: ESBaseStationEventDelayed
   id: ESStationEventSpaceDust

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -54,7 +54,7 @@
   components:
   - type: ESVote
     queryString: es-voter-query-string-gas-leak-gas
-    duration: 15
+    duration: 30
   - type: ESGasVote
     gases:
     - Ammonia
@@ -70,7 +70,7 @@
   components:
   - type: ESVote
     queryString: es-voter-query-string-gas-leak-location
-    duration: 15
+    duration: 30
   - type: ESGasVentVote
 
 ## Power Grid Check

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -66,7 +66,7 @@
 
 - type: entity
   id: ESVoteGasLeakLocation
-  name: Where Will the Gas Leak?
+  name: Where should the gas leak?
   components:
   - type: ESVote
     queryString: es-voter-query-string-gas-leak-location

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -50,7 +50,7 @@
 
 - type: entity
   id: ESVoteGasLeakGases
-  name: Which Gas Will Leak?
+  name: Which gas should leak?
   components:
   - type: ESVote
     queryString: es-voter-query-string-gas-leak-gas


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Events now can have secondary votes that determine aspects about them. adds in custom logic for handling all this in a nice way.

only has implementation for gas leak rn

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="871" height="767" alt="image" src="https://github.com/user-attachments/assets/c87eb47a-d5dc-4c43-843e-6b3b03202502" />

