### PR TITLE
Add directional support to spawners

### DIFF
--- a/Content.Server/Spawners/Components/EntityTableSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/EntityTableSpawnerComponent.cs
@@ -29,7 +29,7 @@ public sealed partial class EntityTableSpawnerComponent : Component
 
 // ES START
     /// <summary>
-    /// If true, the spawned items will inherit the direction of the spawner.
+    /// If true, the spawned items will inherit the rotation of the spawner.
     /// </summary>
     [DataField]
     public bool Directional;

--- a/Content.Server/Spawners/Components/EntityTableSpawnerComponent.cs
+++ b/Content.Server/Spawners/Components/EntityTableSpawnerComponent.cs
@@ -26,5 +26,13 @@ public sealed partial class EntityTableSpawnerComponent : Component
     /// </summary>
     [DataField]
     public bool DeleteSpawnerAfterSpawn = true;
+
+// ES START
+    /// <summary>
+    /// If true, the spawned items will inherit the direction of the spawner.
+    /// </summary>
+    [DataField]
+    public bool Directional;
+// ES END
 }
 

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Spawners.Components;
 using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using JetBrains.Annotations;
+using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
 
@@ -15,6 +16,9 @@ namespace Content.Server.Spawners.EntitySystems
         [Dependency] private readonly IRobustRandom _robustRandom = default!;
         [Dependency] private readonly GameTicker _ticker = default!;
         [Dependency] private readonly EntityTableSystem _entityTable = default!;
+// ES START
+        [Dependency] private readonly TransformSystem _esTransform = default!;
+// ES END
 
         public override void Initialize()
         {
@@ -126,7 +130,10 @@ namespace Content.Server.Spawners.EntitySystems
             if (TerminatingOrDeleted(ent) || !Exists(ent))
                 return;
 
-            var coords = Transform(ent).Coordinates;
+// ES START
+            var xform = Transform(ent);
+            var coords = xform.Coordinates;
+// ES END
 
             var spawns = _entityTable.GetSpawns(ent.Comp.Table);
             foreach (var proto in spawns)
@@ -135,7 +142,13 @@ namespace Content.Server.Spawners.EntitySystems
                 var yOffset = _robustRandom.NextFloat(-ent.Comp.Offset, ent.Comp.Offset);
                 var trueCoords = coords.Offset(new Vector2(xOffset, yOffset));
 
-                SpawnAtPosition(proto, trueCoords);
+// ES START
+                // We change the SpawnAtPosition to a Spawn with Map Coordinates.
+                // This is the same behavior internally but this lets us pass in a rotation.
+                var mapCoords = _esTransform.ToMapCoordinates(trueCoords);
+                var rotation = ent.Comp.Directional ? xform.LocalRotation : default;
+                Spawn(proto, mapCoords, rotation: rotation);
+// ES END
             }
         }
     }

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -4,9 +4,11 @@ using Content.Server.Spawners.Components;
 using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using JetBrains.Annotations;
-using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
+// ES START
+using Robust.Server.GameObjects;
+// ES END
 
 namespace Content.Server.Spawners.EntitySystems
 {

--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/structures.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/structures.yml
@@ -184,7 +184,7 @@
 - type: entity
   parent: ESSpawnerBase
   id: ESSpawnerRandomArcadeOrPiano
-  name: Arcade Machine or Piano Spawner
+  name: Bar Entertainment Spawner
   suffix: ES, 50
   components:
   - type: Sprite
@@ -201,3 +201,4 @@
         weight: 2
       - id: PianoInstrument
         weight: 1
+    directional: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
EntityTableSpawner now has a "directional" bool that can be used to make the spawns face a particular direction. This is false by default just to preserve previous behavior.

adds this to the bar entertainment spawner because otherwise the piano is Dode