### PR TITLE
Tighten viewcone slightly

### DIFF
--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -29,7 +29,7 @@ namespace Content.Shared.Movement.Components
         public const float DefaultBaseSprintSpeed = 4.5f;
 
         // ES START
-        public static Angle ESDefaultBackwardsAngle = Angle.FromDegrees(150);
+        public static Angle ESDefaultBackwardsAngle = Angle.FromDegrees(140);
         // ES END
 
         #endregion

--- a/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
@@ -32,7 +32,7 @@ namespace Content.Shared._ES.Viewcone;
 public sealed partial class ESViewconeComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public float ConeAngle = 270f;
+    public float ConeAngle = 225f;
 
     [DataField, AutoNetworkedField]
     public float ConeFeather = 10f;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

old branch 270>225 slightly less field of view behind

not super meaningful but i just like it better this way i think

old branch where i was trying to mitigate the thing where you can look to the side and strafe while still maintaining full speed and seeing behind where you're moving, though to actually solve that it'd need to be <180 angle i think which is just way too small for my liking (anything <180 is too much i think but i could be convinced otherwise)

ill probably solve that later by making strafing slightly slower (like 5-10%) not to the degree that backwalking is, just so its suboptimal while not actually being an imposition on people moving normally. but doing that will probably necessitate changing the approach and refactoring movement a tad