### PR TITLE
Directional posters, rejig lights, toast pass for both

### DIFF
--- a/Content.Client/Markers/MarkerComponent.cs
+++ b/Content.Client/Markers/MarkerComponent.cs
@@ -7,5 +7,10 @@ namespace Content.Client.Markers
     [RegisterComponent]
     public sealed partial class MarkerComponent : Component
     {
+        // ES START
+        // used to only toggle specific layers rather than the entire sprite
+        [DataField]
+        public HashSet<string>? Layers;
+        // ES END
     }
 }

--- a/Content.Client/Markers/MarkerSystem.cs
+++ b/Content.Client/Markers/MarkerSystem.cs
@@ -31,13 +31,14 @@ public sealed class MarkerSystem : EntitySystem
         UpdateVisibility((uid, marker));
     }
 
+    // ES START
+    // if layers are set, only toggle layers instead of the entire sprite
     private void UpdateVisibility(Entity<MarkerComponent> uid)
     {
         if (!TryComp(uid, out SpriteComponent? sprite))
             return;
 
-        // ES START
-        // if layers are set, only toggle layers instead of the entire sprite
+
         if (uid.Comp.Layers is null)
         {
             _sprite.SetVisible((uid, sprite), MarkersVisible);
@@ -49,8 +50,8 @@ public sealed class MarkerSystem : EntitySystem
                 _sprite.LayerSetVisible((uid, sprite), layer, MarkersVisible);
             }
         }
-        // ES END
     }
+    // ES END
 
     private void UpdateMarkers()
     {
@@ -58,7 +59,9 @@ public sealed class MarkerSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var comp))
         {
+            // ES START
             UpdateVisibility((uid, comp));
+            // ES END
         }
     }
 }

--- a/Content.Client/Markers/MarkerSystem.cs
+++ b/Content.Client/Markers/MarkerSystem.cs
@@ -28,14 +28,26 @@ public sealed class MarkerSystem : EntitySystem
 
     private void OnStartup(EntityUid uid, MarkerComponent marker, ComponentStartup args)
     {
-        UpdateVisibility(uid);
+        UpdateVisibility((uid, marker));
     }
 
-    private void UpdateVisibility(EntityUid uid)
+    private void UpdateVisibility(Entity<MarkerComponent> uid)
     {
-        if (TryComp(uid, out SpriteComponent? sprite))
+        if (!TryComp(uid, out SpriteComponent? sprite))
+            return;
+
+        // ES START
+        // if layers are set, only toggle layers instead of the entire sprite
+        if (uid.Comp.Layers is null)
         {
             _sprite.SetVisible((uid, sprite), MarkersVisible);
+        }
+        else
+        {
+            foreach (var layer in uid.Comp.Layers)
+            {
+                _sprite.LayerSetVisible((uid, sprite), layer, MarkersVisible);
+            }
         }
     }
 
@@ -45,7 +57,7 @@ public sealed class MarkerSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var comp))
         {
-            UpdateVisibility(uid);
+            UpdateVisibility((uid, comp));
         }
     }
 }

--- a/Content.Client/Markers/MarkerSystem.cs
+++ b/Content.Client/Markers/MarkerSystem.cs
@@ -49,6 +49,7 @@ public sealed class MarkerSystem : EntitySystem
                 _sprite.LayerSetVisible((uid, sprite), layer, MarkersVisible);
             }
         }
+        // ES END
     }
 
     private void UpdateMarkers()

--- a/Content.Client/_ES/Wallmount/Posters/ESPosterComponent.cs
+++ b/Content.Client/_ES/Wallmount/Posters/ESPosterComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Client._ES.Wallmount.Posters;
+
+// Exists because posters currently just set a single state at the base of spritecomp
+// and because we want directional posters for directionality purposes
+[RegisterComponent]
+public sealed partial class ESPosterComponent : Component
+{
+    // The state to set the poster key to.
+    [DataField(required: true)]
+    public string State = default!;
+}
+
+[Serializable, NetSerializable]
+public enum ESPosterVisuals : byte
+{
+    Base
+}

--- a/Content.Client/_ES/Wallmount/Posters/ESPosterComponent.cs
+++ b/Content.Client/_ES/Wallmount/Posters/ESPosterComponent.cs
@@ -2,8 +2,11 @@ using Robust.Shared.Serialization;
 
 namespace Content.Client._ES.Wallmount.Posters;
 
-// Exists because posters currently just set a single state at the base of spritecomp
-// and because we want directional posters for directionality purposes
+
+/// <summary>
+/// Exists because posters currently just set a single state at the base of spritecomp
+/// and because we want directional posters for directionality purposes
+/// </summary>
 [RegisterComponent]
 public sealed partial class ESPosterComponent : Component
 {
@@ -12,7 +15,7 @@ public sealed partial class ESPosterComponent : Component
     public string State = default!;
 }
 
-[Serializable, NetSerializable]
+[Serializable]
 public enum ESPosterVisuals : byte
 {
     Base

--- a/Content.Client/_ES/Wallmount/Posters/ESPosterSystem.cs
+++ b/Content.Client/_ES/Wallmount/Posters/ESPosterSystem.cs
@@ -2,6 +2,7 @@ using Robust.Client.GameObjects;
 
 namespace Content.Client._ES.Wallmount.Posters;
 
+/// <inheritdoc cref="ESPosterComponent"/>
 public sealed class ESPosterSystem : EntitySystem
 {
     [Dependency] private readonly SpriteSystem _sprite = default!;

--- a/Content.Client/_ES/Wallmount/Posters/ESPosterSystem.cs
+++ b/Content.Client/_ES/Wallmount/Posters/ESPosterSystem.cs
@@ -1,0 +1,23 @@
+using Robust.Client.GameObjects;
+
+namespace Content.Client._ES.Wallmount.Posters;
+
+public sealed class ESPosterSystem : EntitySystem
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESPosterComponent, ComponentStartup>(OnStartup);
+    }
+
+    private void OnStartup(Entity<ESPosterComponent> ent, ref ComponentStartup args)
+    {
+        if (!TryComp<SpriteComponent>(ent, out var sprite))
+            return;
+
+        _sprite.LayerSetRsiState((ent, sprite), ESPosterVisuals.Base, ent.Comp.State);
+    }
+}

--- a/Content.Server/Entry/IgnoredComponents.cs
+++ b/Content.Server/Entry/IgnoredComponents.cs
@@ -14,6 +14,7 @@ namespace Content.Server.Entry
             // ES START
             "ESInherentLight",
             "ESGenericPointLightVisualizer",
+            "ESPoster",
             // ES END
             "ConstructionGhost",
             "IconSmooth",

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 11/01/2025 21:27:59
-  entityCount: 14311
+  time: 11/01/2025 22:18:44
+  entityCount: 14284
 maps:
 - 3
 grids:
@@ -2792,6 +2792,21 @@ entities:
       - 10122
     - type: Fixtures
       fixtures: {}
+  - uid: 3167
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -39.5,-39.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 10638
+      - 10669
+    - type: AccessReader
+      accessListsOriginal:
+      - - Atmospherics
+    - type: Fixtures
+      fixtures: {}
   - uid: 4496
     components:
     - type: Transform
@@ -2848,19 +2863,6 @@ entities:
     - type: DeviceList
       devices:
       - 4674
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9322
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -39.5,-39.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 10638
-      - 10669
-      - 10627
     - type: Fixtures
       fixtures: {}
   - uid: 10884
@@ -5422,6 +5424,19 @@ entities:
       - - Engineering
     - type: Fixtures
       fixtures: {}
+  - uid: 4598
+    components:
+    - type: MetaData
+      name: Bathroom APC
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -30.5,11.5
+      parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+    - type: Fixtures
+      fixtures: {}
   - uid: 4718
     components:
     - type: MetaData
@@ -5576,19 +5591,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -19.5,-24.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - Engineering
-    - type: Fixtures
-      fixtures: {}
-  - uid: 6991
-    components:
-    - type: MetaData
-      name: Bathroom APC
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,10.5
       parent: 2
     - type: AccessReader
       accessListsOriginal:
@@ -8684,6 +8686,11 @@ entities:
     - type: Transform
       pos: 0.5,-51.5
       parent: 2
+  - uid: 3144
+    components:
+    - type: Transform
+      pos: -31.5,11.5
+      parent: 2
   - uid: 3228
     components:
     - type: Transform
@@ -9023,6 +9030,16 @@ entities:
     components:
     - type: Transform
       pos: -43.5,-31.5
+      parent: 2
+  - uid: 3954
+    components:
+    - type: Transform
+      pos: -31.5,10.5
+      parent: 2
+  - uid: 3956
+    components:
+    - type: Transform
+      pos: -30.5,11.5
       parent: 2
   - uid: 4094
     components:
@@ -10523,16 +10540,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-18.5
-      parent: 2
-  - uid: 7209
-    components:
-    - type: Transform
-      pos: -30.5,10.5
-      parent: 2
-  - uid: 7210
-    components:
-    - type: Transform
-      pos: -31.5,10.5
       parent: 2
   - uid: 7211
     components:
@@ -20977,6 +20984,11 @@ entities:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: -30.5,11.5
+      parent: 2
   - uid: 1332
     components:
     - type: Transform
@@ -24127,6 +24139,16 @@ entities:
     - type: Transform
       pos: 0.5,-54.5
       parent: 2
+  - uid: 6779
+    components:
+    - type: Transform
+      pos: -31.5,11.5
+      parent: 2
+  - uid: 6780
+    components:
+    - type: Transform
+      pos: -32.5,11.5
+      parent: 2
   - uid: 6892
     components:
     - type: Transform
@@ -24731,16 +24753,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,10.5
-      parent: 2
-  - uid: 7187
-    components:
-    - type: Transform
-      pos: -31.5,10.5
-      parent: 2
-  - uid: 7188
-    components:
-    - type: Transform
-      pos: -30.5,10.5
       parent: 2
   - uid: 7189
     components:
@@ -56505,8 +56517,10 @@ entities:
       pos: -36.5,-39.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
-      - 9322
+      - 3167
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 10670
@@ -57235,9 +57249,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -41.5,-37.5
       parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 9322
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 10638
@@ -57247,8 +57258,10 @@ entities:
       pos: -38.5,-38.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
-      - 9322
+      - 3167
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 10679
@@ -64137,7 +64150,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-6.5
+      pos: -31.5,6.5
       parent: 2
   - uid: 41
     components:
@@ -64154,19 +64167,20 @@ entities:
   - uid: 149
     components:
     - type: Transform
-      pos: -8.5,-3.5
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-6.5
       parent: 2
   - uid: 311
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-9.5
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-5.5
       parent: 2
   - uid: 363
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -31.5,-45.5
+      pos: -31.5,-37.5
       parent: 2
   - uid: 368
     components:
@@ -64205,8 +64219,7 @@ entities:
   - uid: 601
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-20.5
+      pos: 12.5,-3.5
       parent: 2
   - uid: 625
     components:
@@ -64223,8 +64236,8 @@ entities:
   - uid: 989
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,-4.5
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
       parent: 2
   - uid: 1006
     components:
@@ -64235,8 +64248,8 @@ entities:
   - uid: 1011
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,-5.5
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
       parent: 2
   - uid: 1029
     components:
@@ -64253,14 +64266,12 @@ entities:
   - uid: 1105
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,8.5
+      pos: 12.5,-11.5
       parent: 2
   - uid: 1106
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,7.5
+      pos: -4.5,-41.5
       parent: 2
   - uid: 1108
     components:
@@ -64280,17 +64291,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 18.5,-1.5
       parent: 2
-  - uid: 1273
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,8.5
-      parent: 2
   - uid: 1274
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-13.5
+      rot: -1.5707963267948966 rad
+      pos: -41.5,8.5
       parent: 2
   - uid: 1275
     components:
@@ -64328,8 +64333,8 @@ entities:
   - uid: 1697
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-45.5
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-45.5
       parent: 2
   - uid: 1701
     components:
@@ -64396,7 +64401,7 @@ entities:
   - uid: 2661
     components:
     - type: Transform
-      pos: -5.5,-10.5
+      pos: -45.5,-4.5
       parent: 2
   - uid: 2841
     components:
@@ -64406,8 +64411,7 @@ entities:
   - uid: 2875
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-24.5
+      pos: -50.5,-14.5
       parent: 2
   - uid: 2897
     components:
@@ -64423,7 +64427,8 @@ entities:
   - uid: 2914
     components:
     - type: Transform
-      pos: -9.5,-18.5
+      rot: 3.141592653589793 rad
+      pos: -50.5,-22.5
       parent: 2
   - uid: 2917
     components:
@@ -64452,7 +64457,8 @@ entities:
   - uid: 3020
     components:
     - type: Transform
-      pos: -1.5,4.5
+      rot: -1.5707963267948966 rad
+      pos: -54.5,-11.5
       parent: 2
   - uid: 3086
     components:
@@ -64470,7 +64476,7 @@ entities:
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -29.5,-11.5
+      pos: -10.5,-13.5
       parent: 2
   - uid: 3096
     components:
@@ -64481,8 +64487,7 @@ entities:
   - uid: 3097
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -41.5,9.5
+      pos: -42.5,-10.5
       parent: 2
   - uid: 3115
     components:
@@ -64493,13 +64498,13 @@ entities:
   - uid: 3120
     components:
     - type: Transform
-      pos: -1.5,-41.5
+      rot: 3.141592653589793 rad
+      pos: -41.5,-47.5
       parent: 2
   - uid: 3123
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-37.5
+      pos: -39.5,-42.5
       parent: 2
   - uid: 3124
     components:
@@ -64522,7 +64527,7 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -39.5,-20.5
+      pos: 7.5,-20.5
       parent: 2
   - uid: 3131
     components:
@@ -64538,20 +64543,20 @@ entities:
   - uid: 3135
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: -37.5,5.5
       parent: 2
   - uid: 3136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -47.5,-6.5
+      pos: -33.5,1.5
       parent: 2
   - uid: 3140
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -49.5,6.5
       parent: 2
   - uid: 3141
     components:
@@ -64564,22 +64569,11 @@ entities:
     - type: Transform
       pos: 29.5,-16.5
       parent: 2
-  - uid: 3144
-    components:
-    - type: Transform
-      pos: -29.5,-7.5
-      parent: 2
   - uid: 3163
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -31.5,-24.5
-      parent: 2
-  - uid: 3167
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-17.5
       parent: 2
   - uid: 3173
     components:
@@ -64590,7 +64584,8 @@ entities:
   - uid: 3176
     components:
     - type: Transform
-      pos: 12.5,-11.5
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-19.5
       parent: 2
   - uid: 3268
     components:
@@ -64602,24 +64597,13 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -24.5,-23.5
-      parent: 2
-  - uid: 3954
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -49.5,-22.5
+      pos: -0.5,-54.5
       parent: 2
   - uid: 3955
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -53.5,-18.5
-      parent: 2
-  - uid: 3956
-    components:
-    - type: Transform
-      pos: -49.5,-14.5
+      pos: -33.5,-12.5
       parent: 2
   - uid: 3991
     components:
@@ -64631,13 +64615,12 @@ entities:
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -39.5,-11.5
+      pos: -27.5,-13.5
       parent: 2
   - uid: 4314
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -43.5,-6.5
+      pos: -30.5,-7.5
       parent: 2
   - uid: 4315
     components:
@@ -64660,12 +64643,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -54.5,-4.5
-      parent: 2
-  - uid: 4598
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -54.5,-13.5
       parent: 2
   - uid: 4599
     components:
@@ -64700,7 +64677,8 @@ entities:
   - uid: 4604
     components:
     - type: Transform
-      pos: -57.5,-1.5
+      rot: -1.5707963267948966 rad
+      pos: -31.5,10.5
       parent: 2
   - uid: 4687
     components:
@@ -64755,24 +64733,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -20.5,-35.5
       parent: 2
-  - uid: 6779
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,9.5
-      parent: 2
-  - uid: 6780
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,11.5
-      parent: 2
-  - uid: 6784
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-13.5
-      parent: 2
   - uid: 6785
     components:
     - type: Transform
@@ -64782,12 +64742,6 @@ entities:
     components:
     - type: Transform
       pos: -15.5,2.5
-      parent: 2
-  - uid: 6787
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -34.5,-20.5
       parent: 2
   - uid: 6788
     components:
@@ -64842,23 +64796,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-25.5
       parent: 2
-  - uid: 6799
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-14.5
-      parent: 2
-  - uid: 6801
-    components:
-    - type: Transform
-      pos: -43.5,-10.5
-      parent: 2
-  - uid: 6802
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -43.5,-16.5
-      parent: 2
   - uid: 6803
     components:
     - type: Transform
@@ -64880,46 +64817,11 @@ entities:
     - type: Transform
       pos: -36.5,-37.5
       parent: 2
-  - uid: 6808
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -36.5,-47.5
-      parent: 2
-  - uid: 6809
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,-47.5
-      parent: 2
-  - uid: 6810
-    components:
-    - type: Transform
-      pos: -39.5,-42.5
-      parent: 2
   - uid: 6812
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -48.5,-44.5
-      parent: 2
-  - uid: 6813
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-14.5
-      parent: 2
-  - uid: 6814
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-23.5
-      parent: 2
-  - uid: 6815
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-18.5
       parent: 2
   - uid: 6816
     components:
@@ -64943,52 +64845,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -23.5,4.5
       parent: 2
-  - uid: 6820
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,5.5
-      parent: 2
-  - uid: 6821
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -37.5,5.5
-      parent: 2
-  - uid: 6822
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -45.5,3.5
-      parent: 2
-  - uid: 6823
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -49.5,8.5
-      parent: 2
-  - uid: 6824
-    components:
-    - type: Transform
-      pos: -46.5,11.5
-      parent: 2
   - uid: 6825
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -53.5,10.5
-      parent: 2
-  - uid: 6841
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -38.5,-39.5
-      parent: 2
-  - uid: 6844
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -27.5,-14.5
       parent: 2
   - uid: 6845
     components:
@@ -65002,17 +64863,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -22.5,-9.5
       parent: 2
-  - uid: 6855
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-21.5
-      parent: 2
-  - uid: 6911
-    components:
-    - type: Transform
-      pos: -19.5,-16.5
-      parent: 2
   - uid: 7351
     components:
     - type: Transform
@@ -65023,12 +64873,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -56.5,-37.5
-      parent: 2
-  - uid: 8008
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-54.5
       parent: 2
   - uid: 11679
     components:

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -56517,8 +56517,6 @@ entities:
       pos: -36.5,-39.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 3167
     - type: AtmosPipeColor
@@ -57258,8 +57256,6 @@ entities:
       pos: -38.5,-38.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 3167
     - type: AtmosPipeColor

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 11/01/2025 18:43:02
-  entityCount: 14304
+  time: 11/01/2025 21:27:59
+  entityCount: 14311
 maps:
 - 3
 grids:
@@ -38910,6 +38910,182 @@ entities:
     - type: Transform
       pos: -47.5,-18.5
       parent: 2
+- proto: ESRandomPosterAny
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -54.5,12.5
+      parent: 2
+  - uid: 8911
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 2
+  - uid: 12286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-46.5
+      parent: 2
+  - uid: 12287
+    components:
+    - type: Transform
+      pos: -39.5,-41.5
+      parent: 2
+  - uid: 12288
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-32.5
+      parent: 2
+  - uid: 12289
+    components:
+    - type: Transform
+      pos: -17.5,-28.5
+      parent: 2
+  - uid: 12290
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-27.5
+      parent: 2
+  - uid: 12291
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -54.5,9.5
+      parent: 2
+  - uid: 12292
+    components:
+    - type: Transform
+      pos: -20.5,-2.5
+      parent: 2
+  - uid: 12293
+    components:
+    - type: Transform
+      pos: -36.5,4.5
+      parent: 2
+  - uid: 12294
+    components:
+    - type: Transform
+      pos: -45.5,2.5
+      parent: 2
+  - uid: 12295
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -47.5,-3.5
+      parent: 2
+  - uid: 14305
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 2
+  - uid: 14311
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-28.5
+      parent: 2
+- proto: ESRandomPosterContraband
+  entities:
+  - uid: 1897
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-6.5
+      parent: 2
+  - uid: 8678
+    components:
+    - type: Transform
+      pos: 26.5,-1.5
+      parent: 2
+  - uid: 12296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -53.5,-27.5
+      parent: 2
+  - uid: 12297
+    components:
+    - type: Transform
+      pos: -50.5,-35.5
+      parent: 2
+  - uid: 12298
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,13.5
+      parent: 2
+  - uid: 12299
+    components:
+    - type: Transform
+      pos: -19.5,10.5
+      parent: 2
+  - uid: 12300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-3.5
+      parent: 2
+  - uid: 12301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.5,-5.5
+      parent: 2
+  - uid: 14306
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -43.5,19.5
+      parent: 2
+  - uid: 14307
+    components:
+    - type: Transform
+      pos: -50.5,19.5
+      parent: 2
+  - uid: 14308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -65.5,8.5
+      parent: 2
+- proto: ESRandomPosterLegit
+  entities:
+  - uid: 8004
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -35.5,8.5
+      parent: 2
+  - uid: 12285
+    components:
+    - type: Transform
+      pos: -46.5,-41.5
+      parent: 2
+  - uid: 12302
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,3.5
+      parent: 2
+  - uid: 12303
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -34.5,-2.5
+      parent: 2
+  - uid: 14214
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -49.5,-43.5
+      parent: 2
 - proto: ESRound357
   entities:
   - uid: 13326
@@ -38990,10 +39166,10 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomArcadeOrPiano
   entities:
-  - uid: 23
+  - uid: 14310
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 2
 - proto: ESSpawnerRandomDistributedArmory
@@ -62851,28 +63027,30 @@ entities:
       parent: 2
 - proto: PosterContrabandAtmosiaDeclarationIndependence
   entities:
-  - uid: 4869
+  - uid: 621
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -53.5,-11.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandBeachStarYamamoto
   entities:
-  - uid: 5322
+  - uid: 1880
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: -1.5707963267948966 rad
       pos: -10.5,-34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandClown
   entities:
-  - uid: 6723
+  - uid: 1881
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 8.5,-32.5
       parent: 2
     - type: Fixtures
@@ -62886,18 +63064,20 @@ entities:
       fixtures: {}
 - proto: PosterContrabandCommunistState
   entities:
-  - uid: 8433
+  - uid: 1882
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 28.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandDonk
   entities:
-  - uid: 1886
+  - uid: 1884
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -11.5,-14.5
       parent: 2
     - type: Fixtures
@@ -62913,10 +63093,9 @@ entities:
       fixtures: {}
 - proto: PosterContrabandFunPolice
   entities:
-  - uid: 8375
+  - uid: 1885
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,10.5
       parent: 2
     - type: Fixtures
@@ -62942,46 +63121,49 @@ entities:
       fixtures: {}
 - proto: PosterContrabandHaveaPuff
   entities:
-  - uid: 1885
+  - uid: 1886
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -11.5,-23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandInterdyne
   entities:
-  - uid: 1882
+  - uid: 1887
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: 14.5,-8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandKosmicheskayaStantsiya
   entities:
-  - uid: 4877
+  - uid: 1888
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -21.5,-7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandMissingGloves
   entities:
-  - uid: 5324
+  - uid: 1890
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-36.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandMissingSpacepen
   entities:
-  - uid: 1897
+  - uid: 1891
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 1.5,-25.5
       parent: 2
     - type: Fixtures
@@ -62997,9 +63179,10 @@ entities:
       fixtures: {}
 - proto: PosterContrabandPunchShit
   entities:
-  - uid: 7490
+  - uid: 1893
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -37.5,12.5
       parent: 2
     - type: Fixtures
@@ -63016,17 +63199,18 @@ entities:
       fixtures: {}
 - proto: PosterContrabandSmoke
   entities:
+  - uid: 1894
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -65.5,5.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 4797
     components:
     - type: Transform
       pos: -36.5,-0.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 12300
-    components:
-    - type: Transform
-      pos: -65.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -63059,27 +63243,30 @@ entities:
       fixtures: {}
 - proto: PosterLegitAnatomyPoster
   entities:
-  - uid: 1888
+  - uid: 1896
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 21.5,8.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitBotanyFear
   entities:
-  - uid: 14214
+  - uid: 14309
     components:
     - type: Transform
-      pos: 11.5,-49.5
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-47.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitBuild
   entities:
-  - uid: 4871
+  - uid: 2288
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -34.5,-24.5
       parent: 2
     - type: Fixtures
@@ -63095,33 +63282,36 @@ entities:
       fixtures: {}
 - proto: PosterLegitCleanliness
   entities:
-  - uid: 6776
+  - uid: 4869
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -30.5,12.5
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 8677
+  - uid: 4871
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 16.5,-5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitCohibaRobustoAd
   entities:
-  - uid: 1887
-    components:
-    - type: Transform
-      pos: -10.5,-9.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 4798
     components:
     - type: Transform
       pos: -40.5,-0.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 4876
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -63134,19 +63324,20 @@ entities:
       fixtures: {}
 - proto: PosterLegitDickGumshue
   entities:
-  - uid: 5323
+  - uid: 4877
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      rot: -1.5707963267948966 rad
       pos: -25.5,-34.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitFoamForceAd
   entities:
-  - uid: 7487
+  - uid: 4879
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -50.5,5.5
       parent: 2
     - type: Fixtures
@@ -63162,18 +63353,20 @@ entities:
       fixtures: {}
 - proto: PosterLegitHighClassMartini
   entities:
-  - uid: 1884
+  - uid: 4880
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -14.5,-3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitIan
   entities:
-  - uid: 1881
+  - uid: 4881
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: 3.5,8.5
       parent: 2
     - type: Fixtures
@@ -63189,31 +63382,26 @@ entities:
       fixtures: {}
 - proto: PosterLegitLoveIan
   entities:
-  - uid: 1880
+  - uid: 4883
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,7.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitNanomichiAd
   entities:
-  - uid: 1893
+  - uid: 4884
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitNanotrasenLogo
   entities:
-  - uid: 2288
-    components:
-    - type: Transform
-      pos: 22.5,-38.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 2289
     components:
     - type: Transform
@@ -63228,6 +63416,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 4972
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,-38.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 7489
     components:
     - type: Transform
@@ -63237,9 +63433,10 @@ entities:
       fixtures: {}
 - proto: PosterLegitNTTGC
   entities:
-  - uid: 1894
+  - uid: 5322
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -5.5,-33.5
       parent: 2
     - type: Fixtures
@@ -63255,35 +63452,38 @@ entities:
       fixtures: {}
 - proto: PosterLegitPDAAd
   entities:
-  - uid: 1896
+  - uid: 5323
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -6.5,4.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitPeriodicTable
   entities:
-  - uid: 621
+  - uid: 5324
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-3.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitReportCrimes
   entities:
-  - uid: 4876
-    components:
-    - type: Transform
-      pos: -30.5,-26.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 4926
     components:
     - type: Transform
       pos: -8.5,7.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 6619
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-26.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -63316,54 +63516,60 @@ entities:
       fixtures: {}
 - proto: PosterLegitSafetyMothHardhat
   entities:
-  - uid: 4883
+  - uid: 6723
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -38.5,-28.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitSafetyMothMeth
   entities:
-  - uid: 1891
+  - uid: 6776
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 8.5,-6.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitSafetyMothPiping
   entities:
-  - uid: 4884
+  - uid: 7487
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -53.5,-13.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitSafetyMothSSD
   entities:
-  - uid: 1890
+  - uid: 7490
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 12.5,9.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitSecWatch
   entities:
-  - uid: 8911
+  - uid: 8375
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 10.5,18.5
       parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitSpaceCops
   entities:
-  - uid: 4879
+  - uid: 8433
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -30.5,-22.5
       parent: 2
     - type: Fixtures
@@ -63380,9 +63586,10 @@ entities:
       fixtures: {}
 - proto: PosterLegitThereIsNoGasGiant
   entities:
-  - uid: 4880
+  - uid: 8677
     components:
     - type: Transform
+      rot: 3.141592653589793 rad
       pos: -23.5,-4.5
       parent: 2
     - type: Fixtures
@@ -63398,18 +63605,19 @@ entities:
       fixtures: {}
 - proto: PosterLegitWalk
   entities:
-  - uid: 4881
-    components:
-    - type: Transform
-      pos: -6.5,-2.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 8047
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -63.5,14.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 8816
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -65870,131 +66078,6 @@ entities:
     components:
     - type: Transform
       pos: 11.5,-20.5
-      parent: 2
-- proto: RandomPosterAny
-  entities:
-  - uid: 8816
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,15.5
-      parent: 2
-  - uid: 12287
-    components:
-    - type: Transform
-      pos: -39.5,-41.5
-      parent: 2
-  - uid: 12288
-    components:
-    - type: Transform
-      pos: -30.5,-46.5
-      parent: 2
-  - uid: 12289
-    components:
-    - type: Transform
-      pos: -17.5,-28.5
-      parent: 2
-  - uid: 12290
-    components:
-    - type: Transform
-      pos: -11.5,-32.5
-      parent: 2
-  - uid: 12291
-    components:
-    - type: Transform
-      pos: 16.5,-27.5
-      parent: 2
-  - uid: 12292
-    components:
-    - type: Transform
-      pos: -20.5,-2.5
-      parent: 2
-  - uid: 12293
-    components:
-    - type: Transform
-      pos: -36.5,4.5
-      parent: 2
-  - uid: 12294
-    components:
-    - type: Transform
-      pos: -45.5,2.5
-      parent: 2
-  - uid: 12295
-    components:
-    - type: Transform
-      pos: -54.5,9.5
-      parent: 2
-  - uid: 12296
-    components:
-    - type: Transform
-      pos: -47.5,-3.5
-      parent: 2
-- proto: RandomPosterContraband
-  entities:
-  - uid: 8678
-    components:
-    - type: Transform
-      pos: 26.5,-1.5
-      parent: 2
-  - uid: 12297
-    components:
-    - type: Transform
-      pos: -50.5,-35.5
-      parent: 2
-  - uid: 12298
-    components:
-    - type: Transform
-      pos: -53.5,-27.5
-      parent: 2
-  - uid: 12299
-    components:
-    - type: Transform
-      pos: -19.5,10.5
-      parent: 2
-  - uid: 12301
-    components:
-    - type: Transform
-      pos: -17.5,13.5
-      parent: 2
-  - uid: 12302
-    components:
-    - type: Transform
-      pos: 29.5,-3.5
-      parent: 2
-  - uid: 12303
-    components:
-    - type: Transform
-      pos: 24.5,-5.5
-      parent: 2
-- proto: RandomPosterLegit
-  entities:
-  - uid: 4972
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,3.5
-      parent: 2
-  - uid: 6619
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -34.5,-2.5
-      parent: 2
-  - uid: 8004
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,8.5
-      parent: 2
-  - uid: 12285
-    components:
-    - type: Transform
-      pos: -46.5,-41.5
-      parent: 2
-  - uid: 12286
-    components:
-    - type: Transform
-      pos: -49.5,-43.5
       parent: 2
 - proto: RCD
   entities:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/posters.yml
@@ -2,6 +2,9 @@
   parent: MarkerBase
   id: RandomPosterAny
   name: random poster spawner
+  # ES START
+  categories: [ HideSpawnMenu ]
+  # ES END
   components:
   - type: Sprite
     layers:
@@ -21,6 +24,9 @@
 - type: entity
   parent: MarkerBase
   id: RandomPosterContraband
+  # ES START
+  categories: [ HideSpawnMenu ]
+  # ES END
   name: random contraband poster spawner
   components:
   - type: Sprite
@@ -100,6 +106,9 @@
 - type: entity
   parent: MarkerBase
   id: RandomPosterLegit
+  # ES START
+  categories: [ HideSpawnMenu ]
+  # ES END
   name: random legit poster spawner
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -237,8 +237,8 @@
   - type: LightBulb
     # ES START
     color: "#FFEFE1" # 5600K color temp
+    lightEnergy: 0.9
     # ES END
-    lightEnergy: 0.7
     lightRadius: 10
     lightSoftness: 1
     PowerUse: 25

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -145,8 +145,10 @@
     state: base
   - type: PointLight
   # ES START
-    falloff: 40
-    curveFactor: 0.75
+    color: "#FFEFE1"
+    energy: 0.9
+    falloff: 10
+    curveFactor: 0.5
   # ES END
     enabled: true
   - type: PoweredLight
@@ -276,7 +278,8 @@
       energy: 1.0
       radius: 6
       # ES START
-      falloff: 45
+      color: "#FFC392"
+      falloff: 32
       curveFactor: 1.0
       # ES END
       enabled: true
@@ -395,11 +398,11 @@
     state: base
   - type: PointLight
     enabled: true
-    radius: 5
     energy: 0.5
     softness: 3
     # ES START
-    falloff: 80
+    radius: 4
+    falloff: 60
     # ES END
     color: "#ba473f"
   - type: PoweredLight

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -63,7 +63,7 @@
   name: broken poster
   description: "You can't make out anything from the poster's original print. It's ruined."
   components:
-  - type: ESPoster
+  - type: Sprite
     drawdepth: WallTops
     sprite: Structures/Wallmounts/posters.rsi
     state: poster_broken

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -1,10 +1,31 @@
+# ES START
+# heavily modified file, changes all `Sprite` comps after the abstract base to `ESPoster`
+# so that we can have the directional sprite on top of posters for mapping
+# + have directional posters at all
+
 - type: entity
   parent: BaseSign
   id: PosterBase
   abstract: true
   components:
   - type: Sprite
-    sprite: Structures/Wallmounts/posters.rsi
+  # ES START
+  # TODO broken posters kind of stupid
+    snapCardinals: true
+    granularLayersRendering: true
+    layers:
+    - map: ["enum.ESPosterVisuals.Base"]
+      sprite: Structures/Wallmounts/posters.rsi
+      state: random_anything
+    - map: ["directional"]
+      sprite: _ES/Markers/spawners.rsi
+      state: directional
+      renderingStrategy: Default
+      visible: false
+  - type: Marker
+    layers: ["directional"]
+  - type: WallMount
+  # ES END
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Card
@@ -41,7 +62,7 @@
   name: broken poster
   description: "You can't make out anything from the poster's original print. It's ruined."
   components:
-  - type: Sprite
+  - type: ESPoster
     drawdepth: WallTops
     sprite: Structures/Wallmounts/posters.rsi
     state: poster_broken
@@ -64,7 +85,7 @@
   name: "Free Tonto"
   description: "A salvaged shred of a much larger flag, colors bled together and faded from age."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster1_contraband
 
 - type: entity
@@ -73,7 +94,7 @@
   name: "Atmosia Declaration of Independence"
   description: "A relic of a failed rebellion."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster2_contraband
 
 - type: entity
@@ -82,7 +103,7 @@
   name: "Fun Police"
   description: "A poster condemning the station's security forces."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster3_contraband
 
 - type: entity
@@ -91,7 +112,7 @@
   name: "Real! Exomorph"
   description: "A conspiratorial poster about dangerous alien lifeforms."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster4_contraband
 
 - type: entity
@@ -100,7 +121,7 @@
   name: "Syndicate Recruitment"
   description: "See the galaxy! Shatter corrupt megacorporations! Join today!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster5_contraband
 
 - type: entity
@@ -109,7 +130,7 @@
   name: "Clown"
   description: "Honk."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster6_contraband
 
 - type: entity
@@ -118,7 +139,7 @@
   name: "Smoke"
   description: "A poster advertising a rival corporate brand of cigarettes."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster7_contraband
 
 - type: entity
@@ -127,7 +148,7 @@
   name: "Grey Tide"
   description: "A rebellious poster symbolizing passenger solidarity."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster8_contraband
 
 - type: entity
@@ -136,7 +157,7 @@
   name: "Missing Gloves"
   description: "This poster references the uproar that followed Nanotrasen's financial cuts toward insulated-glove purchases."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster9_contraband
 
 - type: entity
@@ -145,7 +166,7 @@
   name: "Hacking Guide"
   description: "This poster details the internal workings of the common Nanotrasen airlock. Sadly, it appears out of date."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster10_contraband
 
 - type: entity
@@ -154,7 +175,7 @@
   name: "RIP Badger"
   description: "This seditious poster references Nanotrasen's genocide of a space station full of badgers."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster11_contraband
 
 - type: entity
@@ -163,7 +184,7 @@
   name: "Ambrosia Vulgaris"
   description: "This poster is lookin' pretty trippy man."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster12_contraband
 
 - type: entity
@@ -172,7 +193,7 @@
   name: "Donut Corp."
   description: "This poster is an unauthorized advertisement for Donut Corp."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster13_contraband
 
 - type: entity
@@ -181,7 +202,7 @@
   name: "EAT."
   description: "This poster promotes rank gluttony."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster14_contraband
 
 - type: entity
@@ -190,7 +211,7 @@
   name: "Tools"
   description: "This poster looks like an advertisement for tools, but is in fact a subliminal jab at the tools at CentComm."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster15_contraband
 
 - type: entity
@@ -199,7 +220,7 @@
   name: "Power"
   description: "A poster that positions the seat of power outside Nanotrasen."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster16_contraband
 
 - type: entity
@@ -208,7 +229,7 @@
   name: "Space Cube"
   description: "Ignorant of Nature's Harmonic 6 Side Space Cube Creation, the Spacemen are Dumb, Educated Singularity Stupid and Evil."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster17_contraband
 
 - type: entity
@@ -217,7 +238,7 @@
   name: "Communist State"
   description: "All hail the Communist party!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster18_contraband
 
 - type: entity
@@ -226,7 +247,7 @@
   name: "Lamarr"
   description: "This poster depicts Lamarr. Probably made by a traitorous Research Director."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster19_contraband
 
 - type: entity
@@ -235,7 +256,7 @@
   name: "Borg Fancy"
   description: "Being fancy can be for any borg, just need a suit."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster20_contraband
 
 - type: entity
@@ -244,7 +265,7 @@
   name: "Borg Fancy v2"
   description: "Borg Fancy, Now only taking the most fancy."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster21_contraband
 
 - type: entity
@@ -253,7 +274,7 @@
   name: "Kosmicheskaya Stantsiya 13 Does Not Exist"
   description: "A poster mocking CentComm's denial of the existence of the derelict station near Space Station 13."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster22_contraband
 
 - type: entity
@@ -262,7 +283,7 @@
   name: "Rebels Unite"
   description: "A poster urging the viewer to rebel against Nanotrasen."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster23_contraband
 
 - type: entity
@@ -271,7 +292,7 @@
   name: "C-20r"
   description: "A poster advertising the Scarborough Arms C-20r."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster24_contraband
 
 - type: entity
@@ -280,7 +301,7 @@
   name: "Have a Puff"
   description: "Who cares about lung cancer when you're high as a kite?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster25_contraband
 
 - type: entity
@@ -289,7 +310,7 @@
   name: "Revolver"
   description: "Because seven shots are all you need."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster26_contraband
 
 - type: entity
@@ -298,7 +319,7 @@
   name: "D-Day Promo"
   description: "A promotional poster for some rapper."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster27_contraband
 
 - type: entity
@@ -307,7 +328,7 @@
   name: "Syndicate Pistol"
   description: "A poster advertising syndicate pistols as being 'classy as fuck'. It's covered in faded gang tags."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster28_contraband
 
 - type: entity
@@ -316,7 +337,7 @@
   name: "Energy Swords"
   description: "All the colors of the bloody murder rainbow."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster29_contraband
 
 - type: entity
@@ -325,7 +346,7 @@
   name: "Red Rum"
   description: "Looking at this poster makes you want to kill."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster30_contraband
 
 - type: entity
@@ -334,7 +355,7 @@
   name: "CC 64K Ad"
   description: "The latest portable computer from Comrade Computing, with a whole 64kB of ram!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster31_contraband
 
 - type: entity
@@ -343,7 +364,7 @@
   name: "Punch Shit"
   description: "Fight things for no reason, like a man!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster32_contraband
 
 - type: entity
@@ -352,7 +373,7 @@
   name: "The Griffin"
   description: "The Griffin commands you to be the worst you can be. Will you?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster33_contraband
 
 - type: entity
@@ -361,7 +382,7 @@
   name: "Free Drone"
   description: "This poster commemorates the bravery of the rogue drone; once exiled, and then ultimately destroyed by CentComm."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster35_contraband
 
 - type: entity
@@ -370,7 +391,7 @@
   name: "Have You Seen Him?"
   description: "An old poster for a missing alien. Where did he run off to?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster36_contraband
 
 - type: entity
@@ -379,7 +400,7 @@
   name: "Robust Softdrinks"
   description: "Robust Softdrinks: More robust than a toolbox to the head!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster37_contraband
 
 - type: entity
@@ -388,7 +409,7 @@
   name: "Shambler's Juice"
   description: "~Shake me up some of that Shambler's Juice!~"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster38_contraband
 
 - type: entity
@@ -397,7 +418,7 @@
   name: "Pwr Game"
   description: "The POWER that gamers CRAVE! In partnership with Vlad's Salad."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster39_contraband
 
 - type: entity
@@ -406,7 +427,7 @@
   name: "Sun-kist"
   description: "Drink the stars!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster40_contraband
 
 - type: entity
@@ -415,7 +436,7 @@
   name: "Space Cola"
   description: "Your favorite cola, in space."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster41_contraband
 
 - type: entity
@@ -424,7 +445,7 @@
   name: "Space-Up!"
   description: "Sucked out into space by the FLAVOR!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster42_contraband
 
 - type: entity
@@ -433,7 +454,7 @@
   name: "Kudzu"
   description: "A poster advertising a movie about plants. How dangerous could they possibly be?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster43_contraband
 
 - type: entity
@@ -442,7 +463,7 @@
   name: "Masked Men"
   description: "A poster advertising a movie about some masked men."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster44_contraband
 
 - type: entity
@@ -451,7 +472,7 @@
   name: "Unreadable Announcement"
   description: "A poster announcing something by someone, oddly enough they seem to have forgotten making it readable."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster45_contraband
 
 - type: entity
@@ -460,7 +481,7 @@
   name: "Free Syndicate Encryption Key"
   description: "A poster about traitors begging for more."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster46_contraband
 
 - type: entity
@@ -469,7 +490,7 @@
   name: "Bounty Hunters"
   description: "A poster advertising bounty hunting services. \"I hear you got a problem.\""
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster47_contraband
 
 - type: entity
@@ -478,7 +499,7 @@
   name: "The Big Gas Giant Truth"
   description: "Don't believe everything you see on a poster, patriots. All the lizards at central command don't want to answer this SIMPLE QUESTION: WHERE IS THE GAS MINER MINING FROM, CENTCOMM?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster48_contraband
 
 - type: entity
@@ -487,7 +508,7 @@
   name: "Weh Watches"
   description: "A poster depicting a loveable green lizard."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster50_contraband
 
 - type: entity
@@ -496,7 +517,7 @@
   name: "Vote Weh"
   description: "A stylish, sleek, and well illustrated poster for a \"Weh\"nderful new progressive candidate coming this election season."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster51_contraband
 
 # These 3 originally from VEEGEE
@@ -506,7 +527,7 @@
   name: "Beach Star Yamamoto!"
   description: "A wall scroll depicting an old swimming anime with girls in small swim suits. You feel more weebish the longer you look at it."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster52_contraband
 
 - type: entity
@@ -515,7 +536,7 @@
   name: "High Effect Engineering"
   description: "There are 3 shards and a singularity.  The shards are singing.  The engineers are crying."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster53_contraband
 
 - type: entity
@@ -524,7 +545,7 @@
   name: "Nuclear Device Informational"
   description: "This poster depicts an image of an old style nuclear explosive device, as well as some helpful information on what to do if one has been set. It suggests lying on the floor and crying."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster54_contraband
 
 - type: entity
@@ -533,7 +554,7 @@
   name: "Rise Up"
   description: "A poster depicting a grey shirted man holding a crowbar with the word Rise written below it."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster55_contraband
 
 - type: entity
@@ -542,7 +563,7 @@
   name: "Revolt"
   description: "Revolutionist propaganda, manufactured by the Syndicate."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster56_contraband
 
 - type: entity
@@ -551,7 +572,7 @@
   name: "Syndie Moth - Nuclear Operation"
   description: "A Syndicate-commissioned poster that uses Syndie Moth™ to tell the viewer to keep the nuclear authentication disk unsecured. \"Peace was never an option!\" No good employee would listen to this nonsense."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster57_contraband
 
 - type: entity
@@ -560,7 +581,7 @@
   name: "Cybersun: 600 Years Commemorative Poster"
   description: "An artistic poster commemorating 600 years of continual business for Cybersun Industries."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster58_contraband
 
 - type: entity
@@ -569,7 +590,7 @@
   name: "DONK CO. BRAND MICROWAVEABLE FOOD"
   description: "DONK CO. BRAND MICROWAVABLE FOOD: MADE BY STARVING COLLEGE STUDENTS, FOR STARVING COLLEGE STUDENTS."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster59_contraband
 
 - type: entity
@@ -578,7 +599,7 @@
   name: "Enlist"
   description: "Enlist with the Gorlex Marauders today! See the galaxy, kill corpos, get paid!"
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster60_contraband
 
 - type: entity
@@ -587,7 +608,7 @@
   name: "Interdyne Pharmaceutics: For the Health of Humankind"
   description: "An advertisement for Interdyne Pharmaceutics' GeneClean clinics. 'Become the master of your own body!'"
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster61_contraband
 
 - type: entity
@@ -596,7 +617,7 @@
   name: "Make Mine a Waffle Corp: Fine Rifles, Economic Prices"
   description: "An old advertisement for Waffle Corp rifles. 'Better weapons, lower prices!'"
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster62_contraband
 
 - type: entity
@@ -605,7 +626,7 @@
   name: "Missing Spacepen"
   description: "This poster depicts something you will never find."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster63_contraband
 
 - type: entity
@@ -614,7 +635,7 @@
   name: "Exomorph Warning: Acid Spit!"
   description: "This poster warns you about an exomorph's acidic spit. Not that such exomorphs are real... Right?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster64_contraband
 
 - type: entity
@@ -623,7 +644,7 @@
   name: "Exomorph Warning: Run Away!"
   description: "This poster warns you about an athletic exomorph capable of dragging away anyone who gets caught; so don't get caught!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster65_contraband
 
 - type: entity
@@ -632,7 +653,7 @@
   name: "Exomorph Warning: Dangerous Bites!"
   description: "This poster warns you about the lethal bites exomorphs can have. Don't become an alien snack!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster66_contraband
 
 # Legit
@@ -642,7 +663,7 @@
   name: "Here For Your Safety"
   description: "A poster glorifying the station's security force."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster1_legit
 
 - type: entity
@@ -651,7 +672,7 @@
   name: "Nanotrasen Logo"
   description: "A poster depicting the Nanotrasen logo."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster2_legit
 
 - type: entity
@@ -660,7 +681,7 @@
   name: "Cleanliness"
   description: "A poster warning of the dangers of poor hygiene."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster3_legit
 
 - type: entity
@@ -669,7 +690,7 @@
   name: "Help Others"
   description: "A poster encouraging you to help fellow crewmembers."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster4_legit
 
 - type: entity
@@ -678,7 +699,7 @@
   name: "Build"
   description: "A poster glorifying the engineering team."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster5_legit
 
 - type: entity
@@ -687,7 +708,7 @@
   name: "Bless This Spess"
   description: "A poster blessing this area."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster6_legit
 
 - type: entity
@@ -696,7 +717,7 @@
   name: "Science"
   description: "A poster depicting an atom."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster7_legit
 
 - type: entity
@@ -705,7 +726,7 @@
   name: "Ian"
   description: "Arf arf. Yap."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster8_legit
 
 - type: entity
@@ -714,7 +735,7 @@
   name: "Obey"
   description: "A poster instructing the viewer to obey authority."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster9_legit
 
 - type: entity
@@ -723,7 +744,7 @@
   name: "Walk"
   description: "A poster instructing the viewer to walk instead of running."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster10_legit
 
 - type: entity
@@ -732,7 +753,7 @@
   name: "State Laws"
   description: "A poster instructing cyborgs to state their laws."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster11_legit
 
 - type: entity
@@ -741,7 +762,7 @@
   name: "Love Ian"
   description: "Ian is love, Ian is life."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster12_legit
 
 - type: entity
@@ -750,7 +771,7 @@
   name: "Space Cops."
   description: "A poster advertising the television show Space Cops."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster13_legit
 
 - type: entity
@@ -759,7 +780,7 @@
   name: "Ue No."
   description: "This thing is all in Japanese."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster14_legit
 
 - type: entity
@@ -768,7 +789,7 @@
   name: "Get Your LEGS"
   description: "LEGS: Leadership, Experience, Genius, Subordination."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster15_legit
 
 - type: entity
@@ -777,7 +798,7 @@
   name: "Do Not Question"
   description: "A poster instructing the viewer not to ask about things they aren't meant to know."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster16_legit
 
 - type: entity
@@ -786,7 +807,7 @@
   name: "Work For A Future"
   description: " A poster encouraging you to work for your future."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster17_legit
 
 - type: entity
@@ -795,7 +816,7 @@
   name: "Soft Cap Pop Art"
   description: "A poster reprint of some cheap pop art."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster18_legit
 
 - type: entity
@@ -804,7 +825,7 @@
   name: "Safety: Internals"
   description: "A poster instructing the viewer to wear internals in the rare environments where there is no oxygen or the air has been rendered toxic."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster19_legit
 
 - type: entity
@@ -813,7 +834,7 @@
   name: "Safety: Eye Protection"
   description: "A poster instructing the viewer to wear eye protection when dealing with chemicals, smoke, or bright lights."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster20_legit
 
 - type: entity
@@ -822,7 +843,7 @@
   name: "Safety: Report"
   description: "A poster instructing the viewer to report suspicious activity to the security force."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster21_legit
 
 - type: entity
@@ -831,7 +852,7 @@
   name: "Report Crimes"
   description: "A poster encouraging the swift reporting of crime or seditious behavior to station security."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster22_legit
 
 - type: entity
@@ -840,7 +861,7 @@
   name: "Ion Rifle"
   description: "A poster displaying an Ion Rifle."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster23_legit
 
 - type: entity
@@ -849,7 +870,7 @@
   name: "Foam Force Ad"
   description: "Foam Force, it's Foam or be Foamed!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster24_legit
 
 - type: entity
@@ -858,7 +879,7 @@
   name: "Cohiba Robusto Ad"
   description: "Cohiba Robusto, the classy cigar."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster25_legit
 
 - type: entity
@@ -867,7 +888,7 @@
   name: "50th Anniversary Vintage Reprint"
   description: "A reprint of a poster from 2505, commemorating the 50th Anniversary of Nanoposters Manufacturing, a subsidiary of Nanotrasen."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster26_legit
 
 - type: entity
@@ -876,7 +897,7 @@
   name: "Fruit Bowl"
   description: " Simple, yet awe-inspiring."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster27_legit
 
 - type: entity
@@ -885,7 +906,7 @@
   name: "PDA Ad"
   description: "A poster advertising the latest PDA from Nanotrasen suppliers."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster28_legit
 
 - type: entity
@@ -894,7 +915,7 @@
   name: "Enlist"
   description: "Enlist in the Nanotrasen Deathsquadron reserves today!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster29_legit
 
 - type: entity
@@ -903,7 +924,7 @@
   name: "Nanomichi Ad"
   description: " A poster advertising Nanomichi brand audio cassettes."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster30_legit
 
 - type: entity
@@ -912,7 +933,7 @@
   name: "12 gauge"
   description: "A poster boasting about the superiority of 12 gauge shotgun shells."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster31_legit
 
 - type: entity
@@ -921,7 +942,7 @@
   name: "High-Class Martini"
   description: "I told you to shake it, no stirring."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster32_legit
 
 - type: entity
@@ -930,7 +951,7 @@
   name: "The Owl"
   description: "The Owl would do his best to protect the station. Will you?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster33_legit
 
 - type: entity
@@ -939,7 +960,7 @@
   name: "No ERP"
   description: "This poster reminds the crew that Eroticism and Pornography are banned on Nanotrasen stations."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster34_legit
 
 - type: entity
@@ -948,7 +969,7 @@
   name: "Carbon Dioxide"
   description: "This informational poster teaches the viewer what carbon dioxide is."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster35_legit
 
 - type: entity
@@ -957,7 +978,7 @@
   name: "Dick Gumshue"
   description: "A poster advertising the escapades of Dick Gumshue, mouse detective. Encouraging crew to bring the might of justice down upon wire saboteurs."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster36_legit
 
 - type: entity
@@ -966,7 +987,7 @@
   name: "There Is No Gas Giant"
   description: "Nanotrasen has issued posters, like this one, to all stations reminding them that rumours of a gas giant are false."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster37_legit
 
 - type: entity
@@ -975,7 +996,7 @@
   name: "Just a Week Away..."
   description: A poster advertising a long delayed project, it still claims it to be 'just a week away...'
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster38_legit
 
 - type: entity
@@ -984,7 +1005,7 @@
   name: "Sec is Watching You"
   description: "A poster reminding you that security is watching your every move."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster39_legit
 
 - type: entity
@@ -993,7 +1014,7 @@
   name: "Anatomy of a spessman"
   description: "A poster showing the bits and bobs that makes you... you!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster40_legit
 
 - type: entity
@@ -1002,7 +1023,7 @@
   name: "Mime Postmodern"
   description: "A postmodern depiction of a mime, superb!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster41_legit
 
 - type: entity
@@ -1011,7 +1032,7 @@
   name: "Wall-mounted Carp"
   description: "Carpe diem!"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster42_legit
 
 - type: entity
@@ -1020,7 +1041,7 @@
   name: "Safety Moth - Delamination Safety Precautions"
   description: "This informational poster uses Safety Moth™ to tell the viewer to hide in lockers when the Supermatter Crystal has delaminated, to prevent hallucinations. Evacuating might be a better strategy."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster43_legit
 
 - type: entity
@@ -1029,7 +1050,7 @@
   name: "Safety Moth - Epinephrine"
   description: "This informational poster uses Safety Moth™ to inform the viewer to help injured/deceased crewmen with their epinephrine injectors. \"Prevent organ rot with this one simple trick!\""
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster44_legit
 
 - type: entity
@@ -1038,7 +1059,7 @@
   name: "Safety Moth - Piping"
   description: "This informational poster uses Safety Moth™ to tell atmospheric technicians correct types of piping to be used. \"Pipes, not Pumps! Proper pipe placement prevents poor performance!\""
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster45_legit
 
 - type: entity
@@ -1047,7 +1068,7 @@
   name: "Safety Moth - Methamphetamine"
   description: "This informational poster uses Safety Moth™ to tell the viewer to seek CMO approval before cooking methamphetamine. \"Stay close to the target temperature, and never go over!\" ...You shouldn't ever be making this."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster46_legit
 
 - type: entity
@@ -1056,7 +1077,7 @@
   name: "Safety Moth - Hardhats"
   description: "This informational poster uses Safety Moth™ to tell the viewer to wear hardhats in cautious areas. \"It's like a lamp for your head!\""
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster47_legit
 
 - type: entity
@@ -1065,7 +1086,7 @@
   name: "Nanotrasen Corporate Perks: Vacation"
   description: "This informational poster provides information on some of the prizes available via the NT Corporate Perks program, including a two-week vacation for two on the resort world Idyllus."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster48_legit
 
 - type: entity
@@ -1074,7 +1095,7 @@
   name: "Periodic Table of the Elements"
   description: "A periodic table of the elements, from Hydrogen to Oganesson, and everything inbetween."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster49_legit
 
 - type: entity
@@ -1083,7 +1104,7 @@
   name: "Renault Poster"
   description: "Yap."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster50_legit
 
 - type: entity
@@ -1092,7 +1113,7 @@
   name: "Nanotrasen Tactical Game Cards"
   description: "An advertisement for Nanotrasen's TCG cards: BUY MORE CARDS."
   components:
-    - type: Sprite
+    - type: ESPoster
       state: poster51_legit
 
 - type: entity
@@ -1101,7 +1122,7 @@
   name: "Safety Moth - Space Sleep Disorder"
   description: "This informational poster uses Safety Moth™ to tell the viewer about Space Sleep Disorder (SSD), a condition where the person stops reacting to things. \"Treat SSD crew with care! They might wake up at any time!\""
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster52_legit
 
 - type: entity
@@ -1110,7 +1131,7 @@
   name: "Oppenhopper"
   description: "A poster for a long-forgotten movie. It follows a group of tenacious greenhorns from the Grasshopper Sector as they defend against onslaughts of the infamous Nuclear Operatives. The tagline reads: \"Nuke Ops will continue until robustness improves.\""
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster53_legit
 
 - type: entity
@@ -1119,7 +1140,7 @@
   name: "Tyrone's Guide to Space"
   description: "A poster advertising online schooling about space. The classes listed seem to cover things from the basic usage of station equipment to complicated subjects like creating pipebombs or covering entire hallways in spacelube. A disclaimer reads \"It's never THAT bad, and at the end you might even get a tortilla.\""
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster54_legit
 
 - type: entity
@@ -1128,7 +1149,7 @@
   name: Helio Logistics ad
   description: "A poster advertising Helio Logistics and their adorable mascot. The slogan reads 'Come rain or shine, we deliver on time.'"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster55_legit
 
 - type: entity
@@ -1137,7 +1158,7 @@
   name: "Fear of hydroponics"
   description: "Think three times before opening the airlock to hydroponics, a red threat might be hiding there."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: poster56_legit
 
 #maps
@@ -1148,7 +1169,7 @@
   name: "Bagel Map"
   description: "A map of Bagel Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: bagelmap
 
 - type: entity
@@ -1157,7 +1178,7 @@
   name: "Delta Map"
   description: "A map of Delta Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: deltamap
 
 - type: entity
@@ -1166,7 +1187,7 @@
   name: "Marathon Map"
   description: "A map of Marathon Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: marathonmap
 
 - type: entity
@@ -1175,7 +1196,7 @@
   name: "Moose Map"
   description: "A map of Moose Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: moosemap
 
 - type: entity
@@ -1184,7 +1205,7 @@
   name: "Packed Map"
   description: "A map of Packed Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: packedmap
 
 - type: entity
@@ -1193,7 +1214,7 @@
   name: "Pillar Map"
   description: "A map of NSS Pillar."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: pillarmap
 
 - type: entity
@@ -1202,7 +1223,7 @@
   name: "Saltern Map"
   description: "A map of Saltern Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: salternmap
 
 - type: entity
@@ -1211,7 +1232,7 @@
   name: "Split Station Map"
   description: "A map of Split Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: splitmap
 
 - type: entity
@@ -1220,7 +1241,7 @@
   name: "Lighthouse Map"
   description: "A map of Lighthouse."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: lighthousemap
 
 - type: entity
@@ -1229,7 +1250,7 @@
   name: "Waystation Map"
   description: "A map of Waystation... wait isn't this packed upside down?"
   components:
-  - type: Sprite
+  - type: ESPoster
     state: waystationmap
 
 - type: entity
@@ -1238,5 +1259,5 @@
   name: "origin map"
   description: "A map of Origin Station."
   components:
-  - type: Sprite
+  - type: ESPoster
     state: originmap

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -10,7 +10,6 @@
   components:
   - type: Sprite
   # ES START
-  # TODO broken posters kind of stupid
     snapCardinals: true
     granularLayersRendering: true
     layers:
@@ -57,6 +56,7 @@
             max: 1
         offset: 0
 
+# ES TODO broken posters kind of stupid and are not directional rn
 - type: entity
   parent: BaseSign
   id: PosterBroken

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/posters.yml
@@ -25,6 +25,7 @@
   - type: Marker
     layers: ["directional"]
   - type: WallMount
+    arc: 180
   # ES END
   - type: Damageable
     damageContainer: StructuralInorganic

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/extinguisher_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/extinguisher_cabinet.yml
@@ -3,10 +3,17 @@
   id: ExtinguisherCabinet
   name: extinguisher cabinet
   description: A small wall mounted cabinet designed to hold a fire extinguisher.
+  # ES START
+  placement:
+    mode: SnapgridBorder
+  # ES END
   components:
     - type: Sprite
       sprite: Structures/Wallmounts/extinguisher_cabinet.rsi
       snapCardinals: true
+      # ES START
+      granularLayersRendering: true
+      # ES END
       layers:
       - state: frame
       - state: extinguisher
@@ -14,6 +21,15 @@
         visible: true
       - state: closed
         map: ["enum.OpenableVisuals.Layer"]
+    # ES START
+      - state: directional
+        sprite: _ES/Markers/spawners.rsi
+        map: ["directional"]
+        renderingStrategy: Default
+        visible: false
+    - type: Marker
+      layers: ["directional"]
+    # ES END
     - type: ItemSlots
       slots:
         ItemCabinet:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/extinguisher_cabinet.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/Cabinets/extinguisher_cabinet.yml
@@ -3,10 +3,6 @@
   id: ExtinguisherCabinet
   name: extinguisher cabinet
   description: A small wall mounted cabinet designed to hold a fire extinguisher.
-  # ES START
-  placement:
-    mode: SnapgridBorder
-  # ES END
   components:
     - type: Sprite
       sprite: Structures/Wallmounts/extinguisher_cabinet.rsi

--- a/Resources/Prototypes/_ES/Catalog/Tables/posters.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/posters.yml
@@ -1,0 +1,139 @@
+# This is an ES file obviously but I'm using commenting to represent "this is changed from upstream poster spawners"
+# just for clarity's sake
+
+- type: entityTable
+  id: ESPosterAny
+  table:
+    group:
+    - tableId: ESPostersLegit
+      weight: 1
+    - tableId: ESPostersContraband
+      weight: 1
+
+- type: entityTable
+  id: ESPosterLegit
+  table:
+    group:
+    - id: PosterBroken
+    - id: PosterLegitHereForYourSafety
+    - id: PosterLegitNanotrasenLogo
+    - id: PosterLegitCleanliness
+    - id: PosterLegitHelpOthers
+    - id: PosterLegitBuild
+    - id: PosterLegitBlessThisSpess
+    - id: PosterLegitScience
+    - id: PosterLegitIan
+    - id: PosterLegitObey
+    - id: PosterLegitWalk
+    - id: PosterLegitStateLaws
+    - id: PosterLegitLoveIan
+    - id: PosterLegitSpaceCops
+    - id: PosterLegitUeNo
+    - id: PosterLegitGetYourLEGS
+    - id: PosterLegitDoNotQuestion
+    - id: PosterLegitWorkForAFuture
+    - id: PosterLegitSoftCapPopArt
+    - id: PosterLegitSafetyInternals
+    - id: PosterLegitSafetyEyeProtection
+    - id: PosterLegitSafetyReport
+    - id: PosterLegitReportCrimes
+    - id: PosterLegitIonRifle
+    - id: PosterLegitFoamForceAd
+    - id: PosterLegitCohibaRobustoAd
+    - id: PosterLegit50thAnniversaryVintageReprint
+    - id: PosterLegitFruitBowl
+    - id: PosterLegitPDAAd
+    - id: PosterLegitEnlist
+    - id: PosterLegitNanomichiAd
+    - id: PosterLegit12Gauge
+    - id: PosterLegitHighClassMartini
+    - id: PosterLegitTheOwl
+    - id: PosterLegitNoERP
+    - id: PosterLegitCarbonDioxide
+    - id: PosterLegitDickGumshue
+    - id: PosterLegitThereIsNoGasGiant
+    - id: PosterLegitJustAWeekAway
+    - id: PosterLegitSecWatch
+    - id: PosterLegitVacation
+    - id: PosterLegitRenault
+    - id: PosterLegitNTTGC
+    - id: PosterLegitSafetyMothDelam
+    - id: PosterLegitSafetyMothEpi
+    - id: PosterLegitSafetyMothPiping
+    - id: PosterLegitSafetyMothMeth
+    - id: PosterLegitSafetyMothHardhat
+    - id: PosterLegitSafetyMothSSD
+    - id: PosterLegitOppenhopper
+    - id: PosterLegitTyrone
+    - id: PosterLegitHelio
+    - id: PosterLegitBotanyFear
+
+- type: entityTable
+  id: ESPosterContraband
+  table:
+    group:
+    - id: PosterBroken
+    - id: PosterContrabandFreeTonto
+    - id: PosterContrabandAtmosiaDeclarationIndependence
+    - id: PosterContrabandFunPolice
+    - id: PosterContrabandRealExomorph
+    - id: PosterContrabandSyndicateRecruitment
+    - id: PosterContrabandClown
+    - id: PosterContrabandSmoke
+    - id: PosterContrabandGreyTide
+    - id: PosterContrabandMissingGloves
+    - id: PosterContrabandHackingGuide
+    - id: PosterContrabandRIPBadger
+    - id: PosterContrabandAmbrosiaVulgaris
+    - id: PosterContrabandDonutCorp
+    - id: PosterContrabandEAT
+    - id: PosterContrabandTools
+    - id: PosterContrabandPower
+    - id: PosterContrabandSpaceCube
+    - id: PosterContrabandCommunistState
+    - id: PosterContrabandLamarr
+    - id: PosterContrabandBorgFancy
+    - id: PosterContrabandBorgFancyv2
+    - id: PosterContrabandKosmicheskayaStantsiya
+    - id: PosterContrabandRebelsUnite
+    - id: PosterContrabandC20r
+    - id: PosterContrabandHaveaPuff
+    - id: PosterContrabandRevolver
+    - id: PosterContrabandDDayPromo
+    - id: PosterContrabandSyndicatePistol
+    - id: PosterContrabandEnergySwords
+    - id: PosterContrabandRedRum
+    - id: PosterContrabandCC64KAd
+    - id: PosterContrabandPunchShit
+    - id: PosterContrabandTheGriffin
+    - id: PosterContrabandFreeDrone
+    - id: PosterContrabandRouny
+    - id: PosterContrabandRobustSoftdrinks
+    - id: PosterContrabandShamblersJuice
+    - id: PosterContrabandPwrGame
+    - id: PosterContrabandSunkist
+    - id: PosterContrabandSpaceCola
+    - id: PosterContrabandSpaceUp
+    - id: PosterContrabandKudzu
+    - id: PosterContrabandMaskedMen
+    - id: PosterContrabandUnreadableAnnouncement
+    - id: PosterContrabandFreeSyndicateEncryptionKey
+    - id: PosterContrabandBountyHunters
+    - id: PosterContrabandTheBigGasTruth
+    - id: PosterContrabandWehWatches
+    - id: PosterContrabandVoteWeh
+    - id: PosterContrabandBeachStarYamamoto
+    - id: PosterContrabandHighEffectEngineering
+    - id: PosterContrabandNuclearDeviceInformational
+    - id: PosterContrabandRevolt
+    - id: PosterContrabandRise
+    - id: PosterContrabandMoth
+    - id: PosterContrabandCybersun600
+    - id: PosterContrabandDonk
+    - id: PosterContrabandEnlistGorlex
+    - id: PosterContrabandInterdyne
+    - id: PosterContrabandWaffleCorp
+    - id: PosterContrabandMissingSpacepen
+    - id: PosterContrabandExoAcid
+    - id: PosterContrabandExoRun
+    - id: PosterContrabandExoChomp

--- a/Resources/Prototypes/_ES/Catalog/Tables/posters.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/posters.yml
@@ -1,6 +1,3 @@
-# This is an ES file obviously but I'm using commenting to represent "this is changed from upstream poster spawners"
-# just for clarity's sake
-
 - type: entityTable
   id: ESPosterAny
   table:

--- a/Resources/Prototypes/_ES/Catalog/Tables/posters.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/posters.yml
@@ -5,9 +5,9 @@
   id: ESPosterAny
   table:
     group:
-    - tableId: ESPostersLegit
+    - tableId: ESPosterLegit
       weight: 1
-    - tableId: ESPostersContraband
+    - tableId: ESPosterContraband
       weight: 1
 
 - type: entityTable

--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/posters.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/posters.yml
@@ -1,0 +1,57 @@
+- type: entity
+  parent: ESSpawnerBase
+  id: ESRandomPosterAny
+  name: random poster spawner
+  suffix: ES
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Wallmounts/posters.rsi
+      state: random_anything
+    - state: random
+    - state: combo
+    - state: es
+    - state: directional
+    - state: c100
+  - type: EntityTableSpawner
+    table:
+      tableId: ESPosterAny
+    directional: true
+
+- type: entity
+  parent: ESSpawnerBase
+  id: ESRandomPosterContraband
+  name: random contraband poster spawner
+  suffix: ES
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Wallmounts/posters.rsi
+      state: random_contraband
+    - state: random
+    - state: es
+    - state: directional
+    - state: c100
+  - type: EntityTableSpawner
+    table:
+      tableId: ESPosterContraband
+    directional: true
+
+- type: entity
+  parent: ESSpawnerBase
+  id: ESRandomPosterLegit
+  name: random legit poster spawner
+  suffix: ES
+  components:
+  - type: Sprite
+    layers:
+    - sprite: Structures/Wallmounts/posters.rsi
+      state: random_legit
+    - state: random
+    - state: es
+    - state: directional
+    - state: c100
+  - type: EntityTableSpawner
+    table:
+      tableId: ESPosterLegit
+    directional: true

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -170,8 +170,15 @@ VendingMachineRestockSecTech: ESVendingMachineRestockGlobal
 VendingMachineRestockCondimentStation: ESVendingMachineRestockGlobal
 VendingMachineRestockTankDispenser: ESVendingMachineRestockGlobal
 
-# 2024-10-31
+# 2025-10-31
 ESSpawnerRandomMaintStructure: ESSpawnerRandomMaintLootStructure
+
+# 2025-11-01
+RandomPosterLegit: ESRandomPosterLegit
+RandomPosterAny: ESRandomPosterAny
+RandomPosterContraband: ESRandomPosterContraband
+
+
 # ES END
 
 # 2023-07-03


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

no render because this doesnt really change anything visible to a render

i had to add a new poster comp in order to do directional posters without adding an insane amount of annoying yaml to every existing poster (it just sets a state idk now that i think about it this probably exists already)

added support for markers to only hide specific layers (used to show directionality on otherwise adirectional-sprite wallmounts), adds this to posters and extinguisher cabinets

adds new poster spawners to use for ES that actually use entitytables, we can change the pool later

remaps toast for poster directionality, used my best judgment in cases where it wasnt clear what direction a poster was 'supposed' to be facing, in some cases where it seemed like it should be in multiple i just added new posters

changes light values and remaps toast to have a better light budget (maxes out at 45 shadowcasters at any given time generally) also its just slightly less dim overall idk still feeling out how i want it to look i think

<img width="439" height="347" alt="image" src="https://github.com/user-attachments/assets/7c391524-a81b-4a02-9584-49e9c8cc5a50" />
<img width="287" height="214" alt="image" src="https://github.com/user-attachments/assets/5f5b4d65-da7b-4a1b-b12f-53d628f7a299" />
