### PR TITLE
Remove many redundant verbs + verb styling

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -130,6 +130,11 @@ namespace Content.Client.Examine
             if (!CanExamine(args.User, args.Target))
                 return;
 
+            // ES START
+            // No basic examine verb
+            return;
+            // ES END
+
             // Basic examine verb.
             ExamineVerb verb = new();
             verb.Category = VerbCategory.Examine;

--- a/Content.Client/Pointing/PointingSystem.cs
+++ b/Content.Client/Pointing/PointingSystem.cs
@@ -40,6 +40,11 @@ public sealed partial class PointingSystem : SharedPointingSystem
         if (!CanPoint(args.User))
             return;
 
+        // ES START
+        // No pointing verb
+        return;
+        // ES END
+
         // We won't check in range or visibility, as this verb is currently only executable via the context menu,
         // and that should already have checked that, as well as handling the FOV-toggle stuff.
 

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -122,6 +122,11 @@ public abstract class SharedItemSystem : EntitySystem
             !_handsSystem.CanPickupAnyHand(args.User, args.Target, handsComp: args.Hands, item: component))
             return;
 
+        // ES START
+        // No pickup verb
+        return;
+        // ES START
+
         InteractionVerb verb = new();
         verb.Act = () => _handsSystem.TryPickupAnyHand(args.User, args.Target, checkActionBlocker: false,
             handsComp: args.Hands, item: component);

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -256,6 +256,11 @@ public sealed class PullingSystem : EntitySystem
         if (!args.CanAccess || !args.CanInteract)
             return;
 
+        // ES START
+        // No pull verbs
+        return;
+        // ES END
+
         // Are they trying to pull themselves up by their bootstraps?
         if (args.User == args.Target)
             return;

--- a/Content.Shared/Verbs/Verb.cs
+++ b/Content.Shared/Verbs/Verb.cs
@@ -308,7 +308,10 @@ namespace Content.Shared.Verbs
     public sealed class AlternativeVerb : Verb
     {
         public override int TypePriority => 2;
-        public new static string DefaultTextStyleClass = "AlternativeVerb";
+        // ES START
+        // Basic styling
+        public new static string DefaultTextStyleClass = "Verb";
+        // ES END
         public override bool DefaultDoContactInteraction => true;
 
         public AlternativeVerb() : base()
@@ -330,7 +333,10 @@ namespace Content.Shared.Verbs
     public sealed class ActivationVerb : Verb
     {
         public override int TypePriority => 1;
-        public new static string DefaultTextStyleClass = "ActivationVerb";
+        // ES START
+        // Basic styling
+        public new static string DefaultTextStyleClass = "Verb";
+        // ES END
         public override bool DefaultDoContactInteraction => true;
 
         public ActivationVerb() : base()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

part of #276

imagine a world
<img width="691" height="238" alt="image" src="https://github.com/user-attachments/assets/e8d268d9-76a5-44f4-a9cf-e96cf5ffc36b" />
<img width="323" height="270" alt="image" src="https://github.com/user-attachments/assets/f8a4d59a-1bc5-40db-b7ad-a0d5d9a9a21e" />


all verbs removed are things which you can do with other keys anyway, even when entities are stacked: you can just interact with the entity menu (shift+click ctrl+click etc on the entity menu thing all work)

focuses on the verbs that are actually relevant to the specific entity
also removes styling for most verbs bc they look bad and we should just use key glyphs for them at some point IMO also they really did not convey information in any way that was understandable
