### PR TITLE
Smart Internals

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -51,6 +51,7 @@ namespace Content.Client.Input
 
             // ES START
             common.AddFunction(ContentKeyFunctions.ESHoldToFace);
+            common.AddFunction(ContentKeyFunctions.ESToggleInternals);
             // ES END
 
             var human = contexts.GetContext("human");

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -156,6 +156,7 @@ namespace Content.Client.Options.UI.Tabs
             // ES START
             AddHeader("ui-options-header-es");
             AddButton(ContentKeyFunctions.ESHoldToFace);
+            AddButton(ContentKeyFunctions.ESToggleInternals);
             // ES END
 
             AddHeader("ui-options-header-movement");

--- a/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
+++ b/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using Content.Client.Atmos.EntitySystems;
+using Content.Client.Gameplay;
+using Content.Client.Inventory;
+using Content.Client.Popups;
+using Content.Client.UserInterface.Controls;
+using Content.Shared._ES.Internals;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Input;
+using Content.Shared.Popups;
+using JetBrains.Annotations;
+using Robust.Client.Player;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controllers;
+using Robust.Shared.Input.Binding;
+
+namespace Content.Client._ES.Internals.Ui;
+
+[UsedImplicitly]
+public sealed class ESInternalsUIController : UIController, IOnStateChanged<GameplayState>
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    [UISystemDependency] private readonly GasTankSystem _gasTank = default!;
+    [UISystemDependency] private readonly ClientInventorySystem _inventory = default!;
+    [UISystemDependency] private readonly PopupSystem _popup = default!;
+
+    private SimpleRadialMenu? _menu;
+
+    public void OnStateEntered(GameplayState state)
+    {
+        _menu = new SimpleRadialMenu();
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.ESToggleInternals, new PointerInputCmdHandler(OnToggleInternalsPressed, outsidePrediction: true))
+            .Register<ESInternalsUIController>();
+    }
+
+    public void OnStateExited(GameplayState state)
+    {
+        _menu = null;
+
+        CommandBinds.Unregister<ESInternalsUIController>();
+    }
+
+    private bool OnToggleInternalsPressed(in PointerInputCmdHandler.PointerInputCmdArgs args)
+    {
+        // Do not deal with input when they are picking shit out of the radial
+        if (_menu?.IsOpen == true)
+            return false;
+
+        if (_player.LocalEntity is not { } player ||
+            !EntityManager.TryGetComponent<InternalsComponent>(player, out var internals))
+            return false;
+
+        // If they can't connect to a tank, notify them!
+        if (internals.BreathTools.Count == 0)
+        {
+            _popup.PopupPredictedCursor(Loc.GetString("es-internals-popup-no-breathing-tool"), player, PopupType.Medium);
+            return true;
+        }
+
+        // If they have a connected tank already, prioritize turning it off first
+        if (internals.GasTankEntity is { } connectedTank)
+        {
+            SendToggleMessage(connectedTank);
+            return true;
+        }
+
+        // Find candidate tanks
+        var tanks = new HashSet<Entity<GasTankComponent>>();
+        foreach (var entity in _inventory.GetHandOrInventoryEntities(player))
+        {
+            if (!EntityManager.TryGetComponent<GasTankComponent>(entity, out var gasTank) ||
+                !_gasTank.CanConnectToInternals((entity, gasTank)))
+                continue;
+
+            tanks.Add((entity, gasTank));
+        }
+
+        if (tanks.Count == 1)
+        {
+            SendToggleMessage(tanks.First());
+        }
+        else if (tanks.Count > 1)
+        {
+            _menu?.OpenOverMouseScreenPosition();
+            _menu?.SetButtons(GetButtons(tanks));
+        }
+        else
+        {
+            _popup.PopupPredictedCursor(Loc.GetString("es-internals-popup-no-tanks"), player, PopupType.Medium);
+        }
+        return true;
+    }
+
+    private IEnumerable<RadialMenuOptionBase> GetButtons(HashSet<Entity<GasTankComponent>> ent)
+    {
+        foreach (var tank in ent)
+        {
+            var metaData = EntityManager.GetComponent<MetaDataComponent>(tank);
+
+            var option = new RadialMenuActionOption<EntityUid>(SendToggleMessage, tank)
+            {
+                // BUG: Using the sprite view causes items in the inventory to be invisible.
+                IconSpecifier = RadialMenuIconSpecifier.With(metaData.EntityPrototype?.ID),
+                ToolTip = metaData.EntityName,
+            };
+            yield return option;
+        }
+    }
+
+    private void SendToggleMessage(EntityUid tank)
+    {
+        var tankNEnt = EntityManager.GetNetEntity(tank);
+        EntityManager.RaisePredictiveEvent(new ESToggleInternalsEvent(tankNEnt));
+    }
+}

--- a/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
+++ b/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
@@ -57,7 +57,7 @@ public sealed class ESInternalsUIController : UIController, IOnStateChanged<Game
         // If they can't connect to a tank, notify them!
         if (internals.BreathTools.Count == 0)
         {
-            _popup.PopupPredictedCursor(Loc.GetString("es-internals-popup-no-breathing-tool"), player, PopupType.Medium);
+            _popup.PopupPredictedCursor(Loc.GetString("internals-self-no-breath-tool"), player, PopupType.Medium);
             return true;
         }
 
@@ -90,7 +90,7 @@ public sealed class ESInternalsUIController : UIController, IOnStateChanged<Game
         }
         else
         {
-            _popup.PopupPredictedCursor(Loc.GetString("es-internals-popup-no-tanks"), player, PopupType.Medium);
+            _popup.PopupPredictedCursor(Loc.GetString("internals-self-no-tank"), player, PopupType.Medium);
         }
         return true;
     }

--- a/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
+++ b/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Client.Atmos.EntitySystems;
 using Content.Client.Gameplay;
+using Content.Client.Hands.Systems;
 using Content.Client.Inventory;
 using Content.Client.Popups;
 using Content.Client.UserInterface.Controls;
@@ -23,6 +24,7 @@ public sealed class ESInternalsUIController : UIController, IOnStateChanged<Game
     [Dependency] private readonly IPlayerManager _player = default!;
 
     [UISystemDependency] private readonly GasTankSystem _gasTank = default!;
+    [UISystemDependency] private readonly HandsSystem _hands = default!;
     [UISystemDependency] private readonly ClientInventorySystem _inventory = default!;
     [UISystemDependency] private readonly PopupSystem _popup = default!;
 
@@ -69,35 +71,56 @@ public sealed class ESInternalsUIController : UIController, IOnStateChanged<Game
         }
 
         // Find candidate tanks
-        var tanks = new HashSet<Entity<GasTankComponent>>();
-        foreach (var entity in _inventory.GetHandOrInventoryEntities(player))
+        var tanks = new HashSet<(EntityUid Tank, string)>();
+        var slotEnumerator = _inventory.GetSlotEnumerator(player);
+        while (slotEnumerator.MoveNext(out var inventorySlot))
         {
+            if (inventorySlot.ContainedEntity is not { } entity)
+                continue;
+
             if (!EntityManager.TryGetComponent<GasTankComponent>(entity, out var gasTank) ||
                 !_gasTank.CanConnectToInternals((entity, gasTank)))
                 continue;
 
-            tanks.Add((entity, gasTank));
+            _inventory.TryGetSlot(player, inventorySlot.ID, out var def);
+            var identifier = def?.DisplayName.ToLowerInvariant() ?? string.Empty;
+            tanks.Add((entity, identifier));
         }
 
-        if (tanks.Count == 1)
+        foreach (var handId in _hands.EnumerateHands(player))
         {
-            SendToggleMessage(tanks.First());
+            if (!_hands.TryGetHeldItem(player, handId, out var held) ||
+                !_hands.TryGetHand(player, handId, out var hand))
+                continue;
+
+            if (!EntityManager.TryGetComponent<GasTankComponent>(held, out var gasTank) ||
+                !_gasTank.CanConnectToInternals((held.Value, gasTank)))
+                continue;
+
+            // TODO: this should be pulled out to a common place.
+            var slotName = Loc.GetString("es-internals-ui-hand-fmt", ("location", hand.Value.Location.ToString().ToLowerInvariant()));
+            tanks.Add((held.Value, slotName));
         }
-        else if (tanks.Count > 1)
+
+        switch (tanks.Count)
         {
-            _menu?.OpenOverMouseScreenPosition();
-            _menu?.SetButtons(GetButtons(tanks));
-        }
-        else
-        {
-            _popup.PopupPredictedCursor(Loc.GetString("internals-self-no-tank"), player, PopupType.Medium);
+            case 0:
+                _popup.PopupPredictedCursor(Loc.GetString("internals-self-no-tank"), player, PopupType.Medium);
+                break;
+            case 1:
+                SendToggleMessage(tanks.First().Tank);
+                break;
+            case > 1:
+                _menu?.OpenOverMouseScreenPosition();
+                _menu?.SetButtons(GetButtons(tanks));
+                break;
         }
         return true;
     }
 
-    private IEnumerable<RadialMenuOptionBase> GetButtons(HashSet<Entity<GasTankComponent>> ent)
+    private IEnumerable<RadialMenuOptionBase> GetButtons(HashSet<(EntityUid, string)> set)
     {
-        foreach (var tank in ent)
+        foreach (var (tank, slot) in set)
         {
             var metaData = EntityManager.GetComponent<MetaDataComponent>(tank);
 
@@ -105,7 +128,7 @@ public sealed class ESInternalsUIController : UIController, IOnStateChanged<Game
             {
                 // BUG: Using the sprite view causes items in the inventory to be invisible.
                 IconSpecifier = RadialMenuIconSpecifier.With(metaData.EntityPrototype?.ID),
-                ToolTip = metaData.EntityName,
+                ToolTip = Loc.GetString("es-internals-ui-name-fmt", ("name", metaData.EntityName), ("slot", slot)),
             };
             yield return option;
         }

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTankSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTankSystem.cs
@@ -67,6 +67,10 @@ public abstract class SharedGasTankSystem : EntitySystem
 
     private void OnGetActions(EntityUid uid, GasTankComponent component, GetItemActionsEvent args)
     {
+// ES START
+        // No more internal actions!!!
+        return;
+// ES END
         args.AddAction(ref component.ToggleActionEntity, component.ToggleAction);
         Dirty(uid, component);
     }
@@ -82,6 +86,9 @@ public abstract class SharedGasTankSystem : EntitySystem
             args.PushMarkup(Loc.GetString("comp-gas-tank-connected"));
 
         args.PushMarkup(Loc.GetString(component.IsValveOpen ? "comp-gas-tank-examine-open-valve" : "comp-gas-tank-examine-closed-valve"));
+// ES START
+        args.PushMarkup(Loc.GetString("es-internals-examine-key"));
+// ES END
     }
 
     private void OnActionToggle(Entity<GasTankComponent> gasTank, ref ToggleActionEvent args)
@@ -216,7 +223,10 @@ public abstract class SharedGasTankSystem : EntitySystem
         return true;
     }
 
-    private bool ToggleInternals(Entity<GasTankComponent> ent, EntityUid? user = null)
+// ES START
+    // private -> public
+    public bool ToggleInternals(Entity<GasTankComponent> ent, EntityUid? user = null)
+// ES END
     {
         if (ent.Comp.IsConnected)
         {

--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -84,8 +84,17 @@ public abstract class SharedInternalsSystem : EntitySystem
         // Check if a mask is present.
         if (internals.BreathTools.Count == 0)
         {
-            var message = user == target ? Loc.GetString("internals-self-no-breath-tool") : Loc.GetString("internals-other-no-breath-tool", ("ent", Identity.Name(target, EntityManager, user)));
-            _popupSystem.PopupClient(message, target, user);
+// ES START
+            var message = user == target ? Loc.GetString("internals-self-no-breath-tool") : Loc.GetString("internals-other-no-breath-tool", ("ent", Identity.Entity(target, EntityManager, user)));
+            if (user == target)
+            {
+                _popupSystem.PopupPredictedCursor(message, user, PopupType.Medium);
+            }
+            else
+            {
+                _popupSystem.PopupClient(message, target, user, PopupType.Medium);
+            }
+// ES END
             return false;
         }
 
@@ -95,8 +104,17 @@ public abstract class SharedInternalsSystem : EntitySystem
         // If they're not on then check if we have a mask to use
         if (tank == null)
         {
-            var message = user == target ? Loc.GetString("internals-self-no-tank") : Loc.GetString("internals-other-no-tank", ("ent", Identity.Name(target, EntityManager, user)));
-            _popupSystem.PopupClient(message, target, user);
+// ES START
+            var message = user == target ? Loc.GetString("internals-self-no-tank") : Loc.GetString("internals-other-no-tank", ("ent", Identity.Entity(target, EntityManager, user)));
+            if (user == target)
+            {
+                _popupSystem.PopupPredictedCursor(message, user, PopupType.Medium);
+            }
+            else
+            {
+                _popupSystem.PopupClient(message, target, user, PopupType.Medium);
+            }
+// ES END
             return false;
         }
 

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -7,6 +7,7 @@ namespace Content.Shared.Input
     {
         // ES START
         public static readonly BoundKeyFunction ESHoldToFace = "ESHoldToFace";
+        public static readonly BoundKeyFunction ESToggleInternals = "ESToggleInternals";
         // ES END
         public static readonly BoundKeyFunction ToggleKnockdown = "ToggleKnockdown";
         public static readonly BoundKeyFunction UseItemInHand = "ActivateItemInHand";

--- a/Content.Shared/_ES/Internals/ESInternalsSystem.cs
+++ b/Content.Shared/_ES/Internals/ESInternalsSystem.cs
@@ -1,0 +1,45 @@
+using Content.Shared.ActionBlocker;
+using Content.Shared.Atmos.Components;
+using Content.Shared.Atmos.EntitySystems;
+using Content.Shared.Interaction;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._ES.Internals;
+
+public sealed class ESInternalsSystem : EntitySystem
+{
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly SharedGasTankSystem _internals = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeAllEvent<ESToggleInternalsEvent>(OnToggleInternals);
+    }
+
+    private void OnToggleInternals(ESToggleInternalsEvent msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } ent ||
+            !TryGetEntity(msg.Tank, out var tank) ||
+            !TryComp<GasTankComponent>(tank, out var tankComp))
+            return;
+
+        if (!_interaction.IsAccessible(ent, tank.Value) ||
+            !_actionBlocker.CanInteract(ent, tank.Value))
+            return;
+
+        _internals.ToggleInternals((tank.Value, tankComp), ent);
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class ESToggleInternalsEvent : EntityEventArgs
+{
+    public NetEntity Tank;
+
+    public ESToggleInternalsEvent(NetEntity tank)
+    {
+        Tank = tank;
+    }
+}

--- a/Resources/Locale/en-US/_ES/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_ES/escape-menu/ui/options-menu.ftl
@@ -1,2 +1,3 @@
 ui-options-header-es = Ephemeral Space
 ui-options-function-es-hold-to-face = Face Direction / Strafe
+ui-options-function-es-toggle-internals = Toggle Internals

--- a/Resources/Locale/en-US/_ES/internals/internals.ftl
+++ b/Resources/Locale/en-US/_ES/internals/internals.ftl
@@ -1,0 +1,3 @@
+es-internals-popup-no-breathing-tool = No breathing tool!
+es-internals-popup-no-tanks = No tank!
+es-internals-examine-key = Press [color=yellow][keybind="ESToggleInternals"][/color] when equipped to toggle internals.

--- a/Resources/Locale/en-US/_ES/internals/internals.ftl
+++ b/Resources/Locale/en-US/_ES/internals/internals.ftl
@@ -1,3 +1,0 @@
-es-internals-popup-no-breathing-tool = No breathing tool!
-es-internals-popup-no-tanks = No tank!
-es-internals-examine-key = Press [color=yellow][keybind="ESToggleInternals"][/color] when equipped to toggle internals.

--- a/Resources/Locale/en-US/actions/actions/internals.ftl
+++ b/Resources/Locale/en-US/actions/actions/internals.ftl
@@ -3,7 +3,11 @@ action-description-internals-toggle-on = Breathe from the equipped gas tank. Als
 action-name-internals-toggle-off = Toggle Internals Off
 action-description-internals-toggle-off = Breathe from the environment.
 
-internals-self-no-breath-tool = You are not wearing a breathing tool
-internals-other-no-breath-tool = {$ent} is not wearing a breathing tool
-internals-self-no-tank = You are not wearing a gas tank
-internals-other-no-tank = {$ent} is not wearing a gas tank
+# ES START
+internals-self-no-breath-tool = No breathing tool!
+internals-other-no-breath-tool = {CAPITALIZE(SUBJECT($ent))} {CONJUGATE-BASIC($ent, "don't", "doesn't")} have a breathing tool!
+internals-self-no-tank = No gas tank!
+internals-other-no-tank = {CAPITALIZE(SUBJECT($ent))} {CONJUGATE-BASIC($ent, "don't", "doesn't")} have a gas tank!
+
+es-internals-examine-key = Press [color=yellow][keybind="ESToggleInternals"][/color] when equipped to toggle internals.
+# ES END

--- a/Resources/Locale/en-US/actions/actions/internals.ftl
+++ b/Resources/Locale/en-US/actions/actions/internals.ftl
@@ -10,4 +10,6 @@ internals-self-no-tank = No gas tank!
 internals-other-no-tank = {CAPITALIZE(SUBJECT($ent))} {CONJUGATE-BASIC($ent, "don't", "doesn't")} have a gas tank!
 
 es-internals-examine-key = Press [color=yellow][keybind="ESToggleInternals"][/color] when equipped to toggle internals.
+es-internals-ui-name-fmt = {$name} ({$slot})
+es-internals-ui-hand-fmt = {$location} hand
 # ES END

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -62,7 +62,7 @@ alerts-no-battery-desc = You don't have a battery, rendering you unable to charg
 
 alerts-internals-name = Toggle internals
 # ES START
-alerts-internals-desc = [color=yellow]Click[/color] or press [color=yellow][keybind="ESToggleInternals"][/color] to toggle your gas tank internals on and off.
+alerts-internals-desc = [color=yellow]Click[/color] here or press [color=yellow][keybind="ESToggleInternals"][/color] to toggle your gas tank internals on and off.
 # ES END
 
 alerts-piloting-name = Piloting Shuttle

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -61,7 +61,9 @@ alerts-no-battery-name = No Battery
 alerts-no-battery-desc = You don't have a battery, rendering you unable to charge or use your abilities.
 
 alerts-internals-name = Toggle internals
-alerts-internals-desc = Toggles your gas tank internals on or off.
+# ES START
+alerts-internals-desc = [color=yellow]Click[/color] or press [color=yellow][keybind="ESToggleInternals"][/color] to toggle your gas tank internals on and off.
+# ES END
 
 alerts-piloting-name = Piloting Shuttle
 alerts-piloting-desc = You are piloting a shuttle. Click the alert to stop.

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -4,6 +4,9 @@ binds:
 - function: ESHoldToFace
   type: State
   key: Shift
+- function: ESToggleInternals
+  type: State
+  key: R
 # ES END
 - function: UIClick
   type: State


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Proposed by mirrorcult, a more streamlined approach to managing internals.
One of the issues with internals right now is that you tend to pick up and drop tanks over time, shuffling around actions in the hotbar. Additionally, every tank needs its own action, which is unnecessary since you only ever use one tank at most. This significantly contributes to actions bloating up the screen, which is unwelcome.

the new system smartly infers how to connect to internals based on context. If you have no tank or mask, it'll inform you when you press the button. If you have one tank, then the connection will happen automatically with no further input. If there are multiple, when connecting, you'll be prompted to choose one via a radial menu.

https://github.com/user-attachments/assets/c04345eb-d2f2-4861-899e-74186bd797d8

<img width="806" height="523" alt="image" src="https://github.com/user-attachments/assets/5287603b-c31d-4bd7-81ce-9d14ecdae7e6" />

