### PR TITLE
fix random viewcone bug i remembered

### DIFF
--- a/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
@@ -64,7 +64,7 @@ public sealed class ESViewconeOverlayManagementSystem : EntitySystem
         while (enumerator.MoveNext(out var uid, out _, out var eye, out var viewcone, out var xform))
         {
             var eyeAngle = eye.Rotation;
-            var rotation = _xform.GetWorldRotation(xform);
+            var (position, rotation) = _xform.GetWorldPositionRotation(xform);
             var playerAngle = rotation;
             var desiredWasNull = viewcone.DesiredViewAngle == null;
 
@@ -81,7 +81,9 @@ public sealed class ESViewconeOverlayManagementSystem : EntitySystem
                 // if last frame we had a mouse rotation angle, but now we dont,
                 // that means it was disabled
                 // but, we should keep the old mouse angle for viewcone, at least until the real angle actually changes
-                if (MathHelper.CloseToPercent(viewcone.LastWorldRotationAngle, playerAngle, .000001d))
+                // or they move
+                if (MathHelper.CloseToPercent(viewcone.LastWorldRotationAngle, playerAngle, .001d)
+                    && viewcone.LastWorldPos == position)
                 {
                     playerAngle = viewcone.LastMouseRotationAngle;
                 }
@@ -91,6 +93,7 @@ public sealed class ESViewconeOverlayManagementSystem : EntitySystem
                 }
             }
 
+            viewcone.LastWorldPos = position;
             viewcone.LastWorldRotationAngle = rotation;
             viewcone.DesiredViewAngle = playerAngle + eyeAngle;
 

--- a/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._ES.Viewcone;
@@ -48,5 +49,6 @@ public sealed partial class ESViewconeComponent : Component
     public Angle ViewAngle;
     public Angle? DesiredViewAngle = null;
     public Angle LastMouseRotationAngle;
+    public Vector2 LastWorldPos;
     public Angle LastWorldRotationAngle;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

difficult to explain what the bug is but this fixes it. has to do with the viewcone rotation clientside (with mouserotator) and the entitys rotation not being synced bc the entity rotation is secretly only cardinal. and we dont want the viewcone to change just because u turned off mouserotator but we also do we want it to reset correctly if you move