### PR TITLE
Spark tweaks

### DIFF
--- a/Content.Shared/_ES/Sparks/Components/ESSparkOnHitComponent.cs
+++ b/Content.Shared/_ES/Sparks/Components/ESSparkOnHitComponent.cs
@@ -1,13 +1,14 @@
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._ES.Sparks.Components;
 
 /// <summary>
 /// An entity that sparks when damaged by something
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
 [Access(typeof(ESSparkOnHitSystem))]
 public sealed partial class ESSparkOnHitComponent : Component
 {
@@ -22,6 +23,25 @@ public sealed partial class ESSparkOnHitComponent : Component
     /// </summary>
     [DataField]
     public int Count = 3;
+
+    /// <summary>
+    /// Chance for sparks to occur
+    /// </summary>
+    [DataField]
+    public float Prob = 1f;
+
+    /// <summary>
+    /// Minimum time inbetween sparks occuring from hits.
+    /// Used to reduce spark spam.
+    /// </summary>
+    [DataField]
+    public TimeSpan SparkDelay = TimeSpan.FromSeconds(0.5f);
+
+    /// <summary>
+    /// The last time that a spark occured.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
+    public TimeSpan LastSparkTime;
 
     /// <summary>
     /// Spark prototypes

--- a/Content.Shared/_ES/Sparks/ESSparkOnHitSystem.cs
+++ b/Content.Shared/_ES/Sparks/ESSparkOnHitSystem.cs
@@ -1,10 +1,14 @@
 using Content.Shared._ES.Sparks.Components;
 using Content.Shared.Damage.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Shared._ES.Sparks;
 
 public sealed class ESSparkOnHitSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ESSparksSystem _sparks = default!;
 
     /// <inheritdoc/>
@@ -18,9 +22,16 @@ public sealed class ESSparkOnHitSystem : EntitySystem
         if (args.DamageDelta is null)
             return;
 
+        if (!_random.Prob(ent.Comp.Prob))
+            return;
+
         if (args.DamageDelta.GetTotal() < ent.Comp.Threshold)
             return;
 
+        if (_timing.CurTime - ent.Comp.LastSparkTime < ent.Comp.SparkDelay)
+            return;
+
         _sparks.DoSparks(ent, ent.Comp.Count, ent.Comp.SparkPrototype);
+        ent.Comp.LastSparkTime = _timing.CurTime;
     }
 }

--- a/Resources/Prototypes/_ES/Entities/Effects/sparks.yml
+++ b/Resources/Prototypes/_ES/Entities/Effects/sparks.yml
@@ -4,10 +4,12 @@
   components:
   - type: Sprite
     sprite: _ES/Effects/sparks.rsi
-    state: sparks
     drawdepth: Effects
     noRot: true
     loop: false
+    layers:
+    - state: sparks
+      shader: unshaded
   - type: Appearance
   - type: Physics
     bodyType: Dynamic
@@ -39,7 +41,7 @@
   - type: AnimationPlayer
   - type: PointLight
     radius: 1.5
-    energy: 2.4
+    energy: 3
     falloff: 6
     color: "#FAA019"
     netsync: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Increase pointlight strength on spark entities
- make the spark entity unshaded (looks good with the fade out)
- Adds a "prob" field on SparkOnHit (good for whatever future integration we do)
- Adds a min delay to SparkOnHit. Not really relevant besides the face that if you shoot a light with a shotgun it will spark for every hit.