### PR TITLE
mildly large toast update + an entire new lighting pass again

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -156,7 +156,7 @@ namespace Content.Client.Entry
             // we cant set engine cvars by changing the file,
             // and cant set client-only non-replicated cvars with configpresets
             // so
-            _configManager.SetCVar("light.blur_factor", 0.0037f);
+            _configManager.SetCVar("light.blur_factor", 0.0025f);
             // ES END
         }
 

--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -151,6 +151,13 @@ namespace Content.Client.Entry
             _configManager.SetCVar("interface.resolutionAutoScaleLowerCutoffX", 520);
             _configManager.SetCVar("interface.resolutionAutoScaleLowerCutoffY", 240);
             _configManager.SetCVar("interface.resolutionAutoScaleMinimum", 0.5f);
+
+            // ES START
+            // we cant set engine cvars by changing the file,
+            // and cant set client-only non-replicated cvars with configpresets
+            // so
+            _configManager.SetCVar("light.blur_factor", 0.0037f);
+            // ES END
         }
 
         public override void PostInit()

--- a/Content.Client/Light/LightBlurOverlay.cs
+++ b/Content.Client/Light/LightBlurOverlay.cs
@@ -43,7 +43,12 @@ public sealed class LightBlurOverlay : Overlay
 
         var target = beforeLightRes.EnlargedLightTarget;
         // Yeah that's all this does keep walkin.
-        _clyde.BlurRenderTarget(args.Viewport, target, res.BlurTarget, args.Viewport.Eye, 14f * 5f);
+        // ES START
+        // blur multiplier is reduced by a factor, to reduce lightleak that already occurs as a result of this
+        // as well as to account for the fact that we have changed light.blur_factor (which is the baseline this is multiplied by)
+        // otherwise, stuff leaks really badly
+        _clyde.BlurRenderTarget(args.Viewport, target, res.BlurTarget, args.Viewport.Eye, 4f * 5f);
+        // ES END
     }
 
     protected override void DisposeBehavior()

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 12/03/2025 05:33:24
-  entityCount: 14342
+  time: 12/03/2025 06:13:53
+  entityCount: 14366
 maps:
 - 3
 grids:
@@ -6636,39 +6636,11 @@ entities:
       parent: 2
 - proto: ButtonFrameCaution
   entities:
-  - uid: 34
-    components:
-    - type: Transform
-      pos: 7.5,-2.5
-      parent: 2
-  - uid: 1004
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-5.5
-      parent: 2
   - uid: 1085
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,6.5
-      parent: 2
-  - uid: 3733
-    components:
-    - type: Transform
-      pos: -26.5,-16.5
-      parent: 2
-  - uid: 6911
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,4.5
-      parent: 2
-  - uid: 9322
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -38.5,-20.5
       parent: 2
   - uid: 14328
     components:
@@ -6676,22 +6648,16 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -38.5,-39.5
       parent: 2
-  - uid: 14339
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -26.5,-27.5
-      parent: 2
-- proto: ButtonFrameExit
+- proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 448
+  - uid: 1004
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,1.5
+      pos: -27.5,4.5
       parent: 2
-    - type: WallMount
-      arc: 6.283185307179586 rad
+- proto: ButtonFrameExit
+  entities:
   - uid: 6780
     components:
     - type: Transform
@@ -36648,6 +36614,52 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-44.5
+      parent: 2
+- proto: ESButtonFrameCautionDirectional
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 1226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-20.5
+      parent: 2
+  - uid: 14343
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-17.5
+      parent: 2
+- proto: ESButtonFrameCautionSecurityDirectional
+  entities:
+  - uid: 518
+    components:
+    - type: Transform
+      pos: -26.5,-16.5
+      parent: 2
+  - uid: 3733
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-27.5
+      parent: 2
+- proto: ESButtonFrameExitDirectional
+  entities:
+  - uid: 3992
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,1.5
       parent: 2
 - proto: ESCarpetFancyRed
   entities:
@@ -68353,38 +68365,6 @@ entities:
       fixtures: {}
 - proto: SignalSwitch
   entities:
-  - uid: 518
-    components:
-    - type: MetaData
-      name: window shutters
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,4.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        5086:
-        - - Off
-          - Close
-        - - On
-          - Open
-        5085:
-        - - Off
-          - Close
-        - - On
-          - Open
-        6779:
-        - - Off
-          - Close
-        - - On
-          - Open
-        5087:
-        - - Off
-          - Close
-        - - On
-          - Open
-    - type: Fixtures
-      fixtures: {}
   - uid: 3087
     components:
     - type: MetaData
@@ -68429,6 +68409,58 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         3093:
+        - - On
+          - Open
+        - - Off
+          - Close
+    - type: Fixtures
+      fixtures: {}
+  - uid: 4868
+    components:
+    - type: MetaData
+      name: window shutters
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,4.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        5086:
+        - - On
+          - Open
+        - - Off
+          - Close
+        5085:
+        - - Off
+          - Close
+        - - On
+          - Open
+        6779:
+        - - Off
+          - Close
+        - - On
+          - Open
+        5087:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
+  - uid: 6911
+    components:
+    - type: MetaData
+      name: open medbay switch
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,2.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        414:
+        - - Status
+          - Open
+        1053:
         - - On
           - Open
         - - Off
@@ -68791,21 +68823,6 @@ entities:
           - Open
         - - Off
           - Close
-    - type: Fixtures
-      fixtures: {}
-  - uid: 1226
-    components:
-    - type: MetaData
-      name: open medbay door
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,2.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        414:
-        - - Status
-          - Open
     - type: Fixtures
       fixtures: {}
   - uid: 1655
@@ -69177,6 +69194,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 9322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -34.5,-15.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignBar
   entities:
   - uid: 351
@@ -69285,6 +69310,169 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 14346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-28.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalBar
+  entities:
+  - uid: 14353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,-32.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14356
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-28.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalBridge
+  entities:
+  - uid: 14348
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-32.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14357
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-32.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalDorms
+  entities:
+  - uid: 14362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-2.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalEng
+  entities:
+  - uid: 14344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-28.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalEvac
+  entities:
+  - uid: 14359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-32.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalFood
+  entities:
+  - uid: 14347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,-32.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalHop
+  entities:
+  - uid: 14365
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalMed
+  entities:
+  - uid: 14352
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-32.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14355
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-28.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalSci
+  entities:
+  - uid: 14350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-32.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14354
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-28.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14366
+    components:
+    - type: Transform
+      pos: 1.5,-2.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalSec
+  entities:
+  - uid: 14345
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-28.28
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: SignDirectionalSolar
   entities:
   - uid: 8674
@@ -69308,6 +69496,42 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -72.5,0.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalSupply
+  entities:
+  - uid: 14351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,-32.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-32.72
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: SignDirectionalWash
+  entities:
+  - uid: 14361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,-2.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14363
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -69393,10 +69617,10 @@ entities:
       fixtures: {}
 - proto: SignEngineering
   entities:
-  - uid: 3992
+  - uid: 14349
     components:
     - type: Transform
-      pos: -34.5,-15.5
+      pos: -34.5,-21.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -69707,13 +69931,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 4868
-    components:
-    - type: Transform
-      pos: -34.5,-21.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 7415
     components:
     - type: Transform
@@ -69734,6 +69951,14 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -76.5,2.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14339
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -34.5,-23.5
       parent: 2
     - type: Fixtures
       fixtures: {}

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 11/11/2025 03:03:50
+  time: 12/02/2025 06:40:15
   entityCount: 14291
 maps:
 - 3
@@ -36444,6 +36444,13 @@ entities:
     - type: Transform
       pos: -50,-18.5
       parent: 2
+- proto: ESAntimatterGasPressurePump
+  entities:
+  - uid: 3882
+    components:
+    - type: Transform
+      pos: -43.5,-17.5
+      parent: 2
 - proto: ESBaseComputerTerminalCryptoNuke
   entities:
   - uid: 3834
@@ -38996,6 +39003,750 @@ entities:
     components:
     - type: Transform
       pos: -47.5,-18.5
+      parent: 2
+- proto: ESPoweredLightDepartment
+  entities:
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-8.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 9.5,-15.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 528
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,-25.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-17.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,-27.5
+      parent: 2
+  - uid: 651
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-14.5
+      parent: 2
+  - uid: 989
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 2
+  - uid: 1011
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 2
+  - uid: 1029
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-0.5
+      parent: 2
+  - uid: 1105
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 1106
+    components:
+    - type: Transform
+      pos: -4.5,-41.5
+      parent: 2
+  - uid: 1197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-20.5
+      parent: 2
+  - uid: 1198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-1.5
+      parent: 2
+  - uid: 1275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,2.5
+      parent: 2
+  - uid: 1276
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,5.5
+      parent: 2
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: 16.5,11.5
+      parent: 2
+  - uid: 1546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-38.5
+      parent: 2
+  - uid: 1701
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-45.5
+      parent: 2
+  - uid: 2021
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-31.5
+      parent: 2
+  - uid: 2051
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-38.5
+      parent: 2
+  - uid: 2153
+    components:
+    - type: Transform
+      pos: 30.5,-29.5
+      parent: 2
+  - uid: 2154
+    components:
+    - type: Transform
+      pos: 25.5,-34.5
+      parent: 2
+  - uid: 2227
+    components:
+    - type: Transform
+      pos: 22.5,-26.5
+      parent: 2
+  - uid: 2399
+    components:
+    - type: Transform
+      pos: 27.5,-21.5
+      parent: 2
+  - uid: 2416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 26.5,-26.5
+      parent: 2
+  - uid: 2550
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -43.5,-20.5
+      parent: 2
+  - uid: 2582
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-15.5
+      parent: 2
+  - uid: 2661
+    components:
+    - type: Transform
+      pos: -45.5,-4.5
+      parent: 2
+  - uid: 2875
+    components:
+    - type: Transform
+      pos: -50.5,-14.5
+      parent: 2
+  - uid: 2897
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-22.5
+      parent: 2
+  - uid: 2912
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 2
+  - uid: 2914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -50.5,-22.5
+      parent: 2
+  - uid: 2917
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 2
+  - uid: 2918
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 2
+  - uid: 2940
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-5.5
+      parent: 2
+  - uid: 3020
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -54.5,-11.5
+      parent: 2
+  - uid: 3094
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 3096
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -25.5,-11.5
+      parent: 2
+  - uid: 3097
+    components:
+    - type: Transform
+      pos: -42.5,-10.5
+      parent: 2
+  - uid: 3125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -40.5,-27.5
+      parent: 2
+  - uid: 3127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -39.5,-16.5
+      parent: 2
+  - uid: 3130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-20.5
+      parent: 2
+  - uid: 3132
+    components:
+    - type: Transform
+      pos: -26.5,-21.5
+      parent: 2
+  - uid: 3141
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-35.5
+      parent: 2
+  - uid: 3142
+    components:
+    - type: Transform
+      pos: 29.5,-16.5
+      parent: 2
+  - uid: 3176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -18.5,-19.5
+      parent: 2
+  - uid: 3268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-19.5
+      parent: 2
+  - uid: 3657
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-54.5
+      parent: 2
+  - uid: 3991
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-23.5
+      parent: 2
+  - uid: 4189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -27.5,-13.5
+      parent: 2
+  - uid: 4315
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -38.5,-8.5
+      parent: 2
+  - uid: 4316
+    components:
+    - type: Transform
+      pos: -38.5,-1.5
+      parent: 2
+  - uid: 4428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -54.5,-4.5
+      parent: 2
+  - uid: 4599
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -61.5,-2.5
+      parent: 2
+  - uid: 4600
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -61.5,-6.5
+      parent: 2
+  - uid: 4601
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -61.5,-10.5
+      parent: 2
+  - uid: 4602
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -61.5,-14.5
+      parent: 2
+  - uid: 4603
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -61.5,-18.5
+      parent: 2
+  - uid: 4604
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,10.5
+      parent: 2
+  - uid: 4687
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -55.5,-18.5
+      parent: 2
+  - uid: 4688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -58.5,-25.5
+      parent: 2
+  - uid: 4913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,4.5
+      parent: 2
+  - uid: 4914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,4.5
+      parent: 2
+  - uid: 5045
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,6.5
+      parent: 2
+  - uid: 5046
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.5,4.5
+      parent: 2
+  - uid: 5309
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-39.5
+      parent: 2
+  - uid: 5310
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,-35.5
+      parent: 2
+  - uid: 6795
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,-36.5
+      parent: 2
+  - uid: 6796
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-36.5
+      parent: 2
+  - uid: 6803
+    components:
+    - type: Transform
+      pos: -51.5,-1.5
+      parent: 2
+  - uid: 6804
+    components:
+    - type: Transform
+      pos: -45.5,-1.5
+      parent: 2
+  - uid: 6805
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-42.5
+      parent: 2
+  - uid: 6806
+    components:
+    - type: Transform
+      pos: -36.5,-37.5
+      parent: 2
+  - uid: 6812
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -48.5,-44.5
+      parent: 2
+  - uid: 6813
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -53.5,10.5
+      parent: 2
+  - uid: 6816
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 2
+  - uid: 6818
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.5,4.5
+      parent: 2
+  - uid: 6819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,4.5
+      parent: 2
+  - uid: 6845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,-14.5
+      parent: 2
+  - uid: 6846
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-9.5
+      parent: 2
+  - uid: 7351
+    components:
+    - type: Transform
+      pos: -14.5,-33.5
+      parent: 2
+  - uid: 7828
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-37.5
+      parent: 2
+  - uid: 11679
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-45.5
+      parent: 2
+- proto: ESPoweredLightHallway
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -25.5,-31.5
+      parent: 2
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,6.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-9.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-5.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-37.5
+      parent: 2
+  - uid: 386
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-0.5
+      parent: 2
+  - uid: 1034
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 1274
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -41.5,8.5
+      parent: 2
+  - uid: 1612
+    components:
+    - type: Transform
+      pos: 3.5,-29.5
+      parent: 2
+  - uid: 1648
+    components:
+    - type: Transform
+      pos: -29.5,-17.5
+      parent: 2
+  - uid: 1697
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-45.5
+      parent: 2
+  - uid: 2020
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-27.5
+      parent: 2
+  - uid: 2841
+    components:
+    - type: Transform
+      pos: 14.5,-29.5
+      parent: 2
+  - uid: 2930
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-20.5
+      parent: 2
+  - uid: 3086
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 3088
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 3115
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-33.5
+      parent: 2
+  - uid: 3120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -41.5,-47.5
+      parent: 2
+  - uid: 3123
+    components:
+    - type: Transform
+      pos: -39.5,-42.5
+      parent: 2
+  - uid: 3124
+    components:
+    - type: Transform
+      pos: -20.5,-28.5
+      parent: 2
+  - uid: 3131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-29.5
+      parent: 2
+  - uid: 3135
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -37.5,5.5
+      parent: 2
+  - uid: 3136
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,1.5
+      parent: 2
+  - uid: 3140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -49.5,6.5
+      parent: 2
+  - uid: 3163
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,-24.5
+      parent: 2
+  - uid: 3173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 3955
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -33.5,-12.5
+      parent: 2
+  - uid: 4314
+    components:
+    - type: Transform
+      pos: -30.5,-7.5
+      parent: 2
+  - uid: 4409
+    components:
+    - type: Transform
+      pos: -34.5,-16.5
+      parent: 2
+  - uid: 4968
+    components:
+    - type: Transform
+      pos: -22.5,0.5
+      parent: 2
+  - uid: 6785
+    components:
+    - type: Transform
+      pos: -29.5,0.5
+      parent: 2
+  - uid: 6786
+    components:
+    - type: Transform
+      pos: -15.5,2.5
+      parent: 2
+  - uid: 6788
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-33.5
+      parent: 2
+  - uid: 6789
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-32.5
+      parent: 2
+  - uid: 6791
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,-31.5
+      parent: 2
+  - uid: 6792
+    components:
+    - type: Transform
+      pos: -11.5,-29.5
+      parent: 2
+  - uid: 6793
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-31.5
+      parent: 2
+  - uid: 6794
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-31.5
+      parent: 2
+  - uid: 6797
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-25.5
+      parent: 2
+  - uid: 6810
+    components:
+    - type: Transform
+      pos: 0.5,2.5
       parent: 2
 - proto: ESRandomPosterAny
   entities:
@@ -56099,13 +56850,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -21.5,-50.5
       parent: 2
-- proto: ESAntimatterGasPressurePump
-  entities:
-  - uid: 3882
-    components:
-    - type: Transform
-      pos: -43.5,-17.5
-      parent: 2
 - proto: GasPressurePump
   entities:
   - uid: 554
@@ -64200,748 +64944,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-51.5
-      parent: 2
-- proto: Poweredlight
-  entities:
-  - uid: 38
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-31.5
-      parent: 2
-  - uid: 40
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,6.5
-      parent: 2
-  - uid: 41
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-9.5
-      parent: 2
-  - uid: 147
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-8.5
-      parent: 2
-  - uid: 149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-6.5
-      parent: 2
-  - uid: 311
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-5.5
-      parent: 2
-  - uid: 363
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-37.5
-      parent: 2
-  - uid: 368
-    components:
-    - type: Transform
-      pos: 9.5,-15.5
-      parent: 2
-  - uid: 386
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-1.5
-      parent: 2
-  - uid: 490
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-6.5
-      parent: 2
-  - uid: 528
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,-25.5
-      parent: 2
-  - uid: 580
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-17.5
-      parent: 2
-  - uid: 598
-    components:
-    - type: Transform
-      pos: 6.5,-11.5
-      parent: 2
-  - uid: 601
-    components:
-    - type: Transform
-      pos: 12.5,-3.5
-      parent: 2
-  - uid: 625
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-27.5
-      parent: 2
-  - uid: 651
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,-14.5
-      parent: 2
-  - uid: 989
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,8.5
-      parent: 2
-  - uid: 1006
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-0.5
-      parent: 2
-  - uid: 1011
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,7.5
-      parent: 2
-  - uid: 1029
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-0.5
-      parent: 2
-  - uid: 1034
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-3.5
-      parent: 2
-  - uid: 1105
-    components:
-    - type: Transform
-      pos: 12.5,-11.5
-      parent: 2
-  - uid: 1106
-    components:
-    - type: Transform
-      pos: -4.5,-41.5
-      parent: 2
-  - uid: 1108
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-1.5
-      parent: 2
-  - uid: 1197
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-20.5
-      parent: 2
-  - uid: 1198
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-1.5
-      parent: 2
-  - uid: 1274
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -41.5,8.5
-      parent: 2
-  - uid: 1275
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,2.5
-      parent: 2
-  - uid: 1276
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,5.5
-      parent: 2
-  - uid: 1297
-    components:
-    - type: Transform
-      pos: 16.5,11.5
-      parent: 2
-  - uid: 1546
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-38.5
-      parent: 2
-  - uid: 1612
-    components:
-    - type: Transform
-      pos: 3.5,-29.5
-      parent: 2
-  - uid: 1648
-    components:
-    - type: Transform
-      pos: -29.5,-17.5
-      parent: 2
-  - uid: 1697
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-45.5
-      parent: 2
-  - uid: 1701
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-45.5
-      parent: 2
-  - uid: 2020
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 17.5,-27.5
-      parent: 2
-  - uid: 2021
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 24.5,-31.5
-      parent: 2
-  - uid: 2051
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,-38.5
-      parent: 2
-  - uid: 2153
-    components:
-    - type: Transform
-      pos: 30.5,-29.5
-      parent: 2
-  - uid: 2154
-    components:
-    - type: Transform
-      pos: 25.5,-34.5
-      parent: 2
-  - uid: 2227
-    components:
-    - type: Transform
-      pos: 22.5,-26.5
-      parent: 2
-  - uid: 2399
-    components:
-    - type: Transform
-      pos: 27.5,-21.5
-      parent: 2
-  - uid: 2416
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 26.5,-26.5
-      parent: 2
-  - uid: 2550
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -43.5,-20.5
-      parent: 2
-  - uid: 2582
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-15.5
-      parent: 2
-  - uid: 2661
-    components:
-    - type: Transform
-      pos: -45.5,-4.5
-      parent: 2
-  - uid: 2841
-    components:
-    - type: Transform
-      pos: 14.5,-29.5
-      parent: 2
-  - uid: 2875
-    components:
-    - type: Transform
-      pos: -50.5,-14.5
-      parent: 2
-  - uid: 2897
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-22.5
-      parent: 2
-  - uid: 2912
-    components:
-    - type: Transform
-      pos: -4.5,-18.5
-      parent: 2
-  - uid: 2914
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -50.5,-22.5
-      parent: 2
-  - uid: 2917
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,3.5
-      parent: 2
-  - uid: 2918
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-13.5
-      parent: 2
-  - uid: 2930
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-20.5
-      parent: 2
-  - uid: 2940
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,-5.5
-      parent: 2
-  - uid: 3020
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -54.5,-11.5
-      parent: 2
-  - uid: 3086
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,2.5
-      parent: 2
-  - uid: 3088
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-1.5
-      parent: 2
-  - uid: 3094
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-13.5
-      parent: 2
-  - uid: 3096
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -25.5,-11.5
-      parent: 2
-  - uid: 3097
-    components:
-    - type: Transform
-      pos: -42.5,-10.5
-      parent: 2
-  - uid: 3115
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-33.5
-      parent: 2
-  - uid: 3120
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -41.5,-47.5
-      parent: 2
-  - uid: 3123
-    components:
-    - type: Transform
-      pos: -39.5,-42.5
-      parent: 2
-  - uid: 3124
-    components:
-    - type: Transform
-      pos: -20.5,-28.5
-      parent: 2
-  - uid: 3125
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -40.5,-27.5
-      parent: 2
-  - uid: 3127
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -39.5,-16.5
-      parent: 2
-  - uid: 3130
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-20.5
-      parent: 2
-  - uid: 3131
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-29.5
-      parent: 2
-  - uid: 3132
-    components:
-    - type: Transform
-      pos: -26.5,-21.5
-      parent: 2
-  - uid: 3135
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -37.5,5.5
-      parent: 2
-  - uid: 3136
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,1.5
-      parent: 2
-  - uid: 3140
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -49.5,6.5
-      parent: 2
-  - uid: 3141
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-35.5
-      parent: 2
-  - uid: 3142
-    components:
-    - type: Transform
-      pos: 29.5,-16.5
-      parent: 2
-  - uid: 3163
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,-24.5
-      parent: 2
-  - uid: 3173
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-14.5
-      parent: 2
-  - uid: 3176
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.5,-19.5
-      parent: 2
-  - uid: 3268
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-19.5
-      parent: 2
-  - uid: 3657
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-54.5
-      parent: 2
-  - uid: 3955
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,-12.5
-      parent: 2
-  - uid: 3991
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-23.5
-      parent: 2
-  - uid: 4189
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -27.5,-13.5
-      parent: 2
-  - uid: 4314
-    components:
-    - type: Transform
-      pos: -30.5,-7.5
-      parent: 2
-  - uid: 4315
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -38.5,-8.5
-      parent: 2
-  - uid: 4316
-    components:
-    - type: Transform
-      pos: -38.5,-1.5
-      parent: 2
-  - uid: 4409
-    components:
-    - type: Transform
-      pos: -34.5,-16.5
-      parent: 2
-  - uid: 4428
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -54.5,-4.5
-      parent: 2
-  - uid: 4599
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -61.5,-2.5
-      parent: 2
-  - uid: 4600
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -61.5,-6.5
-      parent: 2
-  - uid: 4601
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -61.5,-10.5
-      parent: 2
-  - uid: 4602
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -61.5,-14.5
-      parent: 2
-  - uid: 4603
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -61.5,-18.5
-      parent: 2
-  - uid: 4604
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -31.5,10.5
-      parent: 2
-  - uid: 4687
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -55.5,-18.5
-      parent: 2
-  - uid: 4688
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -58.5,-25.5
-      parent: 2
-  - uid: 4913
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,4.5
-      parent: 2
-  - uid: 4914
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,4.5
-      parent: 2
-  - uid: 4968
-    components:
-    - type: Transform
-      pos: -22.5,0.5
-      parent: 2
-  - uid: 5045
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,6.5
-      parent: 2
-  - uid: 5046
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,4.5
-      parent: 2
-  - uid: 5309
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-39.5
-      parent: 2
-  - uid: 5310
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -20.5,-35.5
-      parent: 2
-  - uid: 6785
-    components:
-    - type: Transform
-      pos: -29.5,0.5
-      parent: 2
-  - uid: 6786
-    components:
-    - type: Transform
-      pos: -15.5,2.5
-      parent: 2
-  - uid: 6788
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-33.5
-      parent: 2
-  - uid: 6789
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-32.5
-      parent: 2
-  - uid: 6791
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,-31.5
-      parent: 2
-  - uid: 6792
-    components:
-    - type: Transform
-      pos: -11.5,-29.5
-      parent: 2
-  - uid: 6793
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-31.5
-      parent: 2
-  - uid: 6794
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,-31.5
-      parent: 2
-  - uid: 6795
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.5,-36.5
-      parent: 2
-  - uid: 6796
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 18.5,-36.5
-      parent: 2
-  - uid: 6797
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,-25.5
-      parent: 2
-  - uid: 6803
-    components:
-    - type: Transform
-      pos: -51.5,-1.5
-      parent: 2
-  - uid: 6804
-    components:
-    - type: Transform
-      pos: -45.5,-1.5
-      parent: 2
-  - uid: 6805
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,-42.5
-      parent: 2
-  - uid: 6806
-    components:
-    - type: Transform
-      pos: -36.5,-37.5
-      parent: 2
-  - uid: 6812
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -48.5,-44.5
-      parent: 2
-  - uid: 6816
-    components:
-    - type: Transform
-      pos: 8.5,9.5
-      parent: 2
-  - uid: 6817
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 2
-  - uid: 6818
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -29.5,4.5
-      parent: 2
-  - uid: 6819
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,4.5
-      parent: 2
-  - uid: 6825
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -53.5,10.5
-      parent: 2
-  - uid: 6845
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-14.5
-      parent: 2
-  - uid: 6846
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-9.5
-      parent: 2
-  - uid: 7351
-    components:
-    - type: Transform
-      pos: -14.5,-33.5
-      parent: 2
-  - uid: 7828
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -56.5,-37.5
-      parent: 2
-  - uid: 11679
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-45.5
       parent: 2
 - proto: PoweredlightEmpty
   entities:

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 12/02/2025 06:40:15
-  entityCount: 14291
+  time: 12/03/2025 05:33:24
+  entityCount: 14342
 maps:
 - 3
 grids:
@@ -3819,16 +3819,6 @@ entities:
       parent: 2
 - proto: AirlockCargoGlassLocked
   entities:
-  - uid: 1481
-    components:
-    - type: Transform
-      pos: 0.5,-35.5
-      parent: 2
-  - uid: 1483
-    components:
-    - type: Transform
-      pos: 1.5,-35.5
-      parent: 2
   - uid: 1531
     components:
     - type: Transform
@@ -3839,8 +3829,18 @@ entities:
     - type: Transform
       pos: 0.5,-40.5
       parent: 2
-    - type: AccessReader
-      accessListsOriginal: []
+- proto: AirlockCargoLocked
+  entities:
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 1.5,-35.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 0.5,-35.5
+      parent: 2
 - proto: AirlockChemistryGlassLocked
   entities:
   - uid: 1021
@@ -4331,15 +4331,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: -26.5,1.5
       parent: 2
-- proto: AirlockHydroGlassLocked
+- proto: AirlockHydroponicsLocked
   entities:
   - uid: 319
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 2
-- proto: AirlockHydroponicsLocked
-  entities:
   - uid: 3688
     components:
     - type: Transform
@@ -4353,13 +4351,6 @@ entities:
     - type: Transform
       pos: -13.5,-32.5
       parent: 2
-- proto: AirlockKitchenGlassLocked
-  entities:
-  - uid: 85
-    components:
-    - type: Transform
-      pos: -2.5,-16.5
-      parent: 2
 - proto: AirlockKitchenLocked
   entities:
   - uid: 167
@@ -4367,6 +4358,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-16.5
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
       parent: 2
 - proto: AirlockMaintBarLocked
   entities:
@@ -5311,6 +5307,16 @@ entities:
       - - Engineering
     - type: Fixtures
       fixtures: {}
+  - uid: 3144
+    components:
+    - type: MetaData
+      name: Bathrooms APC
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -31.5,8.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 3276
     components:
     - type: MetaData
@@ -5449,19 +5455,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -46.5,-8.5
       parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 4598
-    components:
-    - type: MetaData
-      name: Bathroom APC
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -30.5,11.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal:
-      - - Engineering
     - type: Fixtures
       fixtures: {}
   - uid: 4718
@@ -6316,27 +6309,6 @@ entities:
       parent: 2
 - proto: BlastDoorOpen
   entities:
-  - uid: 406
-    components:
-    - type: Transform
-      pos: 5.5,-2.5
-      parent: 2
-  - uid: 740
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-19.5
-      parent: 2
-  - uid: 999
-    components:
-    - type: Transform
-      pos: 10.5,-2.5
-      parent: 2
-  - uid: 1083
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 2
   - uid: 3718
     components:
     - type: Transform
@@ -6393,25 +6365,6 @@ entities:
     components:
     - type: Transform
       pos: -24.5,-6.5
-      parent: 2
-  - uid: 5085
-    components:
-    - type: Transform
-      pos: -27.5,-28.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal: []
-  - uid: 5086
-    components:
-    - type: Transform
-      pos: -28.5,-28.5
-      parent: 2
-    - type: AccessReader
-      accessListsOriginal: []
-  - uid: 5087
-    components:
-    - type: Transform
-      pos: -29.5,-28.5
       parent: 2
   - uid: 14277
     components:
@@ -6705,6 +6658,30 @@ entities:
     - type: Transform
       pos: -26.5,-16.5
       parent: 2
+  - uid: 6911
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,4.5
+      parent: 2
+  - uid: 9322
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-20.5
+      parent: 2
+  - uid: 14328
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -38.5,-39.5
+      parent: 2
+  - uid: 14339
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-27.5
+      parent: 2
 - proto: ButtonFrameExit
   entities:
   - uid: 448
@@ -6712,6 +6689,13 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,1.5
+      parent: 2
+    - type: WallMount
+      arc: 6.283185307179586 rad
+  - uid: 6780
+    components:
+    - type: Transform
+      pos: 2.5,-20.5
       parent: 2
 - proto: ButtonFrameGrey
   entities:
@@ -6736,6 +6720,23 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -14.5,-6.5
+      parent: 2
+  - uid: 5068
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-37.5
+      parent: 2
+  - uid: 6855
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-20.5
+      parent: 2
+  - uid: 14316
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
       parent: 2
 - proto: C4
   entities:
@@ -7971,6 +7972,21 @@ entities:
     - type: Transform
       pos: 16.5,9.5
       parent: 2
+  - uid: 1481
+    components:
+    - type: Transform
+      pos: -36.5,10.5
+      parent: 2
+  - uid: 1483
+    components:
+    - type: Transform
+      pos: -31.5,11.5
+      parent: 2
+  - uid: 1542
+    components:
+    - type: Transform
+      pos: -31.5,8.5
+      parent: 2
   - uid: 1595
     components:
     - type: Transform
@@ -8651,6 +8667,11 @@ entities:
     - type: Transform
       pos: 0.5,-58.5
       parent: 2
+  - uid: 2580
+    components:
+    - type: Transform
+      pos: -31.5,9.5
+      parent: 2
   - uid: 2590
     components:
     - type: Transform
@@ -8725,11 +8746,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,-51.5
-      parent: 2
-  - uid: 3144
-    components:
-    - type: Transform
-      pos: -31.5,11.5
       parent: 2
   - uid: 3228
     components:
@@ -9075,11 +9091,6 @@ entities:
     components:
     - type: Transform
       pos: -31.5,10.5
-      parent: 2
-  - uid: 3956
-    components:
-    - type: Transform
-      pos: -30.5,11.5
       parent: 2
   - uid: 4094
     components:
@@ -10535,6 +10546,41 @@ entities:
     components:
     - type: Transform
       pos: -16.5,-21.5
+      parent: 2
+  - uid: 6815
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 2
+  - uid: 6820
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 2
+  - uid: 6822
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 6823
+    components:
+    - type: Transform
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 6824
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 6841
+    components:
+    - type: Transform
+      pos: 7.5,-21.5
+      parent: 2
+  - uid: 6844
+    components:
+    - type: Transform
+      pos: 8.5,-21.5
       parent: 2
   - uid: 6902
     components:
@@ -21024,11 +21070,6 @@ entities:
     - type: Transform
       pos: 3.5,6.5
       parent: 2
-  - uid: 1273
-    components:
-    - type: Transform
-      pos: -30.5,11.5
-      parent: 2
   - uid: 1332
     components:
     - type: Transform
@@ -21038,6 +21079,11 @@ entities:
     components:
     - type: Transform
       pos: -27.5,-27.5
+      parent: 2
+  - uid: 1538
+    components:
+    - type: Transform
+      pos: -31.5,8.5
       parent: 2
   - uid: 1630
     components:
@@ -24184,16 +24230,6 @@ entities:
     - type: Transform
       pos: 0.5,-54.5
       parent: 2
-  - uid: 6779
-    components:
-    - type: Transform
-      pos: -31.5,11.5
-      parent: 2
-  - uid: 6780
-    components:
-    - type: Transform
-      pos: -32.5,11.5
-      parent: 2
   - uid: 6787
     components:
     - type: Transform
@@ -24823,11 +24859,6 @@ entities:
     components:
     - type: Transform
       pos: -32.5,9.5
-      parent: 2
-  - uid: 7186
-    components:
-    - type: Transform
-      pos: -32.5,10.5
       parent: 2
   - uid: 7189
     components:
@@ -32214,23 +32245,25 @@ entities:
     - type: Transform
       pos: 14.5,11.5
       parent: 2
-- proto: CurtainsRedOpen
+- proto: CurtainsRed
   entities:
-  - uid: 5067
-    components:
-    - type: Transform
-      pos: -26.5,-32.5
-      parent: 2
-  - uid: 5068
-    components:
-    - type: Transform
-      pos: -27.5,-32.5
-      parent: 2
-  - uid: 5077
+  - uid: 3956
     components:
     - type: Transform
       pos: -28.5,-32.5
       parent: 2
+  - uid: 4598
+    components:
+    - type: Transform
+      pos: -27.5,-32.5
+      parent: 2
+  - uid: 4975
+    components:
+    - type: Transform
+      pos: -26.5,-32.5
+      parent: 2
+- proto: CurtainsRedOpen
+  entities:
   - uid: 7356
     components:
     - type: Transform
@@ -36451,6 +36484,40 @@ entities:
     - type: Transform
       pos: -43.5,-17.5
       parent: 2
+- proto: ESApcNetSwitchLight
+  entities:
+  - uid: 6814
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-10.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 6817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 6821
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-17.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 6825
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-21.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: ESBaseComputerTerminalCryptoNuke
   entities:
   - uid: 3834
@@ -39747,6 +39814,26 @@ entities:
     components:
     - type: Transform
       pos: 0.5,2.5
+      parent: 2
+- proto: ESPoweredSmallLightMaintenance
+  entities:
+  - uid: 14322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -16.5,-4.5
+      parent: 2
+  - uid: 14341
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -42.5,-49.5
+      parent: 2
+  - uid: 14342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -35.5,-49.5
       parent: 2
 - proto: ESRandomPosterAny
   entities:
@@ -58775,12 +58862,6 @@ entities:
     - type: Transform
       pos: 10.5,-26.5
       parent: 2
-  - uid: 518
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,-27.5
-      parent: 2
   - uid: 523
     components:
     - type: Transform
@@ -59991,6 +60072,11 @@ entities:
     components:
     - type: Transform
       pos: -28.5,1.5
+      parent: 2
+  - uid: 4980
+    components:
+    - type: Transform
+      pos: -26.5,-27.5
       parent: 2
   - uid: 5006
     components:
@@ -62308,15 +62394,15 @@ entities:
     - type: Transform
       pos: -10.5,-15.5
       parent: 2
-  - uid: 318
-    components:
-    - type: Transform
-      pos: -3.5,-20.5
-      parent: 2
   - uid: 3704
     components:
     - type: Transform
       pos: -21.5,-10.5
+      parent: 2
+  - uid: 4981
+    components:
+    - type: Transform
+      pos: -3.5,-20.5
       parent: 2
   - uid: 8822
     components:
@@ -62470,10 +62556,10 @@ entities:
     - type: Transform
       pos: 27.454319,-16.162394
       parent: 2
-  - uid: 4975
+  - uid: 4982
     components:
     - type: Transform
-      pos: -27.532053,4.8906326
+      pos: -27.061106,4.794282
       parent: 2
   - uid: 7344
     components:
@@ -63491,15 +63577,15 @@ entities:
     - type: Transform
       pos: 11.5,5.5
       parent: 2
-  - uid: 1538
-    components:
-    - type: Transform
-      pos: -4.5,-37.5
-      parent: 2
   - uid: 3217
     components:
     - type: Transform
       pos: -29.5,-24.5
+      parent: 2
+  - uid: 5067
+    components:
+    - type: Transform
+      pos: -4.5090218,-38.769787
       parent: 2
   - uid: 12284
     components:
@@ -63549,10 +63635,10 @@ entities:
     - type: Transform
       pos: -23.5,3.5
       parent: 2
-  - uid: 7353
+  - uid: 4984
     components:
     - type: Transform
-      pos: -38.5,-39.5
+      pos: -38.664032,-40.306698
       parent: 2
   - uid: 7991
     components:
@@ -63630,10 +63716,10 @@ entities:
       parent: 2
 - proto: Pen
   entities:
-  - uid: 1542
+  - uid: 4983
     components:
     - type: Transform
-      pos: -4.4765134,-37.09762
+      pos: -4.5090218,-38.582287
       parent: 2
   - uid: 8918
     components:
@@ -64711,12 +64797,6 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-8.5
-      parent: 2
-  - uid: 898
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -16.5,-4.5
       parent: 2
   - uid: 899
     components:
@@ -66602,12 +66682,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -26.5,-25.5
       parent: 2
-  - uid: 2580
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,-27.5
-      parent: 2
   - uid: 2883
     components:
     - type: Transform
@@ -67057,6 +67131,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -39.5,-48.5
+      parent: 2
+  - uid: 5077
+    components:
+    - type: Transform
+      pos: -26.5,-27.5
       parent: 2
   - uid: 5219
     components:
@@ -67911,6 +67990,13 @@ entities:
       parent: 2
 - proto: ShuttersNormal
   entities:
+  - uid: 587
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
   - uid: 589
     components:
     - type: Transform
@@ -67923,6 +68009,40 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-22.5
       parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      pos: 1.5,-19.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 898
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 999
+    components:
+    - type: Transform
+      pos: -29.5,-28.5
+      parent: 2
+  - uid: 1083
+    components:
+    - type: Transform
+      pos: -28.5,-28.5
+      parent: 2
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: -27.5,-28.5
+      parent: 2
   - uid: 1686
     components:
     - type: Transform
@@ -67934,6 +68054,140 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-43.5
+      parent: 2
+  - uid: 5085
+    components:
+    - type: Transform
+      pos: -28.5,1.5
+      parent: 2
+  - uid: 5086
+    components:
+    - type: Transform
+      pos: -27.5,1.5
+      parent: 2
+  - uid: 5087
+    components:
+    - type: Transform
+      pos: -24.5,1.5
+      parent: 2
+  - uid: 6779
+    components:
+    - type: Transform
+      pos: -25.5,1.5
+      parent: 2
+  - uid: 6991
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 7186
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 7187
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 7188
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 7209
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 7210
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 7353
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 8008
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 2
+  - uid: 14313
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-19.5
+      parent: 2
+  - uid: 14314
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-18.5
+      parent: 2
+  - uid: 14315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-17.5
+      parent: 2
+  - uid: 14318
+    components:
+    - type: Transform
+      pos: -2.5,-20.5
+      parent: 2
+  - uid: 14319
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 2
+  - uid: 14320
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 2
+  - uid: 14321
+    components:
+    - type: Transform
+      pos: -2.5,-23.5
+      parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 14324
+    components:
+    - type: Transform
+      pos: -3.5,-35.5
+      parent: 2
+  - uid: 14325
+    components:
+    - type: Transform
+      pos: -2.5,-35.5
+      parent: 2
+  - uid: 14326
+    components:
+    - type: Transform
+      pos: -1.5,-35.5
+      parent: 2
+  - uid: 14327
+    components:
+    - type: Transform
+      pos: -0.5,-35.5
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
@@ -68000,25 +68254,37 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -10.5,-3.5
       parent: 2
-  - uid: 4980
+  - uid: 14331
     components:
     - type: Transform
-      pos: -28.5,1.5
+      pos: -38.5,-41.5
       parent: 2
-  - uid: 4981
+  - uid: 14332
     components:
     - type: Transform
-      pos: -27.5,1.5
+      pos: -37.5,-41.5
       parent: 2
-  - uid: 4982
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 14333
     components:
     - type: Transform
-      pos: -25.5,1.5
+      pos: -36.5,-41.5
       parent: 2
-  - uid: 4983
+  - uid: 14334
     components:
     - type: Transform
-      pos: -24.5,1.5
+      pos: -35.5,-41.5
+      parent: 2
+  - uid: 14335
+    components:
+    - type: Transform
+      pos: -34.5,-39.5
+      parent: 2
+  - uid: 14336
+    components:
+    - type: Transform
+      pos: -34.5,-40.5
       parent: 2
 - proto: ShuttersWindowOpen
   entities:
@@ -68087,6 +68353,38 @@ entities:
       fixtures: {}
 - proto: SignalSwitch
   entities:
+  - uid: 518
+    components:
+    - type: MetaData
+      name: window shutters
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -27.5,4.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        5086:
+        - - Off
+          - Close
+        - - On
+          - Open
+        5085:
+        - - Off
+          - Close
+        - - On
+          - Open
+        6779:
+        - - Off
+          - Close
+        - - On
+          - Open
+        5087:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
   - uid: 3087
     components:
     - type: MetaData
@@ -68135,6 +68433,121 @@ entities:
           - Open
         - - Off
           - Close
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14323
+    components:
+    - type: MetaData
+      name: desk shutters
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-37.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        14327:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14325:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14326:
+        - - On
+          - Open
+        - - Off
+          - Close
+        14324:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -38.5,-39.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        14335:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14336:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14334:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14333:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14332:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14331:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14337
+    components:
+    - type: MetaData
+      name: robotics bay shutters
+    - type: Transform
+      pos: 2.5,-20.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        589:
+        - - On
+          - Open
+        - - Off
+          - Close
+        590:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14338
+    components:
+    - type: MetaData
+      name: desk shutters
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-20.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        740:
+        - - Off
+          - Close
+        - - On
+          - Open
+        8008:
+        - - Off
+          - Close
+        - - On
+          - Open
     - type: Fixtures
       fixtures: {}
 - proto: SignalSwitchDirectional
@@ -68221,13 +68634,23 @@ entities:
   - uid: 445
     components:
     - type: MetaData
-      name: desk blast door
+      name: desk shutters
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        406:
+        7186:
+        - - Off
+          - Close
+        - - On
+          - Open
+        6991:
+        - - On
+          - Open
+        - - Off
+          - Close
+        587:
         - - On
           - Open
         - - Off
@@ -68263,42 +68686,6 @@ entities:
         - - On
           - Open
         537:
-        - - On
-          - Open
-        - - Off
-          - Close
-    - type: Fixtures
-      fixtures: {}
-  - uid: 587
-    components:
-    - type: MetaData
-      name: robotics bay shutters
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-20.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        740:
-        - - On
-          - Open
-        - - Off
-          - Close
-    - type: Fixtures
-      fixtures: {}
-  - uid: 741
-    components:
-    - type: Transform
-      pos: 2.5,-20.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        589:
-        - - On
-          - Open
-        - - Off
-          - Close
-        590:
         - - On
           - Open
         - - Off
@@ -68350,14 +68737,24 @@ entities:
   - uid: 1003
     components:
     - type: MetaData
-      name: desk blast door
+      name: desk shutters
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 8.5,-5.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        999:
+        741:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7187:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7188:
         - - On
           - Open
         - - Off
@@ -68367,14 +68764,29 @@ entities:
   - uid: 1084
     components:
     - type: MetaData
-      name: desk blast door
+      name: desk shutters
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,6.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        1083:
+        898:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7209:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7210:
+        - - On
+          - Open
+        - - Off
+          - Close
+        7353:
         - - On
           - Open
         - - Off
@@ -68472,6 +68884,8 @@ entities:
       fixtures: {}
   - uid: 3729
     components:
+    - type: MetaData
+      name: permabrig lockdown
     - type: Transform
       pos: -26.5,-16.5
       parent: 2
@@ -68629,36 +69043,6 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 4984
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -27.5,4.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        4980:
-        - - On
-          - Open
-        - - Off
-          - Close
-        4981:
-        - - On
-          - Open
-        - - Off
-          - Close
-        4982:
-        - - On
-          - Open
-        - - Off
-          - Close
-        4983:
-        - - On
-          - Open
-        - - Off
-          - Close
-    - type: Fixtures
-      fixtures: {}
   - uid: 11879
     components:
     - type: Transform
@@ -68672,6 +69056,89 @@ entities:
           - Open
         - - Off
           - Close
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14312
+    components:
+    - type: MetaData
+      name: desk shutters
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-20.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        14313:
+        - - On
+          - Open
+        - - Off
+          - Close
+        14314:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14315:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14317
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        14318:
+        - - On
+          - Open
+        - - Off
+          - Close
+        14320:
+        - - On
+          - Open
+        - - Off
+          - Close
+        14319:
+        - - Off
+          - Close
+        - - On
+          - Open
+        14321:
+        - - Off
+          - Close
+        - - On
+          - Open
+    - type: Fixtures
+      fixtures: {}
+  - uid: 14340
+    components:
+    - type: MetaData
+      name: window shutters
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -26.5,-27.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        1273:
+        - - On
+          - Open
+        - - Off
+          - Close
+        1083:
+        - - Off
+          - Close
+        - - On
+          - Open
+        999:
+        - - Off
+          - Close
+        - - On
+          - Open
     - type: Fixtures
       fixtures: {}
 - proto: SignAnomaly
@@ -85329,6 +85796,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,17.5
+      parent: 2
+  - uid: 14329
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -38.5,-39.5
       parent: 2
 - proto: Welder
   entities:

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 267.3.0
   forkId: ""
   forkVersion: ""
-  time: 12/03/2025 06:13:53
-  entityCount: 14366
+  time: 12/03/2025 06:45:59
+  entityCount: 14357
 maps:
 - 3
 grids:
@@ -10513,21 +10513,6 @@ entities:
     - type: Transform
       pos: -16.5,-21.5
       parent: 2
-  - uid: 6815
-    components:
-    - type: Transform
-      pos: 6.5,-10.5
-      parent: 2
-  - uid: 6820
-    components:
-    - type: Transform
-      pos: 7.5,-14.5
-      parent: 2
-  - uid: 6822
-    components:
-    - type: Transform
-      pos: 8.5,-17.5
-      parent: 2
   - uid: 6823
     components:
     - type: Transform
@@ -10537,16 +10522,6 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-16.5
-      parent: 2
-  - uid: 6841
-    components:
-    - type: Transform
-      pos: 7.5,-21.5
-      parent: 2
-  - uid: 6844
-    components:
-    - type: Transform
-      pos: 8.5,-21.5
       parent: 2
   - uid: 6902
     components:
@@ -36450,40 +36425,6 @@ entities:
     - type: Transform
       pos: -43.5,-17.5
       parent: 2
-- proto: ESApcNetSwitchLight
-  entities:
-  - uid: 6814
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-10.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 6817
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,-14.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 6821
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-17.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 6825
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-21.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: ESBaseComputerTerminalCryptoNuke
   entities:
   - uid: 3834

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -75,7 +75,9 @@
       - state: lighttube
   - type: StorageFill
     contents:
-      - id: LightTube
+      # ES START
+      - id: ESPoweredLightDepartment
+      # ES END
         amount: 12
 
 - type: entity
@@ -89,7 +91,9 @@
       - state: lightmixed
   - type: StorageFill
     contents:
-      - id: LightTube
+      # ES START
+      - id: ESPoweredLightDepartment
+      # ES END
         amount: 6
       - id: LightBulb
         amount: 6

--- a/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/general.yml
@@ -76,7 +76,7 @@
   - type: StorageFill
     contents:
       # ES START
-      - id: ESPoweredLightDepartment
+      - id: ESLightTubeDepartment
       # ES END
         amount: 12
 
@@ -92,7 +92,7 @@
   - type: StorageFill
     contents:
       # ES START
-      - id: ESPoweredLightDepartment
+      - id: ESLightTubeDepartment
       # ES END
         amount: 6
       - id: LightBulb

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -12,7 +12,7 @@
   - type: LightReplacer
     contents:
     # ES START
-    - id: ESPoweredLightDepartment
+    - id: ESLightTubeDepartment
     # ES END
       amount: 8
     - id: LightBulb
@@ -31,6 +31,6 @@
   - type: LightReplacer
     contents:
     # ES START
-    - id: ESPoweredLightDepartment
+    - id: ESLightTubeDepartment
     # ES END
       amount: 0

--- a/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/light_replacer.yml
@@ -11,7 +11,9 @@
     sprite: Objects/Specific/Janitorial/light_replacer.rsi
   - type: LightReplacer
     contents:
-    - id: LightTube
+    # ES START
+    - id: ESPoweredLightDepartment
+    # ES END
       amount: 8
     - id: LightBulb
       amount: 5
@@ -28,5 +30,7 @@
   components:
   - type: LightReplacer
     contents:
-    - id: LightTube
+    # ES START
+    - id: ESPoweredLightDepartment
+    # ES END
       amount: 0

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -419,6 +419,11 @@
       types:
         Heat: 1
     popupText: powered-light-component-burn-hand
+  # ES START
+  # no responding to light switches
+  - type: DeviceNetwork
+    receiveFrequencyId: null
+  # ES END
 
 - type: entity
   id: PoweredWarmSmallLight

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -169,17 +169,6 @@
     graph: LightSwitchDirectionalGraph
     node: LightSwitchDirectionalNode
 
-# ES START
-- type: entity
-  parent: ApcNetSwitchDirectional
-  id: ESApcNetSwitchLight
-  name: light switch
-  suffix: directional
-  components:
-  - type: WallMount
-    arc: 175
-# ES END
-
 # lockable buttons
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -452,9 +452,7 @@
   components:
   - type: Clickable
   - type: WallMount
-    # ES START
-    arc: 180
-    # ES END
+    arc: 360
   - type: Physics
     canCollide: false
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -452,7 +452,9 @@
   components:
   - type: Clickable
   - type: WallMount
-    arc: 360
+    # ES START
+    arc: 180
+    # ES END
   - type: Physics
     canCollide: false
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
@@ -30,7 +30,9 @@
   suffix: Wall
   components:
     - type: WallMount
-      arc: 360
+      # ES START
+      arc: 180
+      # ES END
     - type: Appearance
     - type: StationMap
     - type: Sprite

--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -63,7 +63,7 @@
     - id: FloorTileItemSteel
     - id: CheapLighter
     - id: TreasureCoinIron
-    - id: LightTube
+    - id: ESPoweredLightDepartment
     - id: LightBulb
     - id: Matchstick
     - id: DrinkGlass

--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -63,7 +63,7 @@
     - id: FloorTileItemSteel
     - id: CheapLighter
     - id: TreasureCoinIron
-    - id: ESPoweredLightDepartment
+    - id: ESLightTubeDepartment
     - id: LightBulb
     - id: Matchstick
     - id: DrinkGlass

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -13,7 +13,7 @@
   components:
   - type: PointLight
     color: "#ece2dd"
-    energy: 1.45
+    energy: 1.35
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeDepartment
 

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -9,11 +9,11 @@
   parent: Poweredlight
   name: light fixture
   description: Draws power and produces light when equipped with a light tube.
-  suffix: ES
+  suffix: ES, Departments
   components:
   - type: PointLight
     color: "#ece2dd"
-    energy: 1.35
+    energy: 1.38
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeDepartment
 
@@ -21,19 +21,23 @@
 - type: entity
   id: ESPoweredLightHallway
   parent: Poweredlight
-  name: hallway light fixture
-  description: Draws power and produces light when equipped with a light tube. Dimmer than room lighting and unresponsive to light switches.
-  suffix: ES
+  name: light fixture
+  description: Draws power and produces light when equipped with a light tube. Unresponsive to light switches.
+  suffix: ES, Hallway
   components:
   - type: PointLight
     color: "#929291"
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeHallway
+  - type: DeviceNetwork
+    receiveFrequencyId: null
 
 # Small light fixtures used in maint or elsewhere (just so they're unresponsive to light switches)
-#- type: entity
-#  id: ESPoweredSmallLightMaintenance
-#  parent: PoweredSmallLight
-#  components:
-#  - type: PoweredLight
-#    hasLampOnSpawn: ESLightTubeHallway
+# Separate from regular ones, which get used in rooms normally and should still turn on/off
+- type: entity
+  id: ESPoweredSmallLightMaintenance
+  parent: PoweredSmallLight
+  suffix: Maintenance
+  components:
+  - type: DeviceNetwork
+    receiveFrequencyId: null

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -1,0 +1,39 @@
+# Light fixtures used in ES maps -- separate from light tubes, which actually control the light values used
+# (although all fixtures here have pointlights set to the same value as their default tubes, for visualizing lighting
+# during the mapping process)
+
+# Used in departments. Brighter light than hallways for contrast, and can be controlled by lightswitches
+# Off by default. Intended flow is that lightswitches are off, then ppl come in and turn em on for vibes
+- type: entity
+  id: ESPoweredLightDepartment
+  parent: Poweredlight
+  name: light fixture
+  description: Draws power and produces light when equipped with a light tube.
+  suffix: ES
+  components:
+  - type: PointLight
+    color: "#ece2dd"
+    energy: 1.45
+  - type: PoweredLight
+    hasLampOnSpawn: ESLightTubeDepartment
+
+# Used in hallways. Dimmer light, to contrast with department lights (below)
+- type: entity
+  id: ESPoweredLightHallway
+  parent: Poweredlight
+  name: hallway light fixture
+  description: Draws power and produces light when equipped with a light tube. Dimmer than room lighting and unresponsive to light switches.
+  suffix: ES
+  components:
+  - type: PointLight
+    color: "#929291"
+  - type: PoweredLight
+    hasLampOnSpawn: ESLightTubeHallway
+
+# Small light fixtures used in maint or elsewhere (just so they're unresponsive to light switches)
+#- type: entity
+#  id: ESPoweredSmallLightMaintenance
+#  parent: PoweredSmallLight
+#  components:
+#  - type: PoweredLight
+#    hasLampOnSpawn: ESLightTubeHallway

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -13,7 +13,7 @@
   components:
   - type: PointLight
     color: "#ece2dd"
-    energy: 1.38
+    energy: 1.45
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeDepartment
 

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -1,0 +1,21 @@
+# See light_fixtures.yml for what these are for
+- type: entity
+  id: ESLightTubeDepartment
+  parent: LightTube
+  suffix: ES
+  components:
+  - type: LightBulb
+    color: "#f5eae5"
+    lightEnergy: 1.45
+    lightSoftness: 2
+
+- type: entity
+  id: ESLightTubeHallway
+  parent: LightTube
+  name: hallway fluorescent light tube
+  description: A light fixture. Dimmer than regular department lights.
+  suffix: ES
+  components:
+  - type: LightBulb
+    color: "#929291"
+    lightSoftness: 2

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -5,8 +5,8 @@
   suffix: ES
   components:
   - type: LightBulb
-    color: "#f5eae5"
-    lightEnergy: 1.45
+    color: "#ece2dd"
+    lightEnergy: 1.35
     lightSoftness: 2
 
 - type: entity

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -6,7 +6,7 @@
   components:
   - type: LightBulb
     color: "#ece2dd"
-    lightEnergy: 1.35
+    lightEnergy: 1.45
     lightSoftness: 2
 
 - type: entity

--- a/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/button_frames.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/button_frames.yml
@@ -1,0 +1,40 @@
+# Directional variants of button frames
+- type: entity
+  id: ESButtonFrameGreyDirectional
+  parent: ButtonFrameGrey
+  suffix: grey, directional
+  components:
+  - type: WallMount
+    arc: 180
+
+- type: entity
+  id: ESButtonFrameCautionDirectional
+  parent: ButtonFrameCaution
+  suffix: caution, directional
+  components:
+  - type: WallMount
+    arc: 180
+
+- type: entity
+  id: ESButtonFrameCautionSecurityDirectional
+  parent: ButtonFrameCautionSecurity
+  suffix: caution, directional
+  components:
+  - type: WallMount
+    arc: 180
+
+- type: entity
+  id: ESButtonFrameExitDirectional
+  parent: ButtonFrameExit
+  suffix: exit, directional
+  components:
+  - type: WallMount
+    arc: 180
+
+- type: entity
+  id: ESButtonFrameJanitorDirectional
+  parent: ButtonFrameJanitor
+  suffix: janitor, directional
+  components:
+  - type: WallMount
+    arc: 180

--- a/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -8,7 +8,7 @@
   - type: WallMount
     arc: 180
   - type: PointLight
-    radius: 1.2
+    radius: 1.1
     energy: 3
     color: "#fc9928"
     castShadows: false

--- a/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -3,12 +3,12 @@
   parent: ApcNetSwitchDirectional
   id: ESApcNetSwitchLight
   name: light switch
-  suffix: directional
+  suffix: ES, directional
   components:
   - type: WallMount
     arc: 180
   - type: PointLight
-    radius: 2.2
+    radius: 1.2
     energy: 3
     color: "#fc9928"
     castShadows: false

--- a/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/switch.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Wallmounts/Switches/switch.yml
@@ -1,0 +1,19 @@
+# TODO MIRROR sprite and visualizer
+- type: entity
+  parent: ApcNetSwitchDirectional
+  id: ESApcNetSwitchLight
+  name: light switch
+  suffix: directional
+  components:
+  - type: WallMount
+    arc: 180
+  - type: PointLight
+    radius: 2.2
+    energy: 3
+    color: "#fc9928"
+    castShadows: false
+    netsync: false
+    mask: /Textures/Effects/LightMasks/cone.png
+    falloff: 20
+    curveFactor: 1.0
+    autoRot: true

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -178,6 +178,10 @@ RandomPosterLegit: ESRandomPosterLegit
 RandomPosterAny: ESRandomPosterAny
 RandomPosterContraband: ESRandomPosterContraband
 
+# 2025-12-01
+# More lighting stuff
+LightTube: ESLightTubeDepartment
+Poweredlight: ESPoweredLightDepartment
 
 # ES END
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

okay this is a lot of stuff in one and it doesnt include the main thing i wanted to do (resprite and map lightswitches everywhere) but here are the changes and why

**1)** lighting pass again. sorry. i really like how it looks this time for actual though and i dont think ill majorly change it again. summary is as follows
  **1.1)** general station lighting (fluorescents) has been split into two types. department lights (brighter, used in most Rooms) and hallway lights (dimmer, unresponsive to lightswitches). this is because i think it looks really good and it makes for a nice contrast between transitory areas and more 'inviting' brighter areas. much more fun this way. in general it fulfills my desire to have moody lighting while still having high visibility in areas that should have high visibility (departments)
  **1.2)** lightblur factor has been increased overall, this makes softshadows look much better in my opinion (especially with clashing light colors like i have introduced) and in general makes stuff look a little better. i had to reduce the multiplier in contents lightbluroverlay (spacelight and stuff) because otherwise it was untuned
  **1.3)** there is also a new maintenance smalllight variant (the only diff is it cant be triggered by lightswitches which is an obvious problem otherwise) but its not mapped yet ill do it when i actually map and test light switches

**2)** lots of changes to visibility/sightlines on toast which are relevant for lightleak reasons, stealthy sightline reasons and arrival vibe reasons
  **2.1)** all situations where rooms had a shutter control that only shut over tables have been changed to shut over nearby windows, thus actually blocking sightlines into a room
  **2.2)** more rooms have been given shutters over their windows, and in general these shutters are closed roundstart (again for arrivals vibes reasons see arrivals doc). this includes: engineering foyer, sec (bottom area, main sec is still easy to see into), cargo foyer, botany, det room (closed the blinds), security checkpoint (open roundstart), chemistry, rnd/robotics. notably, not main sec area, the kitchen, the bar, or medbay
  **2.3)** most rooms which had glass airlocks, but windows into the room, have been changed to be solid airlocks, again so that sightlines into the room can be completely shut off if desired. this includes botany, cargo foyer, the kitchen, but -not- sec or medbay

**3)** adds directional signage to toast. it didnt have this and it bothered me so i added some. for the most part, they are assuming the player is coming from arrivals (as they all will be) and so is catered around navigating from arrivals to the other departments, not necessarily from other departments to anywhere else. i didnt want to bloat walls too much, but they should still be very useful.

and also a veritable motley of other random stuff
- fixes #136 by accident mostly
- station maps are now directional
- introduces directional buttonframes, remaps some buttons to be nondirectional which were directional by accident (ones on tables and stuff)
- adds a recharger into the sec checkpoint. i am open to removing this but this was a staple in ss13 maps and it made these rooms a lot more useful than they otherwise would be and its just kind of something i noticed didnt exist

ok now screenshots click for fullres
<img width="360" height="360" alt="2025-12-02_23 48 31" src="https://github.com/user-attachments/assets/2193a573-7bee-46f7-8557-6945e1d3c277" /> <img width="360" height="360" alt="2025-12-02_23 49 29" src="https://github.com/user-attachments/assets/762cea82-1565-4c1f-a361-7e47b7929132" />
<img width="360" height="360" alt="2025-12-02_23 49 48" src="https://github.com/user-attachments/assets/750a2018-e2a2-4c9d-881e-dffbba77c04b" /> <img width="360" height="360" alt="2025-12-02_23 50 24" src="https://github.com/user-attachments/assets/ce0d37d0-9628-4b6d-9dbd-620a71c5d8f2" />
<img width="360" height="360" alt="2025-12-02_23 51 05" src="https://github.com/user-attachments/assets/0113fab9-0a60-4621-87a1-6715b0ba30eb" /> <img width="360" height="360" alt="2025-12-02_23 51 49" src="https://github.com/user-attachments/assets/2c0a5d23-563c-4439-8e3e-e2db51af42f1" />
<img width="360" height="360" alt="2025-12-02_23 52 31" src="https://github.com/user-attachments/assets/e5bcde6c-3a4d-4d80-9f7e-8b2c8cde47dd" /> <img width="360" height="360" alt="2025-12-02_23 53 00" src="https://github.com/user-attachments/assets/caaab520-6368-4f09-b3a7-8b4b63f35391" />
