### PR TITLE
change interaction outline colors for no reason

### DIFF
--- a/Resources/Prototypes/Shaders/outline.yml
+++ b/Resources/Prototypes/Shaders/outline.yml
@@ -3,7 +3,7 @@
   kind: source
   path: "/Textures/Shaders/outline.swsl"
   params:
-    outline_color: "#FF000055"
+    outline_color: "#95002eaa"
     light_boost: 2
     light_gamma: 1.5
     light_whitepoint: 48
@@ -13,7 +13,7 @@
   kind: source
   path: "/Textures/Shaders/outline.swsl"
   params:
-    outline_color: "#00FF0055"
+    outline_color: "#c7e4eaaa"
     light_boost: 2
     light_gamma: 0.9
     light_whitepoint: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

by 'no reason' i mean 'no practical reason but just because its kind of nice to have things be slightly different for vibes purposes'

in range
<img width="193" height="187" alt="image" src="https://github.com/user-attachments/assets/2ee268e1-4c86-4a4a-95f1-f46eb87542a6" />

out of range
<img width="174" height="284" alt="image" src="https://github.com/user-attachments/assets/e026eb14-d8ad-4233-bc5d-127cf7deddbf" />
