### PR TITLE
Redo emag

### DIFF
--- a/Content.Shared/_ES/Emag/Components/ESEmagComponent.cs
+++ b/Content.Shared/_ES/Emag/Components/ESEmagComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Emag.Components;
+
+/// <summary>
+/// General device that applies emag effects to objects
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ESEmagSystem))]
+public sealed partial class ESEmagComponent : Component;

--- a/Content.Shared/_ES/Emag/ESEmagSystem.cs
+++ b/Content.Shared/_ES/Emag/ESEmagSystem.cs
@@ -1,0 +1,111 @@
+using Content.Shared._ES.Emag.Components;
+using Content.Shared._ES.Sparks;
+using Content.Shared.Access.Components;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Charges.Systems;
+using Content.Shared.Database;
+using Content.Shared.Doors.Components;
+using Content.Shared.Doors.Systems;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.Lock;
+using Content.Shared.Popups;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Emag;
+
+/// <summary>
+/// This handles <see cref="ESEmagComponent"/>
+/// </summary>
+public sealed class ESEmagSystem : EntitySystem
+{
+    [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
+    [Dependency] private readonly SharedChargesSystem _charges = default!;
+    [Dependency] private readonly SharedDoorSystem _door = default!;
+    [Dependency] private readonly LockSystem _lock = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ESSparksSystem _sparks = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+
+    private static readonly ProtoId<TagPrototype> EmagImmuneTag = "EmagImmune";
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESEmagComponent, AfterInteractEvent>(OnAfterInteract);
+
+        SubscribeLocalEvent<LockComponent, ESEmaggedEvent>(OnLockEmagged);
+        SubscribeLocalEvent<DoorComponent, ESEmaggedEvent>(OnDoorEmagged);
+    }
+
+    private void OnAfterInteract(Entity<ESEmagComponent> ent, ref AfterInteractEvent args)
+    {
+        if (!args.CanReach || args.Target is not { } target)
+            return;
+
+        args.Handled = TryEmag(ent.AsNullable(), target, args.User);
+    }
+
+    private void OnLockEmagged(Entity<LockComponent> ent, ref ESEmaggedEvent args)
+    {
+        // Emags don't count for things that are already locked.
+        if (!ent.Comp.Locked)
+            return;
+
+        // Only emag things like lockers, crates, etc.
+        if (!HasComp<AccessReaderComponent>(ent))
+            return;
+
+        _lock.Unlock(ent, args.User, ent);
+        args.Handled = true;
+    }
+
+    private void OnDoorEmagged(Entity<DoorComponent> ent, ref ESEmaggedEvent args)
+    {
+        if (!TryComp<AirlockComponent>(ent, out var airlock))
+            return;
+
+        args.Handled = _door.TryOpenAndBolt(ent, ent, airlock);
+    }
+
+    public bool TryEmag(Entity<ESEmagComponent?> used, EntityUid target, EntityUid? user = null)
+    {
+        if (!Resolve(used, ref used.Comp))
+            return false;
+
+        if (_tag.HasTag(target, EmagImmuneTag))
+            return false;
+
+        if (_charges.IsEmpty(used.Owner))
+        {
+            if (user != null)
+                _popup.PopupClient(Loc.GetString("emag-no-charges"), user.Value, user.Value);
+            return false;
+        }
+
+        var emaggedEvent = new ESEmaggedEvent(user);
+        RaiseLocalEvent(target, ref emaggedEvent);
+
+        if (!emaggedEvent.Handled)
+            return false;
+
+        _charges.TryUseCharge(used.Owner);
+        if (user.HasValue)
+        {
+            _popup.PopupPredicted(
+                Loc.GetString("emag-success", ("target", Identity.Entity(target, EntityManager))),
+                user.Value,
+                user,
+                PopupType.Medium);
+        }
+
+        _sparks.DoSparks(target, 3);
+
+        _adminLog.Add(LogType.Emag, LogImpact.High, $"{ToPrettyString(user):player} emagged {ToPrettyString(target):target}");
+        return true;
+    }
+}
+
+[ByRefEvent]
+public record struct ESEmaggedEvent(EntityUid? User, bool Handled = false);

--- a/Content.Shared/_ES/Emag/ESEmagSystem.cs
+++ b/Content.Shared/_ES/Emag/ESEmagSystem.cs
@@ -100,7 +100,7 @@ public sealed class ESEmagSystem : EntitySystem
                 PopupType.Medium);
         }
 
-        _sparks.DoSparks(target, 3);
+        _sparks.DoSparks(target);
 
         _adminLog.Add(LogType.Emag, LogImpact.High, $"{ToPrettyString(user):player} emagged {ToPrettyString(target):target}");
         return true;

--- a/Resources/Prototypes/_ES/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Tools/emag.yml
@@ -1,8 +1,9 @@
 - type: entity
-  parent: AccessBreaker # doesnt have the magic hacking properties of the classic "combined" emag...
+  parent: [BaseItem, BaseSyndicateContraband]
   id: ESEmag
-  name: cryptographic sequencer #...but uses the original sprites and name.
+  name: cryptographic sequencer
   description: The all-in-one hacking solution. Friend of any syndicate. The iconic EMAG.
+  suffix: ES, Limited
   components:
   - type: Sprite
     sprite: Objects/Tools/emag.rsi
@@ -10,3 +11,6 @@
   - type: Item
     sprite: Objects/Tools/emag.rsi
     storedRotation: -90
+  - type: ESEmag
+  - type: LimitedCharges
+  - type: AutoRecharge


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Closes #221 

redoes emag with new code and less obvious effects.

summative changes:
- Access-readers no longer get their access wiped when emagged
- Emagging now sends out sparks