### PR TITLE
Add sabotage effect to tcomms servers

### DIFF
--- a/Content.Server/Animals/Systems/ParrotMemorySystem.cs
+++ b/Content.Server/Animals/Systems/ParrotMemorySystem.cs
@@ -40,8 +40,10 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
 
         SubscribeLocalEvent<EraseEvent>(OnErase);
 
-        SubscribeLocalEvent<ParrotListenerComponent, MapInitEvent>(ListenerOnMapInit);
-
+        // ES START
+        // removed mapinit event (useless)
+        // + event for regular radio relay
+        SubscribeLocalEvent<ParrotListenerComponent, RadioReceiveEvent>(OnRadioReceive);
         SubscribeLocalEvent<ParrotListenerComponent, ListenEvent>(OnListen);
         SubscribeLocalEvent<ParrotListenerComponent, HeadsetRadioReceiveRelayEvent>(OnHeadsetReceive);
 
@@ -51,13 +53,6 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
     private void OnErase(ref EraseEvent args)
     {
         DeletePlayerMessages(args.PlayerNetUserId);
-    }
-
-    private void ListenerOnMapInit(Entity<ParrotListenerComponent> entity, ref MapInitEvent args)
-    {
-        // If an entity has a ParrotListenerComponent it really ought to have an ActiveListenerComponent
-        if (!HasComp<ActiveListenerComponent>(entity))
-            Log.Warning($"Entity {ToPrettyString(entity)} has a ParrotListenerComponent but was not given an ActiveListenerComponent");
     }
 
     private void OnListen(Entity<ParrotListenerComponent> entity, ref ListenEvent args)
@@ -73,6 +68,14 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
 
         TryLearn(entity.Owner, message, source);
     }
+
+    // ES START
+    private void OnRadioReceive(Entity<ParrotListenerComponent> ent, ref RadioReceiveEvent args)
+    {
+        TryLearn((ent.Owner, null, ent.Comp), args.Message, args.MessageSource);
+    }
+    // ES END
+
 
     /// <summary>
     /// Called when an entity with a ParrotMemoryComponent tries to vocalize.
@@ -163,7 +166,7 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
             sourceNetUserId = mind.UserId;
         }
 
-        var newMemory = new SpeechMemory(sourceNetUserId, message);
+        var newMemory = new SpeechMemory(sourceNetUserId, message, Name(source));
 
         // add a new message if there is space in the memory
         if (entity.Comp.SpeechMemories.Count < entity.Comp.MaxSpeechMemory)

--- a/Content.Server/Animals/Systems/ParrotMemorySystem.cs
+++ b/Content.Server/Animals/Systems/ParrotMemorySystem.cs
@@ -44,6 +44,7 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
         // removed mapinit event (useless)
         // + event for regular radio relay
         SubscribeLocalEvent<ParrotListenerComponent, RadioReceiveEvent>(OnRadioReceive);
+        // ES END
         SubscribeLocalEvent<ParrotListenerComponent, ListenEvent>(OnListen);
         SubscribeLocalEvent<ParrotListenerComponent, HeadsetRadioReceiveRelayEvent>(OnHeadsetReceive);
 
@@ -75,7 +76,6 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
         TryLearn((ent.Owner, null, ent.Comp), args.Message, args.MessageSource);
     }
     // ES END
-
 
     /// <summary>
     /// Called when an entity with a ParrotMemoryComponent tries to vocalize.
@@ -166,7 +166,10 @@ public sealed partial class ParrotMemorySystem : SharedParrotMemorySystem
             sourceNetUserId = mind.UserId;
         }
 
+        // ES START
+        // add name
         var newMemory = new SpeechMemory(sourceNetUserId, message, Name(source));
+        // ES END
 
         // add a new message if there is space in the memory
         if (entity.Comp.SpeechMemories.Count < entity.Comp.MaxSpeechMemory)

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -15,6 +15,11 @@ using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 // ES START
 using Content.Server._ES.Radio;
+using Content.Server.Animals.Systems;
+using Content.Shared._ES.Degradation;
+using Content.Shared._ES.Masks.Traitor;
+using Content.Shared.Animals.Components;
+
 // ES END
 
 namespace Content.Server.Radio.EntitySystems;
@@ -31,6 +36,7 @@ public sealed class RadioSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
 // ES START
+    [Dependency] private ILocalizationManager _loc = default!;
     [Dependency] private readonly ESRadioSystem _esRadio = default!;
 // ES END
 
@@ -45,8 +51,45 @@ public sealed class RadioSystem : EntitySystem
         SubscribeLocalEvent<IntrinsicRadioReceiverComponent, RadioReceiveEvent>(OnIntrinsicReceive);
         SubscribeLocalEvent<IntrinsicRadioTransmitterComponent, EntitySpokeEvent>(OnIntrinsicSpeak);
 
+        // ES START
+        SubscribeLocalEvent<TelecomServerComponent, TransformSpeakerNameEvent>(OnTransformServerName);
+        SubscribeLocalEvent<TelecomServerComponent, ESUndergoDegradationEvent>(OnServerDegraded);
+        // ES END
+
         _exemptQuery = GetEntityQuery<TelecomExemptComponent>();
     }
+
+    // ES START
+    private void OnServerDegraded(Entity<TelecomServerComponent> ent, ref ESUndergoDegradationEvent args)
+    {
+        // tcomms servers have parrot memory, for the radio channel they listen on
+        // we pull one from there, scramble it, then send it on this channel
+        if (!TryComp<ParrotMemoryComponent>(ent, out var memory))
+            return;
+
+        if (!TryComp<EncryptionKeyHolderComponent>(ent, out var keys))
+            return;
+
+        // pick 1 memory for the message
+        // we don't distort it here, because its probably already distorted
+        var msg = _random.Pick(memory.SpeechMemories).Message;
+
+        foreach (var channel in keys.Channels)
+        {
+            SendRadioMessage(ent.Owner, msg, channel, ent.Owner);
+        }
+    }
+
+    private void OnTransformServerName(EntityUid uid, TelecomServerComponent component, TransformSpeakerNameEvent args)
+    {
+        if (!TryComp<ParrotMemoryComponent>(uid, out var memory))
+            return;
+
+        // use a random name from memories to transform whatever message we send (thru sabotage, usually)
+        var source = _random.Pick(memory.SpeechMemories);
+        args.VoiceName = source.EntityName;
+    }
+    // ES END
 
     private void OnIntrinsicSpeak(EntityUid uid, IntrinsicRadioTransmitterComponent component, EntitySpokeEvent args)
     {

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -15,11 +15,8 @@ using Robust.Shared.Replays;
 using Robust.Shared.Utility;
 // ES START
 using Content.Server._ES.Radio;
-using Content.Server.Animals.Systems;
 using Content.Shared._ES.Degradation;
-using Content.Shared._ES.Masks.Traitor;
 using Content.Shared.Animals.Components;
-
 // ES END
 
 namespace Content.Server.Radio.EntitySystems;
@@ -77,6 +74,8 @@ public sealed class RadioSystem : EntitySystem
         {
             SendRadioMessage(ent.Owner, msg, channel, ent.Owner);
         }
+
+        args.Handled = true;
     }
 
     private void OnTransformServerName(EntityUid uid, TelecomServerComponent component, TransformSpeakerNameEvent args)

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -36,7 +36,6 @@ public sealed class RadioSystem : EntitySystem
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
 // ES START
-    [Dependency] private ILocalizationManager _loc = default!;
     [Dependency] private readonly ESRadioSystem _esRadio = default!;
 // ES END
 

--- a/Content.Shared/Animals/Components/ParrotMemoryComponent.cs
+++ b/Content.Shared/Animals/Components/ParrotMemoryComponent.cs
@@ -58,4 +58,7 @@ public sealed partial class ParrotMemoryComponent : Component
 }
 
 [Serializable, NetSerializable]
-public record struct SpeechMemory(NetUserId? NetUserId, string Message);
+// ES START
+// add entity name
+public record struct SpeechMemory(NetUserId? NetUserId, string Message, string EntityName);
+// ES END

--- a/Content.Shared/_ES/Masks/Traitor/ESSabotageSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESSabotageSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared._ES.Degradation;
 using Content.Shared._ES.Masks.Traitor.Components;
+using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
 using Content.Shared.DoAfter;
 using Content.Shared.Popups;
 using Content.Shared.Verbs;
@@ -9,6 +11,7 @@ namespace Content.Shared._ES.Masks.Traitor;
 
 public sealed class ESSabotageSystem : EntitySystem
 {
+    [Dependency] private readonly ISharedAdminManager _admin = default!;
     [Dependency] private readonly ESDegradationSystem _degradation = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly ESSharedMaskSystem _mask = default!;
@@ -23,7 +26,8 @@ public sealed class ESSabotageSystem : EntitySystem
 
     private void OnGetVerbs(Entity<ESSabotageTargetComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
-        if (_mask.GetTroupeOrNull(args.User) != ent.Comp.SabotageTroupe)
+        if (_mask.GetTroupeOrNull(args.User) != ent.Comp.SabotageTroupe
+            || !_admin.HasAdminFlag(args.User, AdminFlags.Debug))
             return;
 
         var user = args.User;

--- a/Content.Shared/_ES/Masks/Traitor/ESSabotageSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESSabotageSystem.cs
@@ -27,7 +27,7 @@ public sealed class ESSabotageSystem : EntitySystem
     private void OnGetVerbs(Entity<ESSabotageTargetComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (_mask.GetTroupeOrNull(args.User) != ent.Comp.SabotageTroupe
-            || !_admin.HasAdminFlag(args.User, AdminFlags.Debug))
+            && !_admin.HasAdminFlag(args.User, AdminFlags.Debug))
             return;
 
         var user = args.User;

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -139,7 +139,7 @@
       - EncryptionKeyCommand
   # ES START
   - type: ActiveRadio
-    channels: [ Common, Cargo, Engineering, Medical, Science, Security, Service, Command ]
+    channels: [ Common, Supply, Engineering, Medical, Science, Security, Service, Command ]
   # ES END
 
 
@@ -168,7 +168,7 @@
       - EncryptionKeyCargo
   # ES START
   - type: ActiveRadio
-    channels: [ Cargo ]
+    channels: [ Supply ]
   # ES END
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -117,7 +117,7 @@
   - type: ParrotListener
   - type: ParrotMemory
     learnChance: 1.0
-    learnCooldown: 1s
+    learnCooldown: 1m
   - type: ActiveRadio
 # ES END
 

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -139,7 +139,7 @@
       - EncryptionKeyCommand
   # ES START
   - type: ActiveRadio
-    receiveAllChannels: true
+    channels: [ Common, Cargo, Engineering, Medical, Science, Security, Service, Command ]
   # ES END
 
 

--- a/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/telecomms.yml
@@ -114,6 +114,11 @@
       machine_parts: !type:Container
 # ES START
   - type: ESSabotageTarget
+  - type: ParrotListener
+  - type: ParrotMemory
+    learnChance: 1.0
+    learnCooldown: 1s
+  - type: ActiveRadio
 # ES END
 
 - type: entity
@@ -132,6 +137,11 @@
       - EncryptionKeySecurity
       - EncryptionKeyService
       - EncryptionKeyCommand
+  # ES START
+  - type: ActiveRadio
+    receiveAllChannels: true
+  # ES END
+
 
 - type: entity
   parent: TelecomServer
@@ -142,6 +152,10 @@
     containers:
       key_slots:
       - EncryptionKeyCommon
+  # ES START
+  - type: ActiveRadio
+    channels: [ Common ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -152,6 +166,10 @@
     containers:
       key_slots:
       - EncryptionKeyCargo
+  # ES START
+  - type: ActiveRadio
+    channels: [ Cargo ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -162,6 +180,10 @@
     containers:
       key_slots:
       - EncryptionKeyEngineering
+  # ES START
+  - type: ActiveRadio
+    channels: [ Engineering ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -172,6 +194,10 @@
     containers:
       key_slots:
       - EncryptionKeyMedical
+  # ES START
+  - type: ActiveRadio
+    channels: [ Medical ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -182,6 +208,10 @@
     containers:
       key_slots:
       - EncryptionKeyScience
+  # ES START
+  - type: ActiveRadio
+    channels: [ Science ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -192,6 +222,10 @@
     containers:
       key_slots:
       - EncryptionKeySecurity
+  # ES START
+  - type: ActiveRadio
+    channels: [ Security ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -202,6 +236,10 @@
     containers:
       key_slots:
       - EncryptionKeyService
+  # ES START
+  - type: ActiveRadio
+    channels: [ Service ]
+  # ES END
 
 - type: entity
   parent: TelecomServer
@@ -212,3 +250,7 @@
     containers:
       key_slots:
       - EncryptionKeyCommand
+  # ES START
+  - type: ActiveRadio
+    channels: [ Command ]
+  # ES END


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- saves radio messages sent to the channel in parrot memory (like polly)
- sends message on sabo. picks random message + picks a random name from a different random message, so the name and msg dont match
- doesnt distort, under the assumption that it might already have distortion added (both from the source msg and from when it sends). it doesnt in my video but
- parrot now saves nonrelayed radio messages also (thru activeradio) and also saves entity name

one technical issue is that the channels for listening and the channels the tcomms server are connected to are not technically synced, but i dont think theres any real way for it to get desynced anyway in a way that matters


https://github.com/user-attachments/assets/be4bbc9a-3d75-473a-82e5-473114d94111

