### PR TITLE
Power rebalance

### DIFF
--- a/Content.Shared/Light/Components/LightBulbComponent.cs
+++ b/Content.Shared/Light/Components/LightBulbComponent.cs
@@ -57,7 +57,9 @@ public sealed partial class LightBulbComponent : Component
     /// The amount of power used by the lightbulb when it's active.
     /// </summary>
     [DataField("PowerUse")]
-    public int PowerUse = 60;
+    // ES START
+    public int PowerUse = 20;
+    // ES END
 
     /// <summary>
     /// The sound produced when the lightbulb breaks.

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -242,7 +242,6 @@
     # ES END
     lightRadius: 10
     lightSoftness: 1
-    PowerUse: 25
 
 - type: entity
   parent: LightTube

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -6,7 +6,9 @@
   parent: BaseComputer
   components:
   - type: ApcPowerReceiver
-    powerLoad: 350
+    # ES START
+    powerLoad: 100
+    # ES END
   - type: ExtensionCableReceiver
   - type: PointLight
     radius: 1.8

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -17,7 +17,9 @@
       - board
   - type: Computer
   - type: ApcPowerReceiver
-    powerLoad: 200
+    # ES START
+    powerLoad: 100
+    # ES END
   - type: ExtensionCableReceiver
   - type: ActivatableUIRequiresPower
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -504,7 +504,9 @@
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Computer
     board: ResearchComputerCircuitboard
   - type: AccessReader
@@ -555,7 +557,9 @@
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Computer
     board: AnalysisComputerCircuitboard
   - type: PointLight
@@ -637,7 +641,9 @@
   description: A body scanner.
   components:
   - type: ApcPowerReceiver
-    powerLoad: 500
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Computer
     board: BodyScannerComputerCircuitboard
   - type: PointLight
@@ -1553,7 +1559,9 @@
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: RoboticsConsole
@@ -1619,7 +1627,9 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Computer
     board: StationAiUploadCircuitboard
   - type: AccessReader
@@ -1695,7 +1705,9 @@
           True: { visible: false }
           False: { visible: true }
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Computer
     board: StationAiFixerCircuitboard
   - type: AccessReader

--- a/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Medical/cryo_pod.yml
@@ -71,7 +71,9 @@
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
   - type: ApcPowerReceiver
-    powerLoad: 3000
+    # ES START
+    powerLoad: 800
+    # ES END
   - type: ExtensionCableReceiver
   - type: NodeContainer
     nodes:

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -250,7 +250,9 @@
   - type: Transform
     anchored: true
   - type: ApcPowerReceiver
-    powerLoad: 1500
+    # ES START
+    powerLoad: 800
+    # ES END
   - type: ExtensionCableReceiver
   - type: AmbientSound
     range: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_sync.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_sync.yml
@@ -41,13 +41,15 @@
           bounds: "-0.35,-0.35,0.35,0.35"
         density: 100
         mask:
-        - ItemMask 
+        - ItemMask
         hard: True
   - type: Transform
     anchored: true
     noRot: false
   - type: ApcPowerReceiver
-    powerLoad: 2500
+    # ES START
+    powerLoad: 800
+    # ES END
     needsPower: true
   - type: ItemPlacer
     whitelist:

--- a/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/artifact_analyzer.yml
@@ -48,7 +48,9 @@
   - type: Transform
     anchored: true
   - type: ApcPowerReceiver
-    powerLoad: 12000
+    # ES START
+    powerLoad: 6000
+    # ES END
     needsPower: false #only turns on when scanning
   - type: ArtifactAnalyzer
   - type: ItemPlacer

--- a/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
@@ -49,7 +49,9 @@
   id: BaseMachinePowered
   components:
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 100
+    # ES END
   - type: ExtensionCableReceiver
   - type: LightningTarget
     priority: 1

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -62,7 +62,9 @@
       enum.ChemMasterUiKey.Key:
         type: ChemMasterBoundUserInterface
   - type: ApcPowerReceiver
-    powerLoad: 250
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -36,7 +36,9 @@
         type: FaxBoundUi
   - type: StationAiWhitelist
   - type: ApcPowerReceiver
-    powerLoad: 250
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Faxecute
     damage:
       types:

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -25,7 +25,9 @@
   - type: Transform
     anchored: true
   - type: ApcPowerReceiver
-    powerLoad: 2500
+    # ES START
+    powerLoad: 600
+    # ES END
   - type: ExtensionCableReceiver
   - type: Physics
     bodyType: Static

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -98,7 +98,9 @@
     canCreateVacuum: false
     deleteAfterExplosion: false
   - type: ApcPowerReceiver
-    powerLoad: 400
+    # ES START
+    powerLoad: 200
+    # ES END
   - type: Machine
     board: MicrowaveMachineCircuitboard
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -39,7 +39,9 @@
     - map: [ "grinder" ]
       state: "grinder_empty"
   - type: ApcPowerReceiver
-    powerLoad: 300
+    # ES START
+    powerLoad: 100
+    # ES END
   - type: ItemSlots
     slots:
       beakerSlot:

--- a/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/stasisbed.yml
@@ -27,7 +27,9 @@
           False: { visible: false }
   - type: Appearance
   - type: ApcPowerReceiver
-    powerLoad: 1000
+    # ES START
+    powerLoad: 300
+    # ES END
   - type: ExtensionCableReceiver
   - type: Damageable
     damageContainer: Inorganic

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -99,7 +99,9 @@
     radius: 1.5
   - type: LitOnPowered
   - type: ApcPowerReceiver
-    powerLoad: 200
+    # ES START
+    powerLoad: 100
+    # ES END
   - type: Actions
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-mechanical

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -40,7 +40,9 @@
   - type: LightningTarget
     priority: 1
   - type: ApcPowerReceiver
-    powerLoad: 200
+    # ES START
+    powerLoad: 20
+    # ES END
   - type: Rotatable
   - type: Transform
     noRot: false
@@ -104,7 +106,9 @@
     - type: LightningTarget
       priority: 1
     - type: ApcPowerReceiver
-      powerLoad: 200
+      # ES START
+      powerLoad: 20
+      # ES END
     - type: Rotatable
     - type: Transform
       noRot: false

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -34,7 +34,9 @@
     - type: Appearance
     - type: Battery
       startingCharge: 0
-      maxCharge: 8000000
+      # ES START
+      maxCharge: 18000000
+      # ES END
     - type: ExaminableBattery
     - type: NodeContainer
       examinable: true
@@ -119,11 +121,13 @@
 - type: entity
   parent: BaseSMES
   id: SMESBasic
-  suffix: Basic, 8MJ
+  # ES START
+  suffix: Basic, 18MJ
   components:
   - type: Battery
-    maxCharge: 8000000
-    startingCharge: 8000000
+    maxCharge: 18000000
+    startingCharge: 18000000
+  # ES END
 
 - type: entity
   parent: SMESBasic

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -37,7 +37,9 @@
     - type: Appearance
     - type: ThrusterVisuals
     - type: ApcPowerReceiver
-      powerLoad: 1500
+      # ES START
+      powerLoad: 600
+      # ES END
     - type: ExtensionCableReceiver
     - type: Damageable
       damageContainer: StructuralInorganic

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/station_map.yml
@@ -51,7 +51,9 @@
       containers:
         board: !type:Container
     - type: ApcPowerReceiver
-      powerLoad: 200
+      # ES START
+      powerLoad: 20
+      # ES END
     - type: Construction
       graph: StationMap
       node: station_map


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

time to empty smeses is now ~20 minutes, ~15 minutes given arrivals time

<img width="669" height="370" alt="image" src="https://github.com/user-attachments/assets/92247b59-353b-4673-91be-1f26b4d23d99" />

general thought process was just
- pass over all power draw, reduce stuff thats insane and standardize (generally around multiples of 100, and 20 for small common machines)
- then increase smes capacity until it was at the level i wanted

still need to see how it is with lightswitch stuff, and eventually i want more machines to have dynamic power draw, but this is fine for now