### PR TITLE
Add degradation scheduler

### DIFF
--- a/Content.Client/_ES/Voting/Ui/ESVotingWindow.xaml
+++ b/Content.Client/_ES/Voting/Ui/ESVotingWindow.xaml
@@ -1,16 +1,10 @@
 <controls:ESVotingWindow
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._ES.Voting.Ui"
-    xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    xmlns:xNamespace="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:style="clr-namespace:Content.Client.Stylesheets"
     Title="{Loc 'es-voter-ui-title'}"
-    MinSize="480 400">
+    MinSize="580 400">
     <ScrollContainer HScrollEnabled="False" HorizontalExpand="True" VerticalExpand="True" Margin="10">
-        <PanelContainer>
-            <PanelContainer.PanelOverride>
-                <graphics:StyleBoxFlat BackgroundColor="{xNamespace:Static style:StyleNano.PanelDark}" />
-            </PanelContainer.PanelOverride>
+        <PanelContainer StyleClasses="PanelDark">
             <BoxContainer Name="VotesContainer" HorizontalExpand="True" VerticalExpand="True" Orientation="Vertical" Margin="10" SeparationOverride="5"/>
         </PanelContainer>
     </ScrollContainer>

--- a/Content.Server/_ES/Degradation/Components/ESDegradationEventComponent.cs
+++ b/Content.Server/_ES/Degradation/Components/ESDegradationEventComponent.cs
@@ -1,0 +1,42 @@
+using Content.Shared.EntityTable.ValueSelector;
+using Content.Shared.Whitelist;
+
+namespace Content.Server._ES.Degradation.Components;
+
+/// <summary>
+/// Used for a generic station event that marks several random entities for queued degradation.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ESDegradationEventSystem), Other = AccessPermissions.None)]
+public sealed partial class ESDegradationEventComponent : Component
+{
+    /// <summary>
+    /// Number of entities that are targeted for the event.
+    /// </summary>
+    [DataField]
+    public NumberSelector Count = new ConstantNumberSelector();
+
+    /// <summary>
+    /// The component that is targeted
+    /// </summary>
+    [DataField(required: true)]
+    public string Component = string.Empty;
+
+    /// <summary>
+    /// Whitelist to filter which entities are selected for degradation.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// Blacklist to filter which entities are selected for degradation.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist;
+
+    /// <summary>
+    /// If true, degradation will be immediately caused instead of simply queued.
+    /// </summary>
+    [DataField]
+    public bool DegradeImmediately;
+}

--- a/Content.Server/_ES/Degradation/ESDegradationEventSystem.cs
+++ b/Content.Server/_ES/Degradation/ESDegradationEventSystem.cs
@@ -1,0 +1,60 @@
+using Content.Server._ES.Degradation.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared._ES.Degradation;
+using Content.Shared._ES.Degradation.Components;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Whitelist;
+using Robust.Shared.Random;
+
+namespace Content.Server._ES.Degradation;
+
+/// <summary>
+/// Handles <see cref="ESDegradationEventComponent"/>
+/// </summary>
+public sealed class ESDegradationEventSystem : StationEventSystem<ESDegradationEventComponent>
+{
+    [Dependency] private readonly ESDegradationSystem _degradation = default!;
+    [Dependency] private readonly EntityWhitelistSystem _entityWhitelist = default!;
+
+    protected override void Started(EntityUid uid,
+        ESDegradationEventComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        if (!EntityManager.ComponentFactory.TryGetRegistration(component.Component, out var registration))
+        {
+            Log.Error($"Failed to find registration for component with name {component.Component}");
+            return;
+        }
+
+        var entities = new List<EntityUid>();
+        foreach (var (entity, _) in EntityManager.GetAllComponents(registration.Type))
+        {
+            if (!_entityWhitelist.IsWhitelistPassOrNull(component.Whitelist, entity) ||
+                _entityWhitelist.IsWhitelistPass(component.Blacklist, entity))
+                continue;
+
+            entities.Add(entity);
+        }
+
+        var count = Math.Min(component.Count.Get(RobustRandom.GetRandom()), entities.Count);
+        for (var i = 0; i < count; i++)
+        {
+            var ent = RobustRandom.PickAndTake(entities);
+
+            if (component.DegradeImmediately)
+            {
+                _degradation.Degrade(ent, null);
+            }
+            else
+            {
+                EnsureComp<ESQueuedDegradationComponent>(ent);
+            }
+        }
+
+        ForceEndSelf(uid, gameRule);
+        QueueDel(uid); // We don't need these afterward
+    }
+}

--- a/Resources/Locale/en-US/_ES/voting/voting.ftl
+++ b/Resources/Locale/en-US/_ES/voting/voting.ftl
@@ -7,6 +7,7 @@ es-voter-chat-announce-query-default = The vote has concluded. Result:
 es-voter-chat-announce-result = {$query} [bold]{$result}[/bold]
 
 es-voter-query-string-station-event = Running next station event:
+es-voter-query-string-degradation-event = Running next degradation event:
 
 command-description-esvote-ls = Returns a list of all active votes
 command-description-esvote-options = Given a vote entity, returns the different options

--- a/Resources/Prototypes/_ES/GameRules/degradation_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/degradation_events.yml
@@ -62,6 +62,8 @@
   - type: ESDegradationEvent
     component: TelecomServer
     degradeImmediately: true # Doesn't react to anything
+  - type: StationEvent
+    weight: 20
 
 - type: entity
   parent: ESBaseDegradationEvent

--- a/Resources/Prototypes/_ES/GameRules/degradation_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/degradation_events.yml
@@ -1,0 +1,81 @@
+- type: entity
+  parent: BaseGameRule
+  id: ESBaseDegradationEvent
+  name: Unnamed Degradation Event
+  abstract: true
+  components:
+  - type: ESDegradationEvent
+  - type: StationEvent
+    earliestStart: 0
+    reoccurrenceDelay: 0
+    occursDuringRoundEnd: false
+    weight: 10
+
+- type: entityTable
+  id: ESDegradationEvents
+  table:
+    all:
+    - id: ESDegradationEventAirlocks
+    - id: ESDegradationEventCommunicationsConsole
+    - id: ESDegradationEventCriminalRecords
+    - id: ESDegradationEventTelecoms
+    - id: ESDegradationEventCrewMonitoring
+    - id: ESDegradationEventIDCardComputer
+
+# Event Prototypes
+
+- type: entity
+  parent: ESBaseDegradationEvent
+  id: ESDegradationEventAirlocks
+  name: Airlock Bolt Breakage
+  components:
+  - type: ESDegradationEvent
+    count: 1, 5
+    component: Airlock
+    blacklist:
+      components:
+      - Docking
+  - type: StationEvent
+    weight: 50
+
+- type: entity
+  parent: ESBaseDegradationEvent
+  id: ESDegradationEventCommunicationsConsole
+  name: Distorted Announcement
+  components:
+  - type: ESDegradationEvent
+    component: CommunicationsConsole
+
+- type: entity
+  parent: ESBaseDegradationEvent
+  id: ESDegradationEventCriminalRecords
+  name: Hacked Criminal Records
+  components:
+  - type: ESDegradationEvent
+    component: CriminalRecordsConsole
+
+- type: entity
+  parent: ESBaseDegradationEvent
+  id: ESDegradationEventTelecoms
+  name: Telecom Ghosts
+  components:
+  - type: ESDegradationEvent
+    component: TelecomServer
+    degradeImmediately: true # Doesn't react to anything
+
+- type: entity
+  parent: ESBaseDegradationEvent
+  id: ESDegradationEventCrewMonitoring
+  name: Sensor Manipulation
+  components:
+  - type: ESDegradationEvent
+    component: CrewMonitoringServer
+    degradeImmediately: true # Doesn't react to anything
+
+- type: entity
+  parent: ESBaseDegradationEvent
+  id: ESDegradationEventIDCardComputer
+  name: ID Scramble
+  components:
+  - type: ESDegradationEvent
+    component: IdCardConsole

--- a/Resources/Prototypes/_ES/GameRules/presets.yml
+++ b/Resources/Prototypes/_ES/GameRules/presets.yml
@@ -7,6 +7,7 @@
   rules:
   - ESTroupeRuleCrew
   - ESSchedulerRuleStationEventVote
+  - ESSchedulerRuleDegradationEventVote
   - ESBasicRoundstartVariation
 
 - type: gamePreset
@@ -18,6 +19,7 @@
   - ESTroupeRuleCrew
   - ESTroupeRuleTraitor
   - ESSchedulerRuleStationEventVote
+  - ESSchedulerRuleDegradationEventVote
   - ESBasicRoundstartVariation
 
 # Nonstandard modes

--- a/Resources/Prototypes/_ES/GameRules/schedulers.yml
+++ b/Resources/Prototypes/_ES/GameRules/schedulers.yml
@@ -18,10 +18,32 @@
 
 - type: entity # Vote Entity (for above)
   id: ESVoteStationEvent
-  name: Next Station Event...
+  name: Next station event...
   categories: [ HideSpawnMenu ]
   components:
   - type: ESVote
     queryString: es-voter-query-string-station-event
+    duration: 60
+  - type: ESEventVote
+
+- type: entity
+  parent: BaseGameRule
+  id: ESSchedulerRuleDegradationEventVote
+  components:
+  - type: ESEventVoteScheduler
+    eventTable:
+      tableId: ESDegradationEvents
+    votePrototype: ESVoteDegradationEvent
+    voteOptions: 2
+    minEventDelay: 5m
+    maxEventDelay: 15m
+
+- type: entity
+  id: ESVoteDegradationEvent
+  name: Next degradation event...
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ESVote
+    queryString: es-voter-query-string-degradation-event
     duration: 60
   - type: ESEventVote


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
random event scheduler that fires off degradation events. They're currently votable just for vibe purposes (though the low count in the pool means I had to restrict to like 2 options)

adds events for all planned sabo objectives + doors which i think generally covers traitor activity. Might need additional tuning but imo it's probably good for a first pass. This kind of plausible deniability is only kinda tangentially relevant to the first playtest.