### PR TITLE
Add sabotage for ID card consoles

### DIFF
--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -152,7 +152,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         if (component.TargetIdSlot.Item is not { Valid: true } targetId || !PrivilegedIdIsAuthorized(uid, component, out var privilegedId))
             return;
 // ES START
-        _degradation.Degrade(uid, player);
+        _degradation.TryDegrade(uid, player);
 // ES END
 
         _idCard.TryChangeFullName(targetId, newFullName, player: player);

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -22,6 +22,9 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+// ES START
+using Content.Shared._ES.Degradation;
+// ES END
 
 namespace Content.Server.Access.Systems;
 
@@ -39,7 +42,10 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
     [Dependency] private readonly ThrowingSystem _throwing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
-
+// ES START
+    [Dependency] private readonly ESDegradationSystem _degradation = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+// ES END
     public override void Initialize()
     {
         base.Initialize();
@@ -55,6 +61,9 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         // Intercept the event before anyone can do anything with it!
         SubscribeLocalEvent<IdCardConsoleComponent, MachineDeconstructedEvent>(OnMachineDeconstructed,
             before: [typeof(EmptyOnMachineDeconstructSystem), typeof(ItemSlotsSystem)]);
+// ES START
+        SubscribeLocalEvent<IdCardConsoleComponent, ESUndergoDegradationEvent>(OnUndergoDegradation);
+// ES END
     }
 
     private void OnWriteToTargetIdMessage(EntityUid uid, IdCardConsoleComponent component, WriteToTargetIdMessage args)
@@ -142,6 +151,9 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
 
         if (component.TargetIdSlot.Item is not { Valid: true } targetId || !PrivilegedIdIsAuthorized(uid, component, out var privilegedId))
             return;
+// ES START
+        _degradation.Degrade(uid, player);
+// ES END
 
         _idCard.TryChangeFullName(targetId, newFullName, player: player);
         _idCard.TryChangeJobTitle(targetId, newJobTitle, player: player);
@@ -240,6 +252,38 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         if (TryDropAndThrowIds(entity.AsNullable()))
             _chat.TrySendInGameICMessage(entity, Loc.GetString("id-card-console-damaged"), InGameICChatType.Speak, true);
     }
+
+// ES START
+    private void OnUndergoDegradation(Entity<IdCardConsoleComponent> ent, ref ESUndergoDegradationEvent args)
+    {
+        if (Transform(ent).GridUid is not { } grid)
+            return;
+
+        var ids = new HashSet<Entity<IdCardComponent>>();
+        _entityLookup.GetGridEntities(grid, ids);
+
+        if (ids.Count == 0)
+            return;
+
+        // Get icons only for valid jobs
+        var icons = _prototype.EnumeratePrototypes<JobPrototype>()
+            .Where(j => j.OverrideConsoleVisibility ?? j.SetPreference)
+            .Select(j => _prototype.Index(j.Icon))
+            .ToList();
+
+        // Hardcoded because it really doesn't matter very much.
+        var count = Math.Max(_random.NextFloat(0.1f, 0.25f) * ids.Count, 1);
+        for (var i = 0; i < count; i++)
+        {
+            // scramble the icons
+            var id = _random.PickAndTake(ids.ToList());
+            var icon = _random.Pick(icons.Except([_prototype.Index(id.Comp.JobIcon)]).ToList());
+            _idCard.TryChangeJobIcon(id, icon, id);
+        }
+
+        args.Handled = true;
+    }
+// ES END
 
     #region PublicAPI
 

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -262,9 +262,6 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         var ids = new HashSet<Entity<IdCardComponent>>();
         _entityLookup.GetGridEntities(grid, ids);
 
-        if (ids.Count == 0)
-            return;
-
         // Get icons only for valid jobs
         var icons = _prototype.EnumeratePrototypes<JobPrototype>()
             .Where(j => j.OverrideConsoleVisibility ?? j.SetPreference)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
basic sabotage: when degraded, randomize the icon of 10-25% of IDs on station.

activates naturally whenever an inserted ID has its properties modified.