### PR TITLE
Add crew monitoring server sabotage

### DIFF
--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
@@ -135,7 +135,12 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
 
         foreach (var sensor in sensors)
         {
+            // Don't change the sensor of clothing that doesn't support having it changed back
             if (sensor.Comp.ControlsLocked)
+                continue;
+
+            // Don't enable disabled sensors. First because it'll expose stealthy people and dead bodies, second because it doesnt make sense.
+            if (sensor.Comp.Mode == SuitSensorMode.SensorOff)
                 continue;
             _sensors.SetSensor(sensor.AsNullable(), _random.Pick(statuses));
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
On degrade, randomize the suit sensors of everyone on the grid.

using the grid instead of the network stuff is mildly dud but also i think it's the simplest and the different is negligible and not relevant i think.