### PR TITLE
touching the vlone

### DIFF
--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -188,24 +188,35 @@ namespace Content.Client.ContextMenu.UI
             }
         }
 
+        // ES START
+        // reverse returns they were incorrect before
         private bool HandleOpenEntityMenu(in PointerInputCmdHandler.PointerInputCmdArgs args)
         {
+            // ES START
+            // despite what you may infer from outsidePrediction, that doesnt actually mean this doesnt get predicted,
+            // it appears to just mean this is a clientside/local bind that can prevent server binds from running?
+            // so we still have to check. this was papered over in earlier impls, because of the bad return values, afaict.
+            if (!_gameTiming.IsFirstTimePredicted)
+                return true;
+            // ES END
+
             if (args.State != BoundKeyState.Down)
-                return false;
+                return true;
 
             if (_stateManager.CurrentState is not GameplayStateBase)
-                return false;
+                return true;
 
             if (_combatMode.IsInCombatMode(args.Session?.AttachedEntity))
-                return false;
+                return true;
 
             var coords = _xform.ToMapCoordinates(args.Coordinates);
 
             if (_verbSystem.TryGetEntityMenuEntities(coords, out var entities))
                 OpenRootMenu(entities);
 
-            return true;
+            return false;
         }
+        // ES END
 
         /// <summary>
         ///     Check that entities in the context menu are still visible. If not, remove them from the context menu.

--- a/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
@@ -27,7 +27,7 @@ public sealed class ESViewconeOverlayManagementSystem : EntitySystem
     private ESViewconeSetAlphaOverlay _setAlphaOverlay = default!;
     private ESViewconeResetAlphaOverlay _resetAlphaOverlay = default!;
 
-    private const float LerpHalfLife = 0.05f;
+    private const float LerpHalfLife = 0.1f;
 
     // slightly balls state management, but
     // done so we don't have to requery within the same frame

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeResetAlphaOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeResetAlphaOverlay.cs
@@ -33,6 +33,7 @@ public sealed class ESViewconeResetAlphaOverlay : Overlay
         foreach (var (ent, baseAlpha) in _cone.CachedBaseAlphas)
         {
             _sprite.SetColor(ent!, ent.Comp.Color.WithAlpha(baseAlpha));
+            _sprite.SetVisible(ent!, baseAlpha > 0f);
         }
 
         _cone.CachedBaseAlphas.Clear();

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
@@ -108,6 +108,7 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
 
             var alpha = comp.Inverted ? 1f - targetAlpha : targetAlpha;
             _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(alpha));
+            _sprite.SetVisible((uid, sprite), alpha > 0f);
         }
     }
 }

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -146,6 +146,10 @@ namespace Content.Shared.Interaction
                     new PointerInputCmdHandler(HandleActivateItemInWorld))
                 .Bind(ContentKeyFunctions.TryPullObject,
                     new PointerInputCmdHandler(HandleTryPullObject))
+                // ES START
+                .Bind(EngineKeyFunctions.UseSecondary,
+                    new PointerInputCmdHandler(ESHandleEntityMenuRotate))
+                // ES END
                 .Register<SharedInteractionSystem>();
 
             _rateLimit.Register(RateLimitKey,
@@ -158,6 +162,20 @@ namespace Content.Shared.Interaction
 
             InitializeBlocking();
         }
+
+        // ES START
+        private bool ESHandleEntityMenuRotate(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
+        {
+            if (!ValidateClientInput(session, coords, uid, out var user))
+                return true;
+
+            // clientside handles opening the menu, but we want to rotate to it also
+            // // which we do in shared
+            ValidateInteractAndFace(user.Value, coords);
+
+            return false;
+        }
+        // ES END
 
         private void RateLimitAlertAdmins(ICommonSession session)
         {

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Construction.Components;
 using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Database;
 using Content.Shared.Friction;
+using Content.Shared.Interaction;
 using Content.Shared.Projectiles;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -45,6 +46,9 @@ public sealed class ThrowingSystem : EntitySystem
     [Dependency] private readonly SharedCameraRecoilSystem _recoil = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IConfigurationManager _configManager = default!;
+    // ES START
+    [Dependency] private readonly RotateToFaceSystem _rotate = default!;
+    // ES END
 
     private EntityQuery<AnchorableComponent> _anchorableQuery;
 
@@ -264,6 +268,11 @@ public sealed class ThrowingSystem : EntitySystem
             return;
         var msg = new ThrowPushbackAttemptEvent();
         RaiseLocalEvent(uid, msg);
+
+        // ES START
+        // rotate them in the direction of the thrown thing
+        _rotate.TryFaceAngle(user.Value, direction.ToWorldAngle());
+        // ES END
 
         if (msg.Cancelled)
             return;

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._ES.Viewcone;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Gravity;
@@ -9,6 +10,7 @@ using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.Throwing
@@ -27,6 +29,9 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
         // ES START
         [Dependency] private readonly SharedTransformSystem _transform = default!;
+        [Dependency] private readonly ESViewconeEffectSystem _effect = default!;
+
+        public static EntProtoId LandViewconeEffect = "ESViewconeEffectAttack";
         // ES END
 
         private const string ThrowingFixture = "throw-fixture";
@@ -132,6 +137,10 @@ namespace Content.Shared.Throwing
             // ES START
             _transform.SetLocalRotation(uid, Angle.Zero);
             _physics.SetAngularVelocity(uid, 0f, body: physics);
+
+            // play effect if there was a thrower
+            if (thrownItem.Thrower != null)
+                _effect.SpawnEffect(uid, LandViewconeEffect);
             // ES END
 
             _broadphase.RegenerateContacts((uid, physics));

--- a/Resources/Prototypes/_ES/Entities/Effects/viewcone_effects.yml
+++ b/Resources/Prototypes/_ES/Entities/Effects/viewcone_effects.yml
@@ -29,14 +29,15 @@
 - type: entity
   id: ESViewconeEffectFootstep
   parent: ESBaseViewconeEffect
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     state: footstep
 
-# TODO UNUSED
 - type: entity
   id: ESViewconeEffectAttack
   parent: ESBaseViewconeEffect
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     state: attack
@@ -45,22 +46,16 @@
 - type: entity
   id: ESViewconeEffectForcefield
   parent: ESBaseViewconeEffect
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     state: forcefield
 
 # TODO UNUSED
 - type: entity
-  id: ESViewconeEffectGunfire
-  parent: ESBaseViewconeEffect
-  components:
-  - type: Sprite
-    state: gunfire
-
-# TODO UNUSED
-- type: entity
   id: ESViewconeEffectTalk
   parent: ESBaseViewconeEffect
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     state: talk

--- a/Resources/Textures/_ES/Shaders/viewcone.swsl
+++ b/Resources/Textures/_ES/Shaders/viewcone.swsl
@@ -44,7 +44,7 @@ void fragment(){
     mask = 1.0 - clamp(mask, 0.0, 1.0);
 
     // So grim.. so dark
-    highp float grain = zRandom(FRAGCOORD.xy * sin(TIME * 0.01)).x;
+    highp float grain = zRandom(FRAGCOORD.xy * SCREEN_PIXEL_SIZE * (TIME * 0.01)).x;
 
     // Lil bit of grayscale for good measure, too
     highp float grayscale = zGrayscale(color.rgb) * (grain * grainMult + grainBase);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- viewcone effect for throw land closes #360 
- fixes status icons rendering on occluded ents and also other stuff too probably closes #375 
- opening context menu rotates you towards where u opened it closes #216
- throwing now rotates you towards where you threw
- now lerps a bit slower. feels slightly better i think
- noise changed so it doesnt repeat weirdly. i think. idk. it looked fine to me after this change. who knows
- viewcone effects not in spawnmenu anymore also removed the gun one since melee effects + gun effects should be handled by the effects that already get spawned (weapon stuff and muzzleflash)

video nont have the noise change it looks fine tho

https://github.com/user-attachments/assets/65c24b4d-dfde-4415-99d5-566e156b9287



<img width="323" height="234" alt="image" src="https://github.com/user-attachments/assets/18560672-0f2b-4c82-b9c3-24b35a435977" />
<img width="327" height="241" alt="image" src="https://github.com/user-attachments/assets/85357ad6-62d7-49aa-bde1-d18fa5f505e8" />
