### PR TITLE
Remove Mask Toggling

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
@@ -16,8 +16,10 @@
   abstract: true
   parent: ClothingMaskBase
   id: ClothingMaskPullableBase
-  components:
-  - type: Mask
+  # ES START
+  # components:
+  # - type: Mask
+  # ES END
 
 - type: entity
   parent: BaseAction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes the ability to toggle most gas and breath masks. Bandanas are unchanged.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Resolves #292. Toggleable masks have very little downside, and as a result many players will simply always wear a mask, toggled off. Removes an unnecessary action that players basically always have and never actually care about.

## Technical details
<!-- Summary of code changes for easier review. -->
Removes the `MaskComponent` from `ClothingMaskPullableBase`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed toggling of most toggleable masks.
