### PR TITLE
Open verb menu directly if only 1 entity is found

### DIFF
--- a/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/ContextMenuUIController.cs
@@ -113,6 +113,10 @@ namespace Content.Client.ContextMenu.UI
         /// </summary>
         public void Close()
         {
+            // ES START
+            // properly close submenus on root close
+            CloseSubMenus(RootMenu);
+            // ES END
             RootMenu.MenuBody.RemoveAllChildren();
             CancelOpen?.Cancel();
             CancelClose?.Cancel();

--- a/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
+++ b/Content.Client/ContextMenu/UI/EntityMenuUIController.cs
@@ -211,8 +211,16 @@ namespace Content.Client.ContextMenu.UI
 
             var coords = _xform.ToMapCoordinates(args.Coordinates);
 
-            if (_verbSystem.TryGetEntityMenuEntities(coords, out var entities))
+            // ES START
+            // open verb menu directly if 1 entity
+            if (!_verbSystem.TryGetEntityMenuEntities(coords, out var entities))
+                return false;
+
+            if (entities.Count == 1)
+                _verb.OpenVerbMenu(entities[0]);
+            else
                 OpenRootMenu(entities);
+            // ES END
 
             return false;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

number 1 ux tweaker

context root change needed otherwise nested verb submenus stick around on verbmenus opened this way

https://github.com/user-attachments/assets/968a9c9b-477a-4754-8267-a0ea0d901fbf

