### PR TITLE
Disable vgroid and other potential gridfill

### DIFF
--- a/Resources/ConfigPresets/_ES/base.toml
+++ b/Resources/ConfigPresets/_ES/base.toml
@@ -30,3 +30,7 @@ monstermos_equalization = false
 # Square viewport
 [viewport]
 maximum_width = 15
+
+# No gridfill
+[shuttle]
+grid_fill = false

--- a/Resources/Prototypes/_ES/StationConfigs/default.yml
+++ b/Resources/Prototypes/_ES/StationConfigs/default.yml
@@ -5,27 +5,4 @@
   maxStations: 1
   stationGridComponents:
   - type: ESTileBasedRoof
-  dungeons:
-  - configs: [ "VGRoid" ]
-    count: 1
-    distance: 0
-    name: NamesBorer
-    forcePos: true
-    components:
-    - type: Gravity
-      enabled: true
-      inherent: true
-    - type: IFF
-      color: "#d67e27"
-    - type: ESTileBasedRoof
-  - configs: [ "ChunkDebris" ]
-    count: 16, 20
-    distance: 312, 450
-    components:
-    - type: Gravity
-      enabled: true
-      inherent: true
-    - type: IFF
-      flags: HideLabel
-      color: "#88b0d1"
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

closes #413 

we are not reliant on gridfill for anything, since no evac and we spawn arrivals independently of that cvar, so should be safe to disable

also removes the dungen stuff from the station config for obvious reasons

<img width="999" height="857" alt="image" src="https://github.com/user-attachments/assets/1240eafc-504a-48fb-8f1c-d1c5e7e67cde" />

