### PR TITLE
Remove observer spawnpoints from syndiebase

### DIFF
--- a/Resources/Maps/_ES/syndiebase.yml
+++ b/Resources/Maps/_ES/syndiebase.yml
@@ -3950,23 +3950,6 @@ entities:
     - type: Transform
       pos: 0.5,-2.5
       parent: 2
-- proto: SpawnPointObserver
-  entities:
-  - uid: 4
-    components:
-    - type: Transform
-      pos: -1.5,0.5
-      parent: 2
-  - uid: 818
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 2
-  - uid: 822
-    components:
-    - type: Transform
-      pos: -0.5,0.5
-      parent: 2
 - proto: Stool
   entities:
   - uid: 60


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

fixes #392 

syndiebase had 3 and toast had 1, so there was a 75% chance for them to spawn on the syndiebase