### PR TITLE
Draw viewcone in WorldSpaceBelowFOV

### DIFF
--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
@@ -19,7 +19,7 @@ public sealed class ESViewconeConeOverlay : Overlay
     [Dependency] private readonly IEntityManager _ent = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
-    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
     public override bool RequestScreenTexture => true;
 
     public static ProtoId<ShaderPrototype> ShaderPrototype = "Viewcone";


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

<img width="891" height="782" alt="image" src="https://github.com/user-attachments/assets/9d1f25ac-6207-44b7-baea-ea948ac62d1a" />
<img width="937" height="888" alt="image" src="https://github.com/user-attachments/assets/e5dfe671-c2c1-43ee-857b-dbea98a0af8d" />
<img width="942" height="943" alt="image" src="https://github.com/user-attachments/assets/64ed3544-9c63-4a85-b1c7-0dfc748b9ff9" />

looks normal, and this intuitively makes sense to me

fixes #393