### PR TITLE
Fix cryptonuke objective completion + minor refactor

### DIFF
--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -267,6 +267,6 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         EntityManager.AddComponents(mind, mask.MindComponents);
 
         troupe.Comp.TroupeMemberMinds.Add(mind);
-        Objective.RefreshObjectives(mind.Owner);
+        Objective.RegenerateObjectiveList(mind.Owner);
     }
 }

--- a/Content.Server/_ES/Nuke/ESDetonateNukeObjectiveSystem.cs
+++ b/Content.Server/_ES/Nuke/ESDetonateNukeObjectiveSystem.cs
@@ -16,9 +16,6 @@ public sealed class ESDetonateNukeObjectiveSystem : ESBaseObjectiveSystem<ESDeto
 
     private void OnNukeExploded(NukeExplodedEvent ev)
     {
-        foreach (var objective in ObjectivesSys.GetObjectives<ESDetonateNukeObjectiveComponent>())
-        {
-            ObjectivesSys.AdjustObjectiveCounter(objective.Owner);
-        }
+        ObjectivesSys.AdjustObjectiveCounter<ESDetonateNukeObjectiveComponent>();
     }
 }

--- a/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
@@ -105,7 +105,7 @@ public abstract class ESSharedMaskSystem : EntitySystem
     {
         foreach (var mind in ent.Comp.TroupeMemberMinds)
         {
-            Objective.RefreshObjectives(mind);
+            Objective.RegenerateObjectiveList(mind);
         }
     }
 

--- a/Content.Shared/_ES/Nuke/ESSharedCryptoNukeSystem.cs
+++ b/Content.Shared/_ES/Nuke/ESSharedCryptoNukeSystem.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Content.Shared._ES.Masks;
 using Content.Shared._ES.Nuke.Components;
 using Content.Shared._ES.Objectives;
+using Content.Shared._ES.Objectives.Components;
 using Content.Shared._ES.Sparks;
 using Content.Shared.Examine;
 using Content.Shared.Objectives.Components;
@@ -29,7 +30,7 @@ public abstract class ESSharedCryptoNukeSystem : EntitySystem
         SubscribeLocalEvent<ESCryptoNukeConsoleComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<ESCryptoNukeConsoleComponent, ExaminedEvent>(OnExamined);
 
-        SubscribeLocalEvent<ESCryptoNukeHackObjectiveComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+        SubscribeLocalEvent<ESCryptoNukeHackObjectiveComponent, ESGetObjectiveProgressEvent>(OnGetProgress);
 
         Subs.BuiEvents<ESCryptoNukeConsoleComponent>(ESCryptoNukeConsoleUiKey.Key,
             subs =>
@@ -50,7 +51,7 @@ public abstract class ESSharedCryptoNukeSystem : EntitySystem
         args.PushMarkup(Loc.GetString("es-cryptonuke-examine-compromised"));
     }
 
-    private void OnGetProgress(Entity<ESCryptoNukeHackObjectiveComponent> ent, ref ObjectiveGetProgressEvent args)
+    private void OnGetProgress(Entity<ESCryptoNukeHackObjectiveComponent> ent, ref ESGetObjectiveProgressEvent args)
     {
         args.Progress = GetCompromisedTerminalPercent();
     }
@@ -71,6 +72,7 @@ public abstract class ESSharedCryptoNukeSystem : EntitySystem
         ent.Comp.Compromised = true;
         Dirty(ent);
         UpdateUiState((ent, ent, Comp<UserInterfaceComponent>(ent)));
+        _objective.RefreshObjectiveProgress<ESCryptoNukeHackObjectiveComponent>();
     }
 
     protected virtual void UpdateUiState(Entity<ESCryptoNukeConsoleComponent, UserInterfaceComponent> ent)

--- a/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.Counter.cs
+++ b/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.Counter.cs
@@ -49,6 +49,18 @@ public abstract partial class ESSharedObjectiveSystem
     }
 
     /// <summary>
+    /// Adjusts the counter for all objectives with component <see cref="T"/>
+    /// </summary>
+    /// <param name="val">How much to add or remove from the counter</param>
+    public void AdjustObjectiveCounter<T>(float val = 1) where T : Component
+    {
+        foreach (var objective in GetObjectives<T>())
+        {
+            AdjustObjectiveCounter((objective.Owner, objective.Comp2), val);
+        }
+    }
+
+    /// <summary>
     /// Sets the counter for the objective to <see cref="val"/>
     /// </summary>
     /// <param name="ent">Objective entity</param>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

fixes #430

changes some objective stuff for refresh progress that i just noticed while trying to use the api
- api for refreshing all objs of a type
- api for adjusting counter of all objs of a type
- rename refreshprogress because i almost got trolled by it, i thought it would refresh progress of all objectives on an entity or something but it does something entirely different

cryptonuke was two things
- no refreshing after the hack happened
- was using the wrong getprogress event lol (afaict nothing else is accidentally using it so we good)

before hacking final
<img width="974" height="661" alt="image" src="https://github.com/user-attachments/assets/36f4b44f-7079-4b27-913e-377b25338ffa" />

after hacking final
<img width="1246" height="669" alt="image" src="https://github.com/user-attachments/assets/97fb931d-295f-4338-9bca-24f3a37ebe75" />
