### PR TITLE
Remove gibbing and ashing on damage

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/GibBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/GibBehavior.cs
@@ -14,6 +14,11 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
 
         public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
         {
+            // ES START
+            // no gib behavior on damage
+            return;
+            // ES END
+            
             if (system.EntityManager.TryGetComponent(owner, out BodyComponent? body))
             {
                 system.BodySystem.GibBody(owner, _recursive, body);

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -80,21 +80,28 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+    # ES START
+    # TODO ES eventually we should be using our own mob prototypes for this stuff
+    # which i think maybe exist already?
+    # comments out heat trigger threshold
+    # gib behavior is disabled in the thresholdbehavior itself, since we kinda dont ever want it on damage
+    # this is harder to disable that way, bc i dont want situations where it spawns ash and stuff repeatedly or something
+    #- trigger:
+    #    !type:DamageTypeTrigger
+    #    damageType: Heat
+    #    damage: 1500
+    #  behaviors:
+    #  - !type:SpawnEntitiesBehavior
+    #    spawnInContainer: true
+    #    spawn:
+    #      Ash:
+    #        min: 1
+    #        max: 1
+    #  - !type:BurnBodyBehavior { }
+    #  - !type:PlaySoundBehavior
+    #    sound:
+    #      collection: MeatLaserImpact
+    # ES END
     - trigger:
         !type:DamageTypeTrigger
         damageType: Radiation

--- a/Resources/Prototypes/_ESP/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/_ESP/Entities/Mobs/base.yml
@@ -11,23 +11,6 @@
   components:
   - type: Damageable
     damageContainer: Biological
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
   - type: RadiationReceiver
   - type: Stamina
   - type: MobState


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

this 1) isnt especially meaningful right now with no revival anyway and 2) would be better served by having our own mob prototypes which i imagine we'll eventually do for discomed (the ones right now seem placeholdery), but i wanted to get this out of the way because i never ever want gibbing to occur on damage (even for small mobs unless its like, a fly or cockroach or something and besides that isnt really gibbing). same with ashing. ss13 had the balance of these right where these were incredibly rare events that basically required gibber/meatspiking/large explosion/crematorium (for ashing)

ashing is still defined on vox iirc but we dont have vox so. this also removes it from the ES damageable mob prototype which is old and unused afaict but might as well.