### PR TITLE
Better lightglow override support on bulbs

### DIFF
--- a/Content.Client/Light/Visualizers/PoweredLightVisualsComponent.cs
+++ b/Content.Client/Light/Visualizers/PoweredLightVisualsComponent.cs
@@ -57,12 +57,4 @@ public sealed partial class PoweredLightVisualsComponent : Component
     public bool IsBlinking;
 
     #endregion Blinking
-
-    // ES START
-    /// <summary>
-    ///     Affects the alpha of the light glow layer.
-    /// </summary>
-    [DataField]
-    public float GlowAlpha = 1.0f;
-    // ES END
 }

--- a/Content.Shared/Light/Components/LightBulbComponent.cs
+++ b/Content.Shared/Light/Components/LightBulbComponent.cs
@@ -61,6 +61,14 @@ public sealed partial class LightBulbComponent : Component
     public int PowerUse = 20;
     // ES END
 
+    // ES START
+    /// <summary>
+    ///     Overrides the color used for the light glow overlay when this bulb is inserted into a fixture.
+    /// </summary>
+    [DataField]
+    public Color? GlowColorOverride = null;
+    // ES END
+
     /// <summary>
     /// The sound produced when the lightbulb breaks.
     /// </summary>

--- a/Resources/Prototypes/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/lights.yml
@@ -165,6 +165,7 @@
     lightEnergy: 0.5
     # ES START
     lightRadius: 4.0
+    glowColorOverride: "#ba473f33"
     # ES END
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -413,7 +413,6 @@
   - type: PoweredLight
     hasLampOnSpawn: DimLightBulb
   - type: PoweredLightVisuals
-    glowAlpha: 0.3
   - type: DamageOnInteract
     damage:
       types:

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -6,6 +6,7 @@
   components:
   - type: LightBulb
     color: "#ece2dd"
+    glowColorOverride: "#ffffff"
     lightEnergy: 1.45
     lightSoftness: 2
 
@@ -18,4 +19,5 @@
   components:
   - type: LightBulb
     color: "#929291"
+    glowColorOverride: "#dddddd"
     lightSoftness: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

removes my old glowalpha thing
allows fully overriding light glow layer color on bulbs
overrides the color for our basic lights so they stand out more compared to their actual glow color. i like how it looks better

<img width="550" height="843" alt="image" src="https://github.com/user-attachments/assets/9e18c6b5-73c6-4fcf-8c7d-58495e1999d0" />

