### PR TITLE
Adjust jobs on Toast

### DIFF
--- a/Resources/Prototypes/_ES/Maps/toast.yml
+++ b/Resources/Prototypes/_ES/Maps/toast.yml
@@ -18,12 +18,10 @@
           Captain: [ 1, 1 ]
           HeadOfPersonnel: [ 1, 1 ]
           HeadOfSecurity: [ 1, 1 ]
-          #service (6)
+          #service (4)
           Bartender: [ 1, 1 ]
           Botanist: [ 2, 2 ]
           Chef: [ 1, 1 ]
-          Janitor: [ 1, 1 ]
-          Reporter: [ 1, 1 ]
           #engineering (4)
           AtmosphericTechnician: [ 2, 2 ]
           StationEngineer: [ 2, 2 ]
@@ -37,8 +35,9 @@
           SecurityOfficer: [ 3, 3 ]
           Detective: [ 1, 1 ]
           #cargo (4)
-          SalvageSpecialist: [ 2, 2 ]
           CargoTechnician: [ 2, 2 ]
-          #civilian (3)
-          Passenger: [ 2, 2 ]
+          Janitor: [ 2, 2 ]
+          #civilian (2+)
           Clown: [ 1, 1 ]
+          Reporter: [ 1, 1 ]
+          Passenger: [ -1, -1 ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Removes all salvager job slots from Toast
- Adds a second janitor slot
- Makes assistant slots unlimited
- Shuffles around some jobs to be in more appropriate groupings

Closes #285 