### PR TITLE
Hide mindless theatergoers

### DIFF
--- a/Content.Client/_ES/Mind/ESMindVisualsSystem.cs
+++ b/Content.Client/_ES/Mind/ESMindVisualsSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared._ES.Mind;
+using Content.Shared._ES.Mind.Components;
+using Robust.Client.GameObjects;
+
+namespace Content.Client._ES.Mind;
+
+public sealed class ESMindVisualsSystem : ESSharedMindVisualsSystem
+{
+    [Dependency] private readonly SpriteSystem _sprite = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESMindVisualsComponent, AppearanceChangeEvent>(OnAppearanceChange);
+    }
+
+    private void OnAppearanceChange(Entity<ESMindVisualsComponent> ent, ref AppearanceChangeEvent args)
+    {
+        if (!Appearance.TryGetData<bool>(ent, ESMindVisuals.HasMind, out var hasMind))
+            hasMind = true;
+
+        if (!Appearance.TryGetData<bool>(ent, ESMindVisuals.InGame, out var inGame))
+            inGame = true;
+
+        _sprite.SetVisible(ent.Owner, inGame);
+        _sprite.SetColor(ent.Owner, hasMind ? Color.White : ent.Comp.NoMindColor);
+    }
+}

--- a/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
@@ -106,9 +106,11 @@ public sealed partial class MindTests
         Assert.Multiple(() =>
         {
             Assert.That(mind, Is.EqualTo(GetMind(pair)));
-            Assert.That(mind.Comp.CurrentEntity, Is.EqualTo(original));
+// ES START
+            Assert.That(mind.Comp.CurrentEntity, Is.EqualTo(ghost));
             Assert.That(entMan.Deleted(original), Is.False);
-            Assert.That(entMan.Deleted(ghost));
+            Assert.That(entMan.Deleted(ghost), Is.False);
+// ES END
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
@@ -28,7 +28,9 @@ public sealed partial class MindTests
         Assert.Multiple(() =>
         {
             Assert.That(GetMind(pair), Is.EqualTo(mind));
-            Assert.That(entMan.Deleted(ghost));
+// ES START
+            Assert.That(entMan.Deleted(ghost), Is.False);
+// ES END
             Assert.That(entMan.HasComponent<GhostComponent>(mind.Comp.OwnedEntity));
             Assert.That(mind.Comp.VisitingEntity, Is.Null);
         });

--- a/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
+++ b/Content.IntegrationTests/Tests/Minds/MindTests.ReconnectTests.cs
@@ -28,9 +28,7 @@ public sealed partial class MindTests
         Assert.Multiple(() =>
         {
             Assert.That(GetMind(pair), Is.EqualTo(mind));
-// ES START
-            Assert.That(entMan.Deleted(ghost), Is.False);
-// ES END
+            Assert.That(entMan.Deleted(ghost));
             Assert.That(entMan.HasComponent<GhostComponent>(mind.Comp.OwnedEntity));
             Assert.That(mind.Comp.VisitingEntity, Is.Null);
         });
@@ -108,11 +106,9 @@ public sealed partial class MindTests
         Assert.Multiple(() =>
         {
             Assert.That(mind, Is.EqualTo(GetMind(pair)));
-// ES START
-            Assert.That(mind.Comp.CurrentEntity, Is.EqualTo(ghost));
+            Assert.That(mind.Comp.CurrentEntity, Is.EqualTo(original));
             Assert.That(entMan.Deleted(original), Is.False);
-            Assert.That(entMan.Deleted(ghost), Is.False);
-// ES END
+            Assert.That(entMan.Deleted(ghost));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -264,7 +264,10 @@ namespace Content.Server.Ghost
 
         private void OnPlayerDetached(EntityUid uid, GhostComponent component, PlayerDetachedEvent args)
         {
-            DeleteEntity(uid);
+// ES START
+            // Don't let people jailbreak stagehands
+            //DeleteEntity(uid);
+// ES END
         }
 
         private void DeleteEntity(EntityUid uid)

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -265,8 +265,8 @@ namespace Content.Server.Ghost
         private void OnPlayerDetached(EntityUid uid, GhostComponent component, PlayerDetachedEvent args)
         {
 // ES START
-            // Don't let people jailbreak stagehands
-            //DeleteEntity(uid);
+            if (component.DeleteOnDetach)
+                DeleteEntity(uid);
 // ES END
         }
 

--- a/Content.Server/_ES/Mind/ESMindVisualsSystem.cs
+++ b/Content.Server/_ES/Mind/ESMindVisualsSystem.cs
@@ -1,0 +1,6 @@
+using Content.Shared._ES.Mind;
+
+namespace Content.Server._ES.Mind;
+
+/// <inheritdoc/>
+public sealed class ESMindVisualsSystem : ESSharedMindVisualsSystem;

--- a/Content.Shared/Ghost/GhostComponent.cs
+++ b/Content.Shared/Ghost/GhostComponent.cs
@@ -93,6 +93,10 @@ public sealed partial class GhostComponent : Component
     /// <remarks>Used to allow admins to change ghost colors. Should be removed if the capability to edit existing sprite colors is ever added back.</remarks>
     [DataField, AutoNetworkedField]
     public Color Color = Color.White;
+// ES START
+    [DataField]
+    public bool DeleteOnDetach = true;
+// ES END
 }
 
 public sealed partial class ToggleFoVActionEvent : InstantActionEvent { }

--- a/Content.Shared/_ES/Mind/Components/ESMindVisualsComponent.cs
+++ b/Content.Shared/_ES/Mind/Components/ESMindVisualsComponent.cs
@@ -1,0 +1,33 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Network;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._ES.Mind.Components;
+
+/// <summary>
+/// Denotes an entity which is given special visuals when
+/// the owning player has left the game or no longer occupies the body.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ESSharedMindVisualsSystem), Other = AccessPermissions.None)]
+public sealed partial class ESMindVisualsComponent : Component
+{
+    /// <summary>
+    /// The user that this entity is tied to. can be null.
+    /// </summary>
+    [DataField]
+    public NetUserId? AssociatedUser;
+
+    /// <summary>
+    /// Color to set the entity to when no mind is present
+    /// </summary>
+    [DataField]
+    public Color NoMindColor = Color.FromHex("#6c7da088");
+}
+
+[Serializable, NetSerializable]
+public enum ESMindVisuals : byte
+{
+    HasMind,
+    InGame,
+}

--- a/Content.Shared/_ES/Mind/ESSharedMindVisualsSystem.cs
+++ b/Content.Shared/_ES/Mind/ESSharedMindVisualsSystem.cs
@@ -1,0 +1,44 @@
+using Content.Shared._ES.Mind.Components;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
+
+namespace Content.Shared._ES.Mind;
+
+public abstract class ESSharedMindVisualsSystem : EntitySystem
+{
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESMindVisualsComponent, PlayerAttachedEvent>(OnAttached);
+        SubscribeLocalEvent<ESMindVisualsComponent, PlayerDetachedEvent>(OnDetached);
+
+        _player.PlayerStatusChanged += OnStatusChanged;
+    }
+
+    private void OnAttached(Entity<ESMindVisualsComponent> ent, ref PlayerAttachedEvent args)
+    {
+        ent.Comp.AssociatedUser = args.Player.UserId;
+        Appearance.SetData(ent, ESMindVisuals.HasMind, true);
+    }
+
+    private void OnDetached(Entity<ESMindVisualsComponent> ent, ref PlayerDetachedEvent args)
+    {
+        Appearance.SetData(ent, ESMindVisuals.HasMind, false);
+    }
+
+    private void OnStatusChanged(object? sender, SessionStatusEventArgs args)
+    {
+        var newInGame = args.NewStatus == SessionStatus.InGame;
+
+        var query = EntityQueryEnumerator<ESMindVisualsComponent, AppearanceComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var appearance))
+        {
+            if (comp.AssociatedUser != args.Session.UserId)
+                continue;
+            Appearance.SetData(uid, ESMindVisuals.InGame, newInGame, appearance);
+        }
+    }
+}

--- a/Resources/Prototypes/_ES/Entities/Mobs/Player/stagehand.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Player/stagehand.yml
@@ -27,6 +27,7 @@
   - type: Ghost # TODO: reason about the implications of this
     toggleLightingAction: ESActionStagehandChangeLighting
     toggleFoVAction: ESActionStagehandToggleFOV
+    deleteOnDetach: false
   - type: ESStagehand
   - type: ESUsernameEntityName
   - type: ESMindVisuals

--- a/Resources/Prototypes/_ES/Entities/Mobs/Player/stagehand.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Player/stagehand.yml
@@ -29,6 +29,7 @@
     toggleFoVAction: ESActionStagehandToggleFOV
   - type: ESStagehand
   - type: ESUsernameEntityName
+  - type: ESMindVisuals
   - type: ESBlockInteraction
   - type: ShowElectrocutionHUD
   - type: ShowAntagIcons

--- a/Resources/Prototypes/_ES/Entities/Mobs/Player/theatergoer.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Player/theatergoer.yml
@@ -26,6 +26,7 @@
   - type: Examiner
   - type: ESTheatergoerMarker
   - type: ESUsernameEntityName
+  - type: ESMindVisuals
   - type: Buckle
   - type: Hands
     hands:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
closes #428 

- disconnected theatergoers/stagehands are invisible
- theatergoers that are in-round are made transparent
- fixed being able to escape stagehandhood

<img width="607" height="631" alt="image" src="https://github.com/user-attachments/assets/a2c41c35-e322-41f7-acc3-c5aac227bd58" />
