### PR TITLE
Add entityTable support for vendors

### DIFF
--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -14,7 +14,10 @@ namespace Content.Shared.VendingMachines
         /// PrototypeID for the vending machine's inventory, see <see cref="VendingMachineInventoryPrototype"/>
         /// </summary>
         // Okay so not using ProtoId here is load-bearing because the ProtoId serializer will log errors if the prototype doesn't exist.
-        [DataField("pack", customTypeSerializer: typeof(PrototypeIdSerializer<VendingMachineInventoryPrototype>), required: true)]
+// ES START
+        // mark pack protoId as not required
+        [DataField("pack", customTypeSerializer: typeof(PrototypeIdSerializer<VendingMachineInventoryPrototype>), required: false)]
+// ES END
         public string PackPrototypeId = string.Empty;
 
         /// <summary>

--- a/Content.Shared/_ES/EntityTable/Components/ESEntityTableVendorFillComponent.cs
+++ b/Content.Shared/_ES/EntityTable/Components/ESEntityTableVendorFillComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.VendingMachines;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.EntityTable.Components;
+
+/// <summary>
+/// Works with <see cref="VendingMachineComponent"/> to fill the inventory based on an entity table.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(ESEntityTableVendorFillSystem))]
+public sealed partial class ESEntityTableVendorFillComponent : Component
+{
+    /// <summary>
+    /// Items that will be added to <see cref="VendingMachineComponent.Inventory"/> on MapInit.
+    /// </summary>
+    [DataField]
+    public EntityTableSelector Inventory = new NoneSelector();
+}

--- a/Content.Shared/_ES/EntityTable/ESEntityTableVendorFillSystem.cs
+++ b/Content.Shared/_ES/EntityTable/ESEntityTableVendorFillSystem.cs
@@ -1,0 +1,38 @@
+using System.Linq;
+using Content.Shared._ES.EntityTable.Components;
+using Content.Shared.EntityTable;
+using Content.Shared.VendingMachines;
+
+namespace Content.Shared._ES.EntityTable;
+
+/// <summary>
+/// This handles <see cref="ESEntityTableVendorFillComponent"/>
+/// </summary>
+public sealed class ESEntityTableVendorFillSystem : EntitySystem
+{
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESEntityTableVendorFillComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<ESEntityTableVendorFillComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<VendingMachineComponent>(ent, out var vendingMachine))
+        {
+            throw new Exception($"{nameof(VendingMachineComponent)} not found, required for usage with {nameof(ESEntityTableVendorFillComponent)}");
+        }
+
+        var items = _entityTable.GetSpawns(ent.Comp.Inventory)
+            .GroupBy(n => n)
+            .Select(g => (g.Key, (uint) g.Count()));
+
+        foreach (var (entProtoId, count) in items)
+        {
+            vendingMachine.Inventory.Add(entProtoId, new VendingMachineInventoryEntry(InventoryType.Regular, entProtoId, count));
+        }
+        Dirty(ent, vendingMachine);
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
wanted this for meme vendors, figured it'd be easy to put together. It was.

just adds a new component that lets us specify a vendor fill as an entity table.