### PR TITLE
Disable ghost role menu

### DIFF
--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -35,6 +35,9 @@ using Content.Shared.Verbs;
 using Robust.Shared.Collections;
 using Content.Shared.Ghost.Roles.Components;
 using Content.Shared.Roles.Components;
+// ES START
+using Content.Server.Administration;
+// ES END
 
 namespace Content.Server.Ghost.Roles;
 
@@ -918,7 +921,10 @@ public sealed class GhostRoleSystem : EntitySystem
     }
 }
 
-[AnyCommand]
+// ES START
+//[AnyCommand]
+[AdminCommand(AdminFlags.Debug)]
+// ES END
 public sealed class GhostRoles : IConsoleCommand
 {
     [Dependency] private readonly IEntityManager _e = default!;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Closes #395 

they already can't open the menu so this just removed the command for doing it