### PR TITLE
Debloat vending machine YAML

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/vending.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/vending.yml
@@ -1,24 +1,11 @@
+# Base vending machine prototype
 - type: entity
   parent: VendingMachine
-  id: ESVendingMachineCigs
-  name: ShadyCigs Deluxe
-  description: If you want to get cancer, might as well do it in style.
+  id: ESBaseVendingMachine
+  suffix: ES
+  abstract: true
   components:
-  - type: VendingMachine
-    pack: CigaretteMachineInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
-  - type: DatasetVocalizer
-    dataset: CigaretteMachineAds
-  - type: SpeakOnUIClosed
-    pack: CigaretteMachineGoodbyes
   - type: Sprite
-    sprite: _ES/Structures/Vendors/cigs.rsi
     layers:
     - state: "off"
       map: ["enum.VendingMachineVisualLayers.Base"]
@@ -27,29 +14,47 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
-
-- type: entity
-  parent: VendingMachine
-  id: ESVendingMachineCoffee
-  name: Solar's Best Hot Drinks
-  description: Served boiling so it stays hot all shift!
-  components:
   - type: VendingMachine
-    pack: HotDrinksMachineInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
     offState: off
     brokenState: broken
     normalState: normal-unshaded
     ejectState: normal-unshaded
     denyState: deny-unshaded
-    ejectDelay: 5
-    soundVend: /Audio/Machines/machine_vend_hot_drink.ogg
-    initialStockQuality: 0.33
+  - type: PointLight
+    radius: 1.5
+    energy: 3.0
+
+# Variant that dispenses goods on hit
+- type: entity
+  parent: ESBaseVendingMachine
+  id: ESBaseVendingMachineDispenseOnHit
+  abstract: true
+  components:
+  - type: VendingMachine
+    dispenseOnHitChance: 0.25
+    dispenseOnHitThreshold: 2
+
+- type: entity
+  parent: ESBaseVendingMachineDispenseOnHit
+  id: ESVendingMachineCigs
+  name: ShadyCigs Deluxe
+  description: If you want to get cancer, might as well do it in style.
+  components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/cigs.rsi
+  - type: VendingMachine
+    pack: CigaretteMachineInventory
   - type: DatasetVocalizer
-    dataset: HotDrinksMachineAds
+    dataset: CigaretteMachineAds
   - type: SpeakOnUIClosed
-    pack: HotDrinksMachineGoodbyes
+    pack: CigaretteMachineGoodbyes
+
+- type: entity
+  parent: ESBaseVendingMachineDispenseOnHit
+  id: ESVendingMachineCoffee
+  name: Solar's Best Hot Drinks
+  description: Served boiling so it stays hot all shift!
+  components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/coffee.rsi
     layers:
@@ -63,291 +68,149 @@
       shader: unshaded
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: HotDrinksMachineInventory
+    ejectDelay: 5
+    soundVend: /Audio/Machines/machine_vend_hot_drink.ogg
+    initialStockQuality: 0.33
+  - type: DatasetVocalizer
+    dataset: HotDrinksMachineAds
+  - type: SpeakOnUIClosed
+    pack: HotDrinksMachineGoodbyes
   - type: PointLight
-    radius: 1.5
-    energy: 1.3
+    energy: 2.0
     color: "#ad7c4b"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachineDispenseOnHit
   id: ESVendingMachineCola
   name: Robust Softdrinks
   description: A softdrink vendor provided by Robust Industries, LLC.
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/cola.rsi
   - type: VendingMachine
     pack: RobustSoftdrinksInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
     ejectDelay: 1.9
     initialStockQuality: 0.33
   - type: DatasetVocalizer
     dataset: RobustSoftdrinksAds
   - type: SpeakOnUIClosed
     pack: RobustSoftdrinksGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/cola.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#3c5eb5"
 
 - type: entity
-  parent: VendingMachineCola
+  parent: ESVendingMachineCola
   id: ESVendingMachineColaBlack
-  suffix: Black
+  suffix: ES, Black
   components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/cola-black.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#423438"
 
 - type: entity
-  parent: VendingMachineCola
+  parent: ESVendingMachineCola
   id: ESVendingMachineColaRed
   name: Space Cola Vendor
   description: It vends cola, in space.
   components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/cola-red.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#A50824"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineEngivend
   name: Engi-Vend
   description: Spare tool vending. What? Did you expect some witty description?
   components:
-  - type: VendingMachine
-    pack: EngiVendInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: Sprite
     sprite: _ES/Structures/Vendors/engivend.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: EngiVendInventory
   - type: AccessReader
     access: [["Engineering"]]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#b89e2a"
 
-
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineVendomat
   name: Vendomat
   description: Only the finest robust equipment in space!
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/vendomat.rsi
   - type: VendingMachine
     pack: VendomatInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: DatasetVocalizer
     dataset: VendomatAds
   - type: SpeakOnUIClosed
     pack: GenericVendGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/vendomat.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#9dc5c9"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineYouTool
   name: YouTool
   description: "A vending machine containing standard tools. A label reads: Tools for tools."
   components:
-  - type: VendingMachine
-    pack: YouToolInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: Sprite
     sprite: _ES/Structures/Vendors/youtool.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: YouToolInventory
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#d4ab33"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineSeedsUnlocked
   name: MegaSeed Servitor
   description: For when you need seeds fast. Hands down the best seed selection on the station!
-  suffix: Unlocked
+  suffix: ES, Unlocked
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/seeds.rsi
   - type: VendingMachine
     pack: MegaSeedServitorInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: DatasetVocalizer
     dataset: MegaSeedAds
   - type: SpeakOnUIClosed
     pack: GenericVendGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/seeds.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#326e3f"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineNutri
   name: NutriMax
   description: A vending machine containing nutritional substances for plants and botanical tools.
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/nutri.rsi
   - type: VendingMachine
     pack: NutriMaxInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: DatasetVocalizer
     dataset: NutriMaxAds
   - type: SpeakOnUIClosed
     pack: NutriMaxGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/nutri.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Hydroponics"]]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#326e3f"
 
 - type: entity
-  parent: VendingMachineSnack
-  id: ESVendingMachineSustenance
-  name: Sustenance Vendor
-  description: A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement.
-  components:
-  - type: VendingMachine
-    pack: SustenanceInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/sustenance.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#737785"
-
-- type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachineDispenseOnHit
   id: ESVendingMachineSnack
   name: Getmore Chocolate Corp
   description: A snack machine courtesy of the Getmore Chocolate Corporation, based out of Mars.
   components:
   - type: VendingMachine
     pack: GetmoreChocolateCorpInventory
-    dispenseOnHitChance: 0.25
-    dispenseOnHitThreshold: 2
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
     initialStockQuality: 0.33
   - type: DatasetVocalizer
     dataset: GetmoreChocolateCorpAds
@@ -355,214 +218,131 @@
     pack: GetmoreChocolateCorpGoodbyes
   - type: Sprite
     sprite: _ES/Structures/Vendors/snack.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#c73434"
 
 - type: entity
-  parent: VendingMachineSnack
+  parent: ESVendingMachineSnack
   id: ESVendingMachineSnackBlue
-  suffix: Blue
+  suffix: ES, Blue
   components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/snack-blue.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#3c5eb5"
 
 - type: entity
-  parent: VendingMachineSnack
+  parent: ESVendingMachineSnack
   id: ESVendingMachineSnackOrange
-  suffix: Orange
+  suffix: ES, Orange
   components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/snack-orange.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#CE3401"
 
 - type: entity
-  parent: VendingMachineSnack
+  parent: ESVendingMachineSnack
   id: ESVendingMachineSnackGreen
-  suffix: Green
+  suffix: ES, Green
   components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/snack-green.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#5F6A1C"
 
 - type: entity
-  parent: VendingMachineSnack
+  parent: ESVendingMachineSnack
   id: ESVendingMachineSnackTeal
-  suffix: Teal
+  suffix: ES, Teal
   components:
   - type: Sprite
     sprite: _ES/Structures/Vendors/snack-teal.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#207E79"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESVendingMachineSnack
+  id: ESVendingMachineSustenance
+  name: Sustenance Vendor
+  description: A vending machine which vends food, as required by section 47-C of the NT's Prisoner Ethical Treatment Agreement.
+  components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/sustenance.rsi
+  - type: VendingMachine
+    pack: SustenanceInventory
+  - type: PointLight
+    color: "#737785"
+
+- type: entity
+  parent: ESBaseVendingMachine
   id: ESVendingMachineDinnerware
   name: Plasteel Chef's Dinnerware Vendor
   description: A kitchen and restaurant equipment vendor.
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/dinnerware.rsi
   - type: VendingMachine
     pack: DinnerwareInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    denyState: deny-unshaded
-    ejectState: normal-unshaded
   - type: DatasetVocalizer
     dataset: DinnerwareAds
   - type: SpeakOnUIClosed
     pack: GenericVendGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/dinnerware.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Kitchen"]]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#4b93ad"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineGames
   name: Good Clean Fun
   description: Vends things that the Captain and Head of Personnel are probably not going to appreciate you fiddling with instead of your job...
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/games.rsi
   - type: VendingMachine
     pack: GoodCleanFunInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
     ejectDelay: 1.8
   - type: DatasetVocalizer
     dataset: GoodCleanFunAds
   - type: SpeakOnUIClosed
     pack: GoodCleanFunGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/games.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#326e3f"
 
 - type: entity
-  parent: VendingMachineMedicalBase
+  parent: ESBaseVendingMachine
   id: ESVendingMachineMedical
   name: NanoMed Plus
   description: It's a medical drug dispenser. Natural chemicals only!
   components:
-  - type: VendingMachine
-    pack: NanoMedPlusInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
   - type: Sprite
     sprite: _ES/Structures/Vendors/medical.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: NanoMedPlusInventory
+    ejectDelay: 0.6
+  - type: DatasetVocalizer
+    dataset: NanoMedAds
+  - type: SpeakOnUIClosed
+    pack: GenericVendGoodbyes
   - type: AccessReader
     access: [["Medical"]]
+  - type: GuideHelp
+    guides:
+    - MedicalDoctor
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineChemicals
   name: ChemVend
   description: Probably not the coffee machine.
   components:
-  - type: VendingMachine
-    pack: ChemVendInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
-    ejectDelay: 2
   - type: Sprite
     sprite: _ES/Structures/Vendors/chemvend.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: ChemVendInventory
+    ejectDelay: 2
   - type: AccessReader
     access: [["Chemistry"]]
   - type: GuideHelp
@@ -571,68 +351,39 @@
     - Chemist
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineSec
   name: SecTech
   description: A vending machine containing Security equipment. A label reads SECURITY PERSONNEL ONLY.
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/sec.rsi
   - type: VendingMachine
     pack: SecTechInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: DatasetVocalizer
     dataset: SecTechAds
   - type: SpeakOnUIClosed
     pack: SecTechGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/sec.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Security"]]
   - type: PointLight
-    radius: 1
-    energy: 1.2
+    energy: 3.0
     color: "#78645c"
   - type: GuideHelp
     guides:
     - Security
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineSalvage
   name: Salvage Vendor
   description: A dwarf's best friend!
   components:
-  - type: VendingMachine
-    pack: SalvageEquipmentInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: Sprite
     sprite: _ES/Structures/Vendors/mining.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: SalvageEquipmentInventory
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#b89f25"
   - type: AccessReader
     access: [["Salvage"]]
@@ -641,102 +392,58 @@
     - Salvage
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineChefvend
   name: ChefVend
   description: An ingredient vendor for all your cheffin needs.
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/chefvend.rsi
   - type: VendingMachine
     pack: ChefvendInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: DatasetVocalizer
     dataset: ChefvendAds
   - type: SpeakOnUIClosed
     pack: ChefvendGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/chefvend.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Service"]]
   - type: PointLight
-    radius: 1.5
-    energy: 1.6
     color: "#4b93ad"
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineCart
   name: PTech
   description: PTech vending! Providing a ROBUST selection of PDAs, cartridges, and anything else a dull paper pusher needs!
   components:
-  - type: VendingMachine
-    pack: PTechInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: Sprite
     sprite: _ES/Structures/Vendors/cart.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: VendingMachine
+    pack: PTechInventory
   - type: PointLight
-    radius: 1
-    energy: 1.3
+    energy: 2.0
     color: "#ffb0b0"
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
 
 - type: entity
-  parent: VendingMachine
+  parent: ESBaseVendingMachine
   id: ESVendingMachineRobotics
   name: Robotech Deluxe
   description: All the tools you need to create your own robot army.
   components:
+  - type: Sprite
+    sprite: _ES/Structures/Vendors/robotics.rsi
   - type: VendingMachine
     pack: RoboticsInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    ejectState: normal-unshaded
-    denyState: deny-unshaded
   - type: DatasetVocalizer
     dataset: VendomatAds
   - type: SpeakOnUIClosed
     pack: GenericVendGoodbyes
-  - type: Sprite
-    sprite: _ES/Structures/Vendors/robotics.rsi
-    layers:
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.Base"]
-    - state: "off"
-      map: ["enum.VendingMachineVisualLayers.BaseUnshaded"]
-      shader: unshaded
-    - state: panel
-      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: PointLight
+    color: "#B0ADA9"
   - type: AccessReader
     access: [["Research"]]
-  - type: PointLight
-    radius: 1.5
-    energy: 1.6
-    color: "#B0ADA9"
   - type: GuideHelp
     guides:
     - Robotics


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I was _going_ to convert these to entityTables but i got rotated when i saw that the vending machine YAML has insane copypaste from the upstream one.

fixes the pointlight values since we never inherited the fixed ones from upstream.
additionally fixes some weird parenting where ES vendors would inherit from an upstream vendor instead of their respective ES variant