### PR TITLE
Artificially boost alliteration in name generation

### DIFF
--- a/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.Appearance.cs
+++ b/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.Appearance.cs
@@ -186,7 +186,7 @@ public abstract partial class ESSharedAuditionsSystem
     private const float PrefixFirstNameless = 0.5f;
     private const float LastNameless = 0.009f;
     private const float FirstNameless = 0.006f;
-    private const int AlliterationExtraChances = 6;
+    private const int AlliterationTotalChances = 6;
 
     private static readonly ProtoId<LocalizedDatasetPrototype> ParticleDataset = "ESNameParticle";
     private static readonly ProtoId<LocalizedDatasetPrototype> SuffixDataset = "ESNameSuffix";
@@ -219,7 +219,7 @@ public abstract partial class ESSharedAuditionsSystem
         // and if we generate an alliterative name, then we stop. otherwise, we just
         // take the last one that got generated
         var lastName = string.Empty;
-        for (var i = 0; i < AlliterationExtraChances; i++)
+        for (var i = 0; i < AlliterationTotalChances; i++)
         {
             lastName = LastName(lastNameDataSet);
             if (firstName.First() == lastName.First())

--- a/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.Appearance.cs
+++ b/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.Appearance.cs
@@ -186,6 +186,7 @@ public abstract partial class ESSharedAuditionsSystem
     private const float PrefixFirstNameless = 0.5f;
     private const float LastNameless = 0.009f;
     private const float FirstNameless = 0.006f;
+    private const int AlliterationExtraChances = 6;
 
     private static readonly ProtoId<LocalizedDatasetPrototype> ParticleDataset = "ESNameParticle";
     private static readonly ProtoId<LocalizedDatasetPrototype> SuffixDataset = "ESNameSuffix";
@@ -211,7 +212,19 @@ public abstract partial class ESSharedAuditionsSystem
         var prefix = Prefix(profile.Gender);
         var suffix = Suffix();
         var firstName = FirstName(firstNameDataSet);
-        var lastName = LastName(lastNameDataSet);
+
+        // when generating the lastname, we want to artificially boost the chance
+        // that alliteration happens, because alliteration is usually really funny
+        // we do this by essentially just generating the last name a few extra times
+        // and if we generate an alliterative name, then we stop. otherwise, we just
+        // take the last one that got generated
+        var lastName = string.Empty;
+        for (var i = 0; i < AlliterationExtraChances; i++)
+        {
+            lastName = LastName(lastNameDataSet);
+            if (firstName.First() == lastName.First())
+                break;
+        }
 
         if (prefix != string.Empty && _random.Prob(PrefixFirstNameless))
             firstName = string.Empty;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

title and code self explanatory

sample with it boosted even further than this **(30 total chances)**:
```
> cast:generateNames 5
Yara Hayden Yuiry,
L.K. Loveletter,
Ramba Ringer,
Bink Bashline,
Desmond Dumpp
```

sample with the value in this PR (6 total chances)
```
> cast:generateNames 60                                                                                                                                                                                                                                            
Sage "Irvine" Cartridge,
Trolley Spock,
Cucuruz Stugatz,
Angelica S. Emoticon,
Destiny C. Station-Forer,
Riku Seelig,
May le Merryman,
Alex Database,
Abby Cephei,
Accessibility,
Vega Dumpp,
Peregrine Snickerdoodle,
July "Velcro" Jekyll,
Usurgia Gyo,
T.B. McDichael,
Cosmo Cobbler,
Mx. Christman,
Boston Juckport,
Aurora Party,
Ricardo A. Rathen,
Plip Bargain,
Marvin Jorts,
Ninel Yang-Jones,
Nix Chauvin,
Elpeo Ewing,
Lexus Londe,
Corey Ming,
Procyon Persei,
Karla Swabey Ph.D,
Travis "Spikes" Pavlov,
Mirai Grille,
Trud Champion,
Hail Wigglefish,
R.R. Reddit,
Margarine Laser,
Hyperion Corleone,
Maximus Laborde,
Macey Moon Sr.,
Ariana Hyde,
Christian Ditweed,
Natasha Wong,
London Nights-Garland,
Dakota Wentzel,
Plonk Chauvin-Caldwell,
A.H. Ewing,
Happy Gregory,
Donut Decimal,
Doctor Caldwell,
Best Parallax,
Mouar Pembroke,
Ljot Mangosteen,
Angie "Faye" van Mortland,
Leland Kanaga,
Warner Woodward,
Fratuda Siltstrider,
Doc Stanley S. McDonalds,
Jeff Jowers,
Snack Cox,
Aurora Station,
Griffin Upload
```

10 total alliterative names out of 60, so quite a step up from ~1/26 (not really 1/26 because we dont have equal distribution of first letters in names but)