### PR TITLE
Change fires to use TileEmission

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Effects/tile_fires.yml
+++ b/Resources/Prototypes/_ES/Entities/Effects/tile_fires.yml
@@ -28,14 +28,6 @@
     layers:
     - map: [ "base" ]
       state: red_1
-  - type: PointLight
-    netsync: false
-    radius: 1.6
-    energy: 12
-    falloff: 3
-    curveFactor: 1.0
-    castShadows: false
-    color: "#bf6d02"
   - type: ESTileFire
   - type: ActiveEdgeSpreader
   - type: EdgeSpreader
@@ -68,21 +60,9 @@
     sound:
       path: /Audio/Ambience/Objects/fireplace.ogg
   - type: Appearance
-  - type: ESGenericPointLightVisualizer
-    visuals:
-      enum.FireVisuals.FireStacks:
-        0:
-          energy: 12
-          radius: 1.6
-        1:
-          energy: 16
-          radius: 2.0
-        2:
-          energy: 20
-          radius: 2.0
-        3:
-          energy: 30
-          radius: 2.0
+  - type: TileEmission
+    range: 0.5
+    color: "#bf6d02"
   - type: GenericVisualizer
     visuals:
       enum.FireVisuals.FireStacks:

--- a/Resources/Prototypes/_ES/Entities/Effects/tile_fires.yml
+++ b/Resources/Prototypes/_ES/Entities/Effects/tile_fires.yml
@@ -28,6 +28,7 @@
     layers:
     - map: [ "base" ]
       state: red_1
+      shader: unshaded
   - type: ESTileFire
   - type: ActiveEdgeSpreader
   - type: EdgeSpreader
@@ -61,8 +62,7 @@
       path: /Audio/Ambience/Objects/fireplace.ogg
   - type: Appearance
   - type: TileEmission
-    range: 0.5
-    color: "#bf6d02"
+    color: "#fc9003"
   - type: GenericVisualizer
     visuals:
       enum.FireVisuals.FireStacks:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
dear god the lighting budget

OLD:
<img width="2255" height="976" alt="image" src="https://github.com/user-attachments/assets/da3e6fef-f9b5-42f1-a64e-3460dcd1d5a5" />

NEW:
<img width="1890" height="1276" alt="image" src="https://github.com/user-attachments/assets/6f622855-76f2-433f-a668-b1ff03b59fab" />

this is a bit less intense but maybe it's still good? I could go in and add some manual code that adjusts the range and color on TileEmission if that's wanted. I want mirrors opinion on it tho, since it's really her ballpack and the general effect of increasing energy can't be replicated with this method.