### PR TITLE
Test tweaks

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -20,7 +20,11 @@ namespace Content.IntegrationTests.Tests
     {
         private static readonly ProtoId<EntityCategoryPrototype> SpawnerCategory = "Spawner";
 
-        [Test]
+        // ES START
+        // SpawnAndDirtyAllEntities does literally the same thing, but with more checks
+        // this doesnt need to be two separate tests
+        // [Test]
+        // ES END
         public async Task SpawnAndDeleteAllEntitiesOnDifferentMaps()
         {
             // This test dirties the pair as it simply deletes ALL entities when done. Overhead of restarting the round

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -225,9 +225,12 @@ namespace Content.IntegrationTests.Tests
         /// the original entity is gone.
         ///
         /// Note that this isn't really a strict requirement, and there are probably quite a few edge cases. Its a pretty
-        /// crude test to try catch issues like this, and possibly should just be disabled.
+        /// crude test to try catch issues like this, and possibly should just be disabled. // aye aye captain
         /// </remarks>
-        [Test]
+        // ES START
+        // this test really does not catch anything useful -- yes, unsurprisingly, entities will want to spawn other entities sometimes
+        // [Test]
+        // ES END
         public async Task SpawnAndDeleteEntityCountTest()
         {
             var settings = new PoolSettings { Connected = true, Dirty = true };

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -514,7 +514,10 @@ namespace Content.IntegrationTests.Tests
             return resultCount;
         }
 
-        [Test]
+        // ES START
+        // we are deliberately removing maps from tests, this is not a meaningful test anymore
+        // [Test]
+        // ES END
         public async Task AllMapsTested()
         {
             await using var pair = await PoolManager.GetServerClient();

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -90,10 +90,10 @@ namespace Content.IntegrationTests.Tests
 
         private static readonly string[] GameMaps =
         {
-// ES START
+            // ES START
             "ESTestMap",
             "ESToast",
-// ES END
+            /*
             "Dev",
             "TestTeg",
             "Fland",
@@ -112,6 +112,8 @@ namespace Content.IntegrationTests.Tests
             "dm01-entryway",
             "Exo",
             "Snowball",
+            */
+            // ES END
         };
 
         private static readonly ProtoId<EntityCategoryPrototype> DoNotMapCategory = "DoNotMap";

--- a/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
+++ b/Content.IntegrationTests/Tests/Power/StationPowerTests.cs
@@ -21,6 +21,10 @@ public sealed class StationPowerTests
 
     private static readonly string[] GameMaps =
     [
+        // ES START
+        // test toast, dont test upstream maps
+        "ESToast",
+        /*
         "Bagel",
         "Box",
         "Elkridge",
@@ -33,6 +37,8 @@ public sealed class StationPowerTests
         "Snowball",
         "Reach",
         "Exo",
+        */
+        // ES END
     ];
 
     [Explicit]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

disables `SpawnAndDeleteEntityCountTest` (tilefire heisentest and it is not testing anything relevant anyway)

disables `SpawnAndDeleteAllEntitiesOnDifferentMaps` because `SpawnAndDirtyAllEntities` literally does the exact same thing but with more checks, and the comment on that test even notes this

removes upstream maps from `StationPowerTests` and `PostMapInitTest`