### PR TITLE
Remove radio falloff from headsets

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets.yml
@@ -26,9 +26,6 @@
   - type: GuideHelp
     guides:
     - Radio
-# ES START
-  - type: ESRadioFalloff
-# ES END
 
 - type: entity
   parent: ClothingHeadset


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Every early ES mechanic is like "I made a system to fuck over some gameplay for something I went on to completely kill"

radio falloff is basically pointless cuz you're never off-station in ES. It's just annoying and inconsistent and makes dept. radios suck for no reason.