### PR TITLE
Fix disappearing objectives

### DIFF
--- a/Content.Server/_ES/Masks/Objectives/Relays/ESDamageTakerRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESDamageTakerRelaySystem.cs
@@ -1,5 +1,6 @@
 using Content.Server._ES.Masks.Objectives.Relays.Components;
 using Content.Server.Mind;
+using Content.Shared._ES.Mind;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;

--- a/Content.Server/_ES/Masks/Objectives/Relays/ESKilledRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESKilledRelaySystem.cs
@@ -1,6 +1,7 @@
 using Content.Server._ES.Masks.Objectives.Relays.Components;
 using Content.Server.KillTracking;
 using Content.Server.Mind;
+using Content.Shared._ES.Mind;
 
 namespace Content.Server._ES.Masks.Objectives.Relays;
 

--- a/Content.Server/_ES/Masks/Objectives/Relays/ESMobStateRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESMobStateRelaySystem.cs
@@ -1,5 +1,6 @@
 using Content.Server._ES.Masks.Objectives.Relays.Components;
 using Content.Server.Mind;
+using Content.Shared._ES.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 

--- a/Content.Server/_ES/Masks/Objectives/Relays/ESMuncherRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESMuncherRelaySystem.cs
@@ -1,7 +1,7 @@
 using Content.Server._ES.Masks.Objectives.Relays.Components;
 using Content.Server.Mind;
+using Content.Shared._ES.Mind;
 using Content.Shared.Chemistry.Components;
-using Content.Shared.Mind;
 using Content.Shared.Nutrition;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Nutrition.EntitySystems;

--- a/Content.Shared/_ES/Mind/ESBaseMindRelay.cs
+++ b/Content.Shared/_ES/Mind/ESBaseMindRelay.cs
@@ -1,19 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared._ES.Objectives;
 using Content.Shared.Mind;
 
-namespace Content.Server._ES.Masks.Objectives.Relays;
+namespace Content.Shared._ES.Mind;
 
 /// <summary>
 ///     This provides a base class for mind relays and handles raising events on both the mind, and its objectives.
 /// </summary>
 public abstract class ESBaseMindRelay : EntitySystem
 {
+    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly ESSharedObjectiveSystem _objective = default!;
+
+    protected bool TryGetMind(EntityUid body, [NotNullWhen(true)] out Entity<MindComponent>? mind)
+    {
+        mind = null;
+        if (!_mind.TryGetMind(body, out var mindId, out var mindComp))
+            return false;
+
+        mind = (mindId, mindComp);
+        return true;
+    }
 
     /// <summary>
     ///     Raises the given by-ref event on the mind, and all of its objectives.
     /// </summary>
-    public void RaiseMindEvent<TEvent>(Entity<MindComponent> mind, ref TEvent ev) where TEvent : notnull
+    protected void RaiseMindEvent<TEvent>(Entity<MindComponent> mind, ref TEvent ev) where TEvent : notnull
     {
         RaiseLocalEvent(mind, ref ev);
 
@@ -26,7 +38,7 @@ public abstract class ESBaseMindRelay : EntitySystem
     /// <summary>
     ///     Raises the given by-value event on the mind, and all of its objectives.
     /// </summary>
-    public void RaiseMindEvent<TEvent>(Entity<MindComponent> mind, TEvent ev) where TEvent : notnull
+    protected void RaiseMindEvent<TEvent>(Entity<MindComponent> mind, TEvent ev) where TEvent : notnull
     {
         RaiseLocalEvent(mind, ev);
 

--- a/Content.Shared/_ES/Mind/ESPlayerStatusRelaySystem.cs
+++ b/Content.Shared/_ES/Mind/ESPlayerStatusRelaySystem.cs
@@ -1,0 +1,46 @@
+using Content.Shared.Mind.Components;
+using Robust.Shared.Player;
+
+namespace Content.Shared._ES.Mind;
+
+public sealed class ESPlayerStatusRelaySystem : ESBaseMindRelay
+{
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MindContainerComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<MindContainerComponent, PlayerDetachedEvent>(OnPlayerDetached);
+    }
+
+    private void OnPlayerAttached(Entity<MindContainerComponent> ent, ref PlayerAttachedEvent args)
+    {
+        if (!TryGetMind(ent, out var mind))
+            return;
+
+        var ev = new ESMindPlayerAttachedEvent(args.Entity, args.Player);
+        RaiseMindEvent(mind.Value, ref ev);
+    }
+
+    private void OnPlayerDetached(Entity<MindContainerComponent> ent, ref PlayerDetachedEvent args)
+    {
+        if (!TryGetMind(ent, out var mind))
+            return;
+
+        var ev = new ESMindPlayerDetachedEvent(args.Entity, args.Player);
+        RaiseMindEvent(mind.Value, ref ev);
+    }
+}
+
+/// <summary>
+/// Event raised on a mind and objectives when a player is attached to a body.
+/// </summary>
+[ByRefEvent]
+public readonly record struct ESMindPlayerAttachedEvent(EntityUid Entity, ICommonSession Player);
+
+/// <summary>
+/// Event raised on a mind and objectives when a player is detached from a body.
+/// </summary>
+[ByRefEvent]
+public readonly record struct ESMindPlayerDetachedEvent(EntityUid Entity, ICommonSession Player);

--- a/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
+++ b/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._ES.Mind;
 using Content.Shared._ES.Objectives.Components;
 using Content.Shared.EntityTable;
 using Content.Shared.EntityTable.EntitySelectors;
@@ -33,6 +34,9 @@ public abstract partial class ESSharedObjectiveSystem : EntitySystem
 
         SubscribeLocalEvent<ESObjectiveHolderComponent, MindGotAddedEvent>(OnMindGotAdded);
         SubscribeLocalEvent<ESObjectiveHolderComponent, MindGotRemovedEvent>(OnMindGotRemoved);
+
+        SubscribeLocalEvent<ESObjectiveHolderComponent, ESMindPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<ESObjectiveHolderComponent, ESMindPlayerDetachedEvent>(OnPlayerDetached);
     }
 
     private void OnMindGotAdded(Entity<ESObjectiveHolderComponent> ent, ref MindGotAddedEvent args)
@@ -48,6 +52,22 @@ public abstract partial class ESSharedObjectiveSystem : EntitySystem
         foreach (var objective in GetObjectives(ent.AsNullable()))
         {
             RaiseLocalEvent(objective, args);
+        }
+    }
+
+    private void OnPlayerAttached(Entity<ESObjectiveHolderComponent> ent, ref ESMindPlayerAttachedEvent args)
+    {
+        foreach (var objective in GetObjectives(ent.AsNullable()))
+        {
+            _pvsOverride.AddSessionOverride(objective, args.Player);
+        }
+    }
+
+    private void OnPlayerDetached(Entity<ESObjectiveHolderComponent> ent, ref ESMindPlayerDetachedEvent args)
+    {
+        foreach (var objective in GetObjectives(ent.AsNullable()))
+        {
+            _pvsOverride.RemoveSessionOverride(objective, args.Player);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Closes #542 

session overrides dont persist upon client disconnect so it would just stop sending you the data for objectives. Fixed it with a pretty basic relay and some extra events. 