### PR TITLE
Playtest 2 mask rebalancing

### DIFF
--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -159,6 +159,7 @@
   troupe: ESCrew
   description: es-mask-vandal-desc
   color: tomato
+  weight: 0.2
   mindComponents:
   - type: ESCanAlwaysSabotage
   objectives:
@@ -179,6 +180,7 @@
   troupe: ESCrew
   description: es-mask-martyr-desc
   color: gold
+  weight: 0.5
   mindComponents:
   - type: ESMartyr
   objectives:

--- a/Resources/Prototypes/_ES/Objectives/crew.yml
+++ b/Resources/Prototypes/_ES/Objectives/crew.yml
@@ -56,9 +56,9 @@
   - type: ESGuzzleObjective
   - type: ESCounterObjective
     title: es-guzzle-objective-title
-    target: 1000
-    maxTarget: 2000
-    targetIncrement: 100
+    target: 500
+    maxTarget: 1200
+    targetIncrement: 50
 
 - type: entity
   parent: ESBaseMaskObjective
@@ -91,8 +91,8 @@
     - SpaceCleaner
     - SpaceLube
   - type: ESCounterObjective
-    target: 100
-    maxTarget: 200
+    target: 70
+    maxTarget: 150
     targetIncrement: 10
 
 - type: entity
@@ -135,15 +135,15 @@
     - Poison
     - Blunt
   - type: ESCounterObjective
-    target: 250
-    maxTarget: 500
-    targetIncrement: 50
+    target: 75
+    maxTarget: 200
+    targetIncrement: 25
 
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveTakeDamageFromSource
   name: Take damage from source
-  description: Take as much of a certain damage type as you can.
+  description: Take as much damage from a certain source as you can.
   components:
   - type: ESObjective
     icon:
@@ -155,9 +155,9 @@
     - ESEmitter
     - ESAncestor
   - type: ESCounterObjective
-    target: 100
-    maxTarget: 250
-    targetIncrement: 10
+    target: 75
+    maxTarget: 150
+    targetIncrement: 25
 
 - type: entity
   parent: ESBaseMaskObjective
@@ -173,9 +173,9 @@
   - type: ESCounterObjective
     title: es-daredevil-total-objective-title
     description: es-daredevil-total-objective-desc
-    target: 750
-    maxTarget: 1250
-    targetIncrement: 50
+    target: 300
+    maxTarget: 500
+    targetIncrement: 20
 
 - type: entity
   parent: ESBaseMaskObjective
@@ -190,9 +190,9 @@
   - type: ESEatUniqueFoodsObjective
   - type: ESCounterObjective
     title: es-eat-unique-foods-objective-title
-    target: 25
-    maxTarget: 40
-    targetIncrement: 5
+    target: 16
+    maxTarget: 30
+    targetIncrement: 2
 
 - type: entity
   parent: ESBaseMaskObjective


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

fixes #577 
fixes #552 
fixes #554 

reduced the targets for a lot of the freak masks quite substantially, would prefer these to be slightly lower than they ought to be rather than way higher

massively reduces weight for vandal, and slightly reduces weight for martyr (to the same weight as phantom) for now