### PR TITLE
More effective pulling (hack shit) + dont occlude pulled ents

### DIFF
--- a/Content.Client/_ES/Viewcone/ESViewconeClientNoOccludeComponent.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeClientNoOccludeComponent.cs
@@ -1,0 +1,12 @@
+using Content.Shared._ES.Viewcone;
+
+namespace Content.Client._ES.Viewcone;
+
+/// <summary>
+///     Marks an entity which this client should always perceive, even if they have <see cref="ESViewconeOccludableComponent"/>
+/// </summary>
+/// <remarks>
+///     Used for dynamic situations where you should intuitively always show the occludable, like if you're pulling it.
+/// </remarks>
+[RegisterComponent]
+public sealed partial class ESViewconeClientNoOccludeComponent : Component;

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
@@ -84,6 +84,10 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
             var (comp, xform) = entry;
             var uid = entry.Uid; // this uses component.Owner.. oh well
 
+            // dynamic clientside disabling, for effects like pulled entities
+            if (_ent.HasComponent<ESViewconeClientNoOccludeComponent>(uid))
+                continue;
+
             if (!_ent.TryGetComponent<SpriteComponent>(uid, out var sprite))
                 continue;
 

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -102,7 +102,7 @@ namespace Content.Shared.Interaction
         public const string RateLimitKey = "Interaction";
 
         // ES START
-        public const float ESPullRange = 1.0f;
+        public const float ESPullRange = 0.7f;
         // ES END
 
         private static readonly ProtoId<TagPrototype> BypassInteractionRangeChecksTag = "BypassInteractionRangeChecks";

--- a/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullableComponent.cs
@@ -39,6 +39,18 @@ public sealed partial class PullableComponent : Component
     [AutoNetworkedField, DataField]
     public bool PrevFixedRotation;
 
+    // ES START
+    // we have to do some state bookkeeping because just trying to do it with arithmetic
+    // introduces dogshit bugs for some reason
+    // but this is to make it so we can dynamically reduce density on pull and then restore it on stop pull
+    /// <summary>
+    ///     AAAAAAAAAAAAA
+    /// </summary>
+    [Access(typeof(Systems.PullingSystem))]
+    [DataField, AutoNetworkedField]
+    public Dictionary<string, float>? OldFixtureDensities;
+    // ES END
+
     [DataField]
     public ProtoId<AlertPrototype> PulledAlert = "Pulled";
 }

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -380,6 +380,21 @@ public sealed class PullingSystem : EntitySystem
         pullableComp.Puller = null;
         Dirty(pullableUid, pullableComp);
 
+        // ES START
+        // HACK HACK HACK HACK
+        var fix = Comp<FixturesComponent>(pullableUid);
+        foreach (var (id, fixture) in fix.Fixtures)
+        {
+            if (pullableComp.OldFixtureDensities == null)
+                break;
+
+            if (!pullableComp.OldFixtureDensities.TryGetValue(id, out var oldDensity))
+                continue;
+
+            _physics.SetDensity(pullableUid, id, fixture, oldDensity, manager: fix);
+        }
+        // ES END
+
         // No more joints with puller -> force stop pull.
         if (TryComp<PullerComponent>(oldPuller, out var pullerComp))
         {
@@ -585,6 +600,21 @@ public sealed class PullingSystem : EntitySystem
 
             _physics.SetFixedRotation(pullableUid, pullableComp.FixedRotationOnPull, body: pullablePhysics);
         }
+
+        // ES START
+        // HACK HACK HACK HACK
+        // specifically, to make pulling less ass
+        // (and much faster) by just reducing the density of pulled items
+        // yes this probably has weird knock on effects but I can't think of a better way to do this right now
+        // we /100 to avoid storing state, and then just *100 in stoppulling
+        var fix = Comp<FixturesComponent>(pullableUid);
+        pullableComp.OldFixtureDensities = new();
+        foreach (var (id, fixture) in fix.Fixtures)
+        {
+            pullableComp.OldFixtureDensities.Add(id, fixture.Density);
+            _physics.SetDensity(pullableUid, id, fixture, 1f, manager: fix);
+        }
+        // ES END
 
         // Messaging
         var message = new PullStartedMessage(pullerUid, pullableUid);

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -606,7 +606,6 @@ public sealed class PullingSystem : EntitySystem
         // specifically, to make pulling less ass
         // (and much faster) by just reducing the density of pulled items
         // yes this probably has weird knock on effects but I can't think of a better way to do this right now
-        // we /100 to avoid storing state, and then just *100 in stoppulling
         var fix = Comp<FixturesComponent>(pullableUid);
         pullableComp.OldFixtureDensities = new();
         foreach (var (id, fixture) in fix.Fixtures)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- store an entities fixtures density and then set their density artificially low on pull
- restore it to the old density on stop pull
- on client, add comp to occludables that get pulled to never occlude them (looks better this way and i dont want to do the 'you face stuff you pull' thing because backwalking means it would slow you down and i dont like that)


https://github.com/user-attachments/assets/f586c1fb-7b4a-4f30-b65b-449002888cbb

