### PR TITLE
Minor viewcone tweaks

### DIFF
--- a/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeComponent.cs
@@ -36,13 +36,13 @@ public sealed partial class ESViewconeComponent : Component
     public float ConeAngle = 225f;
 
     [DataField, AutoNetworkedField]
-    public float ConeFeather = 5f;
+    public float ConeFeather = 3f;
 
     [DataField, AutoNetworkedField]
-    public float ConeIgnoreRadius = 0.7f;
+    public float ConeIgnoreRadius = 0.65f;
 
     [DataField, AutoNetworkedField]
-    public float ConeIgnoreFeather = 0.1f;
+    public float ConeIgnoreFeather = 0.03f;
 
     // Clientside, used for lerping view angle
     // and keeping it consistent across all overlays

--- a/Resources/Textures/_ES/Shaders/viewcone.swsl
+++ b/Resources/Textures/_ES/Shaders/viewcone.swsl
@@ -5,17 +5,17 @@
 uniform sampler2D SCREEN_TEXTURE;
 uniform highp float Zoom;
 
-uniform highp float ConeAngle; //= 270.0
-uniform highp float ConeFeather; //= 10.0;
-uniform highp float ConeIgnoreRadius; //= 0.5;
-uniform highp float ConeIgnoreFeather; //= 0.1;
+uniform highp float ConeAngle;
+uniform highp float ConeFeather;
+uniform highp float ConeIgnoreRadius;
+uniform highp float ConeIgnoreFeather;
 
 uniform highp float ViewAngle;
 
 const highp float grainMult = 0.35;
 const highp float grainBase = 0.6;
 
-const highp float grayscaleFactor = 0.72;
+const highp float grayscaleFactor = 0.82;
 
 void fragment(){
     highp vec2 pixelSize = vec2(1.0/SCREEN_PIXEL_SIZE.x, 1.0/SCREEN_PIXEL_SIZE.y);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

less feathering
slightly less surround radius
slightly darker

<img width="882" height="780" alt="image" src="https://github.com/user-attachments/assets/d95cb961-0f45-49e4-818d-8783526defea" />

the grain isnt act ually this crazy its just an artifact of the fact that its always going to look grainy when you take a static screenshot vs video
