### PR TITLE
Voting Tweaks

### DIFF
--- a/Content.Client/_ES/Voting/ESVoteSystem.cs
+++ b/Content.Client/_ES/Voting/ESVoteSystem.cs
@@ -42,4 +42,18 @@ public sealed class ESVoteSystem : ESSharedVoteSystem
                 bui.Update();
         }
     }
+
+    protected override void OnSetVote(ESSetVoteMessage args, EntitySessionEventArgs ev)
+    {
+        if (_timing.ApplyingState)
+            return;
+
+        base.OnSetVote(args, ev);
+
+        if (ev.SenderSession.AttachedEntity is not { } attachedEntity)
+            return;
+
+        if (_userInterface.TryGetOpenUi(attachedEntity, ESVoterUiKey.Key, out var bui))
+            bui.Update();
+    }
 }

--- a/Content.Client/_ES/Voting/Ui/ESVoterBui.cs
+++ b/Content.Client/_ES/Voting/Ui/ESVoterBui.cs
@@ -18,10 +18,10 @@ public sealed class ESVoterBui(EntityUid owner, Enum uiKey) : BoundUserInterface
         _window.OpenCenteredAt(new Vector2(0.25f, 0.25f));
         _window.Update(Owner);
 
-        _window.OnVoteChanged += (entity, option) =>
+        _window.OnVoteChanged += (entity, option, selected) =>
         {
             var netEnt = EntMan.GetNetEntity(entity);
-            EntMan.RaisePredictiveEvent(new ESSetVoteMessage(netEnt, option));
+            EntMan.RaisePredictiveEvent(new ESSetVoteMessage(netEnt, option, selected));
         };
     }
 

--- a/Content.Client/_ES/Voting/Ui/ESVotingWindow.xaml.cs
+++ b/Content.Client/_ES/Voting/Ui/ESVotingWindow.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class ESVotingWindow : FancyWindow
 
     private List<Entity<ESVoteComponent>> _lastVotes = new();
 
-    public event Action<Entity<ESVoteComponent>, ESVoteOption>? OnVoteChanged;
+    public event Action<Entity<ESVoteComponent>, ESVoteOption, bool>? OnVoteChanged;
 
     public ESVotingWindow()
     {
@@ -38,7 +38,7 @@ public sealed partial class ESVotingWindow : FancyWindow
                 {
                     Vote = vote,
                 };
-                voteControl.OnVoteChanged += (arg1, arg2) => OnVoteChanged?.Invoke(arg1, arg2);
+                voteControl.OnVoteChanged += (arg1, arg2, arg3) => OnVoteChanged?.Invoke(arg1, arg2, arg3);
                 VotesContainer.AddChild(voteControl);
             }
         }

--- a/Content.Shared/_ES/Voting/Components/ESVoteComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESVoteComponent.cs
@@ -48,7 +48,13 @@ public sealed partial class ESVoteComponent : Component
     /// How the result is selected
     /// </summary>
     [DataField, AutoNetworkedField]
-    public ResultStrategy Strategy = ResultStrategy.HighestValue;
+    public ResultStrategy Strategy = ResultStrategy.WeightedPick;
+
+    /// <summary>
+    /// If true, voters can select multiple options.
+    /// </summary>
+    [DataField]
+    public bool MultiVote = true;
 
     /// <summary>
     /// If false, voters will not be able to see how many votes they have.

--- a/Content.Shared/_ES/Voting/Components/ESVoterComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESVoterComponent.cs
@@ -18,8 +18,9 @@ public enum ESVoterUiKey : byte
 }
 
 [Serializable, NetSerializable]
-public sealed class ESSetVoteMessage(NetEntity vote, ESVoteOption option) : EntityEventArgs
+public sealed class ESSetVoteMessage(NetEntity vote, ESVoteOption option, bool selected) : EntityEventArgs
 {
     public NetEntity Vote = vote;
     public ESVoteOption Option = option;
+    public bool Selected = selected;
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Adds support for approval voting, enables it by default
- Changes default vote result strategy to weighted pick
  - My reasoning is that anyone who wants the HighestVote option will notice this immediately and i think weighted picks are a better strategy for like 99% of cases
- Lets people deselect their votes. this was kinda just broken before.
- Does some weird networking crap. Idk i was just adding random checks until it stopped mispredicting.

Closes #602 