### PR TITLE
no shuttle world

### DIFF
--- a/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
+++ b/Content.Client/Communications/UI/CommunicationsConsoleMenu.xaml
@@ -52,10 +52,14 @@
 
                 <RichTextLabel Name="CountdownLabel"/>
 
+                <!-- ES START -->
+                <!-- change tooltip and disable by default -->
                 <Button Name="EmergencyShuttleButton"
-                    Access="Public" 
+                    Access="Public"
                     Text="Placeholder Text"
-                    ToolTip="{Loc 'comms-console-menu-emergency-shuttle-button-tooltip'}"/>
+                    Disabled="True"
+                    ToolTip="{Loc 'es-comms-console-menu-emergency-shuttle-button-tooltip'}"/>
+                    <!-- ES END -->
             </BoxContainer>
         </BoxContainer>
     </BoxContainer>

--- a/Content.IntegrationTests/Tests/RoundEndTest.cs
+++ b/Content.IntegrationTests/Tests/RoundEndTest.cs
@@ -25,7 +25,10 @@ namespace Content.IntegrationTests.Tests
             }
         }
 
-        [Test]
+        // ES START
+        // not relevant with our roundflow
+        //[Test]
+        // ES END
         public async Task Test()
         {
             await using var pair = await PoolManager.GetServerClient(new PoolSettings

--- a/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
+++ b/Content.IntegrationTests/Tests/Station/EvacShuttleTest.cs
@@ -17,7 +17,10 @@ public sealed class EvacShuttleTest
     /// <summary>
     /// Ensure that the emergency shuttle can be called, and that it will travel to centcomm
     /// </summary>
-    [Test]
+    // ES START
+    // not a relevant test
+    // [Test]
+    // ES END
     public async Task EmergencyEvacTest()
     {
         await using var pair = await PoolManager.GetServerClient(new PoolSettings { DummyTicker = true, Dirty = true });

--- a/Content.Server/Communications/CommunicationsConsoleSystem.cs
+++ b/Content.Server/Communications/CommunicationsConsoleSystem.cs
@@ -233,6 +233,11 @@ namespace Content.Server.Communications
 
         private bool CanCallOrRecall(CommunicationsConsoleComponent comp)
         {
+            // ES START
+            // no calling/recalling here
+            return false;
+            // ES END
+
             // Defer to what the round end system thinks we should be able to do.
             if (_emergency.EmergencyShuttleArrived || !_roundEndSystem.CanCallOrRecall())
                 return false;

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -168,6 +168,11 @@ namespace Content.Server.RoundEnd
         /// <param name="cantRecall">if the station shouldn't be able to recall the shuttle</param>
         public void RequestRoundEnd(TimeSpan countdownTime, EntityUid? requester = null, bool checkCooldown = true, string text = "round-end-system-shuttle-called-announcement", string name = "round-end-system-shuttle-sender-announcement", bool cantRecall = false)
         {
+            // ES START
+            // no shuttles allowed
+            return;
+            // ES END
+
             if (_gameTicker.RunLevel != GameRunLevel.InRound)
                 return;
 

--- a/Resources/Locale/en-US/_ES/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/_ES/communications/communications-console-component.ftl
@@ -1,1 +1,1 @@
-es-comms-console-menu-emergency-shuttle-button-tooltip = The station's communications with CentComm is severed and a distress signal is impossible. There's no easy way out.
+es-comms-console-menu-emergency-shuttle-button-tooltip = The station's communication with CentComm is severed and a distress signal is impossible. There's no easy way out.

--- a/Resources/Locale/en-US/_ES/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/_ES/communications/communications-console-component.ftl
@@ -1,0 +1,1 @@
+es-comms-console-menu-emergency-shuttle-button-tooltip = The station's communications with CentComm is severed and a distress signal is impossible. There's no easy way out.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

closes #607 

disables calling/recalling from the comms console
disables shuttle call ability completely 

i would have removed the button, but i like it being there just greyed out. for themes and writing reasons

<img width="1147" height="430" alt="image" src="https://github.com/user-attachments/assets/e7d49022-3379-4e7f-b623-5ecd70b301ac" />
