### PR TITLE
Nightshift lighting variation + minor other tweaks

### DIFF
--- a/Content.Server/GameTicking/Rules/VariationPass/BaseEntityReplaceVariationPassSystem.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/BaseEntityReplaceVariationPassSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.GameTicking.Rules.VariationPass.Components;
+﻿using Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+using Content.Server.GameTicking.Rules.VariationPass.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
 using Robust.Shared.Random;
@@ -16,7 +17,10 @@ namespace Content.Server.GameTicking.Rules.VariationPass;
 ///     See <see cref="WallReplaceVariationPassSystem"/>
 /// </summary>
 public abstract class BaseEntityReplaceVariationPassSystem<TEntComp, TGameRuleComp> : VariationPassSystem<TGameRuleComp>
-    where TEntComp: IComponent
+    // ES START
+    // different bound so we can have more control
+    where TEntComp: ESBaseReplacementMarkerComponent
+    // ES END
     where TGameRuleComp: IComponent
 {
     /// <summary>
@@ -42,12 +46,21 @@ public abstract class BaseEntityReplaceVariationPassSystem<TEntComp, TGameRuleCo
             return;
 
         var enumerator = AllEntityQuery<TEntComp, TransformComponent>();
-        while (enumerator.MoveNext(out var uid, out _, out var xform))
+        // ES START
+        // comp in enumerator + replacement disabling
+        while (enumerator.MoveNext(out var uid, out var comp, out var xform))
         {
+            if (!comp.Replace)
+                continue;
+            // ES END
+
             if (!IsMemberOfStation((uid, xform), ref args))
                 continue;
 
-            if (RobustRandom.Prob(prob))
+            // ES START
+            // replaceall
+            if (pass.ReplaceAll || RobustRandom.Prob(prob))
+            // ES END
                 QueueReplace((uid, xform), pass.Replacements);
         }
 

--- a/Content.Server/GameTicking/Rules/VariationPass/Components/EntityReplaceVariationPassComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/EntityReplaceVariationPassComponent.cs
@@ -25,6 +25,14 @@ public sealed partial class EntityReplaceVariationPassComponent : Component
     [DataField(required: true)]
     public float EntitiesPerReplacementStdDev;
 
+    // ES START
+    /// <summary>
+    ///     Should every entity we come across be replaced?
+    /// </summary>
+    [DataField]
+    public bool ReplaceAll = false;
+    // ES END
+
     /// <summary>
     ///     Prototype(s) to replace matched entities with.
     /// </summary>

--- a/Content.Server/GameTicking/Rules/VariationPass/Components/ReplacementMarkers/ReinforcedWallReplacementMarkerComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/ReplacementMarkers/ReinforcedWallReplacementMarkerComponent.cs
@@ -1,9 +1,14 @@
-﻿namespace Content.Server.GameTicking.Rules.VariationPass.Components.ReplacementMarkers;
+﻿using Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+
+namespace Content.Server.GameTicking.Rules.VariationPass.Components.ReplacementMarkers;
 
 /// <summary>
 /// This component marks replaceable reinforced walls for use with fast queries in variation passes.
 /// </summary>
 [RegisterComponent]
-public sealed partial class ReinforcedWallReplacementMarkerComponent : Component
+// ES START
+// different base
+public sealed partial class ReinforcedWallReplacementMarkerComponent : ESBaseReplacementMarkerComponent
+// ES END
 {
 }

--- a/Content.Server/GameTicking/Rules/VariationPass/Components/ReplacementMarkers/SolarPanelReplacementMarkerComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/ReplacementMarkers/SolarPanelReplacementMarkerComponent.cs
@@ -1,7 +1,12 @@
+using Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+
 namespace Content.Server.GameTicking.Rules.VariationPass.Components.ReplacementMarkers;
 
 /// <summary>
 /// This component marks replaceable solar panels for use with fast queries in variation passes.
 /// </summary>
 [RegisterComponent]
-public sealed partial class SolarPanelReplacementMarkerComponent : Component;
+// ES START
+// different base
+public sealed partial class SolarPanelReplacementMarkerComponent : ESBaseReplacementMarkerComponent;
+// ES END

--- a/Content.Server/GameTicking/Rules/VariationPass/Components/ReplacementMarkers/WallReplacementMarkerComponent.cs
+++ b/Content.Server/GameTicking/Rules/VariationPass/Components/ReplacementMarkers/WallReplacementMarkerComponent.cs
@@ -1,9 +1,14 @@
-﻿namespace Content.Server.GameTicking.Rules.VariationPass.Components.ReplacementMarkers;
+﻿using Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+
+namespace Content.Server.GameTicking.Rules.VariationPass.Components.ReplacementMarkers;
 
 /// <summary>
 /// This component marks replaceable walls for use with fast queries in variation passes.
 /// </summary>
 [RegisterComponent]
-public sealed partial class WallReplacementMarkerComponent : Component
+// ES START
+// different base
+public sealed partial class WallReplacementMarkerComponent : ESBaseReplacementMarkerComponent
+// ES END
 {
 }

--- a/Content.Server/_ES/StationVariation/Components/ESNightshiftVariationPassComponent.cs
+++ b/Content.Server/_ES/StationVariation/Components/ESNightshiftVariationPassComponent.cs
@@ -1,0 +1,7 @@
+using Content.Server._ES.StationVariation.Systems;
+
+namespace Content.Server._ES.StationVariation.Components;
+
+/// <seealso cref="ESNightshiftVariationPassSystem"/>
+[RegisterComponent]
+public sealed partial class ESNightshiftVariationPassComponent : Component;

--- a/Content.Server/_ES/StationVariation/Components/ReplacementMarkers/ESBaseReplacementMarkerComponent.cs
+++ b/Content.Server/_ES/StationVariation/Components/ReplacementMarkers/ESBaseReplacementMarkerComponent.cs
@@ -3,10 +3,8 @@ using Robust.Shared.Prototypes;
 namespace Content.Server._ES.StationVariation.Components.ReplacementMarkers;
 
 // todo mirror support overriding prototypes when you need that too
-// not now
 /// <summary>
-///     Base class for entity replacement markers, which allows you or disable replacement, per entity.
-///
+///     Base class for entity replacement markers, which allows you to disable replacement per entity.
 /// </summary>
 /// <remarks>
 ///     Disabling replacement is done for ents that inherit from something with a marker, which don't want to be replaced.

--- a/Content.Server/_ES/StationVariation/Components/ReplacementMarkers/ESBaseReplacementMarkerComponent.cs
+++ b/Content.Server/_ES/StationVariation/Components/ReplacementMarkers/ESBaseReplacementMarkerComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+
+// todo mirror support overriding prototypes when you need that too
+// not now
+/// <summary>
+///     Base class for entity replacement markers, which allows you or disable replacement, per entity.
+///
+/// </summary>
+/// <remarks>
+///     Disabling replacement is done for ents that inherit from something with a marker, which don't want to be replaced.
+/// </remarks>
+public abstract partial class ESBaseReplacementMarkerComponent : Component
+{
+    [DataField]
+    public bool Replace = true;
+}

--- a/Content.Server/_ES/StationVariation/Components/ReplacementMarkers/ESNightshiftReplacementMarkerComponent.cs
+++ b/Content.Server/_ES/StationVariation/Components/ReplacementMarkers/ESNightshiftReplacementMarkerComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+
+/// <summary>
+/// Marker components for entities which should be replaced during nightshift.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESNightshiftReplacementMarkerComponent : ESBaseReplacementMarkerComponent;

--- a/Content.Server/_ES/StationVariation/Systems/ESNightshiftVariationPassSystem.cs
+++ b/Content.Server/_ES/StationVariation/Systems/ESNightshiftVariationPassSystem.cs
@@ -1,0 +1,11 @@
+using Content.Server._ES.StationVariation.Components;
+using Content.Server._ES.StationVariation.Components.ReplacementMarkers;
+using Content.Server.GameTicking.Rules.VariationPass;
+
+namespace Content.Server._ES.StationVariation.Systems;
+
+/// <summary>
+///     Handles replacing light entities marked with <see cref="ESNightshiftReplacementMarkerComponent"/>, for nightshift lighting.
+/// </summary>
+public sealed class ESNightshiftVariationPassSystem : BaseEntityReplaceVariationPassSystem<
+    ESNightshiftReplacementMarkerComponent, ESNightshiftVariationPassComponent>;

--- a/Resources/Maps/_ES/Shuttles/arrivals.yml
+++ b/Resources/Maps/_ES/Shuttles/arrivals.yml
@@ -2064,7 +2064,7 @@ entities:
     - type: Transform
       pos: 9.5,-1.5
       parent: 1
-- proto: ESPoweredLightDepartment
+- proto: ESPoweredLightNightshift
   entities:
   - uid: 356
     components:

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -28,7 +28,7 @@
   suffix: ES, Nightshift
   components:
   - type: PointLight
-    color: "#8c785a"
+    color: "#7b5e50"
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeNightshift
   - type: DeviceNetwork

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -16,6 +16,7 @@
     energy: 1.45
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeDepartment
+  - type: ESNightshiftReplacementMarker
 
 # Nightshift lighting. Replaces department lighting randomly at roundstart.
 # Also used on the arrivals shuttle. Sleepytime city for the shuttlers

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -12,12 +12,28 @@
   suffix: ES, Departments
   components:
   - type: PointLight
-    color: "#ece2dd"
+    color: "#ccc2be"
     energy: 1.45
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeDepartment
 
-# Used in hallways. Dimmer light, to contrast with department lights (below)
+# Nightshift lighting. Replaces department lighting randomly at roundstart.
+# Also used on the arrivals shuttle. Sleepytime city for the shuttlers
+- type: entity
+  id: ESPoweredLightNightshift
+  parent: Poweredlight
+  name: light fixture
+  description: Draws power and produces light when equipped with a light tube. Unresponsive to light switches.
+  suffix: ES, Nightshift
+  components:
+  - type: PointLight
+    color: "#8c785a"
+  - type: PoweredLight
+    hasLampOnSpawn: ESLightTubeNightshift
+  - type: DeviceNetwork
+    receiveFrequencyId: null
+
+# Used in hallways. Dimmer light, to contrast with department lights (above)
 - type: entity
   id: ESPoweredLightHallway
   parent: Poweredlight
@@ -26,7 +42,7 @@
   suffix: ES, Hallway
   components:
   - type: PointLight
-    color: "#929291"
+    color: "#7f8082"
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeHallway
   - type: DeviceNetwork

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -2,11 +2,22 @@
 - type: entity
   id: ESLightTubeDepartment
   parent: LightTube
-  suffix: ES
+  suffix: ES, Department
   components:
   - type: LightBulb
-    color: "#ece2dd"
+    color: "#ccc2be"
     glowColorOverride: "#ffffff"
+    lightEnergy: 1.45
+    lightSoftness: 2
+
+- type: entity
+  id: ESLightTubeNightshift
+  parent: LightTube
+  suffix: ES, Nightshift
+  components:
+  - type: LightBulb
+    color: "#8c785a"
+    glowColorOverride: "#e2cc9f"
     lightEnergy: 1.45
     lightSoftness: 2
 
@@ -15,9 +26,9 @@
   parent: LightTube
   name: hallway fluorescent light tube
   description: A light fixture. Dimmer than regular department lights.
-  suffix: ES
+  suffix: ES, Hallway
   components:
   - type: LightBulb
-    color: "#929291"
-    glowColorOverride: "#dddddd"
+    color: "#6c6d6f"
+    glowColorOverride: "#cccccc"
     lightSoftness: 2

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -16,8 +16,8 @@
   suffix: ES, Nightshift
   components:
   - type: LightBulb
-    color: "#8c785a"
-    glowColorOverride: "#e2cc9f"
+    color: "#7b5e50"
+    glowColorOverride: "#d8753d"
     lightEnergy: 1.45
     lightSoftness: 2
 

--- a/Resources/Prototypes/_ES/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Walls/walls.yml
@@ -54,5 +54,5 @@
   - type: IconSmooth
     key: walls
     base: ame
-  - type: ReinforcedWallReplacementMarkerComponent
+  - type: ReinforcedWallReplacementMarker
     replace: false

--- a/Resources/Prototypes/_ES/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Walls/walls.yml
@@ -38,7 +38,7 @@
   - type: Construction
     graph: Girder
     node: ESWallDiagonalTube
- 
+
 # AME containment
 - type: entity
   parent: WallReinforced
@@ -54,3 +54,5 @@
   - type: IconSmooth
     key: walls
     base: ame
+  - type: ReinforcedWallReplacementMarkerComponent
+    replace: false

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/nightshift.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/nightshift.yml
@@ -1,0 +1,10 @@
+# Replaces department lights with nightshift lights (mellower, yellower)
+- type: entity
+  id: ESNightshiftVariationPass
+  parent: BaseVariationPass
+  components:
+  - type: ESNightshiftVariationPass
+  - type: EntityReplaceVariationPass
+    replaceAll: true
+    replacements:
+    - id: ESPoweredLightNightshift

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/nightshift.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/nightshift.yml
@@ -5,6 +5,9 @@
   components:
   - type: ESNightshiftVariationPass
   - type: EntityReplaceVariationPass
+    # avg/stddev not used, just didnt want to change required on the datafield
+    entitiesPerReplacementAverage: 1
+    entitiesPerReplacementStdDev: 1
     replaceAll: true
     replacements:
     - id: ESPoweredLightNightshift

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
@@ -21,3 +21,5 @@
       - id: ESBasicDecalGraffitiVariationPass
       - id: ESBasicDecalDirtMonospaceVariationPass
       - tableId: ESMaplightParallaxVariationTable
+      - id: ESNightshiftVariationPass
+        prob: 0.15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

also fixes #492 lol

overhauls `EntityVariationPass` stuff to allow for some things i want to do in the future and also fixes ame wall thing in the process

darkens+blues hallway lights Slightly its not that big of a diff

adds new nightshift light fixtures & tubes, color is based on tg nightshift lighting, it looks real good i think. 15% chance for it to run roundstart on any given round

changes the lights on the arrivals shuttle to be nightshift ones (i will probably want them even moodier tbh)

new nightshift lights
<img width="960" height="960" alt="2025-12-25_09 22 14" src="https://github.com/user-attachments/assets/6356290d-41f7-4544-8ebc-bfd7d5811059" />
<img width="960" height="960" alt="2025-12-25_09 22 22" src="https://github.com/user-attachments/assets/d1e57819-9e4e-4ada-adb9-9c8aeeed3e22" />

new regular lighting (its not very different)
<img width="960" height="960" alt="2025-12-25_08 41 06" src="https://github.com/user-attachments/assets/3035598d-6d1b-4610-b55c-78439fab5d2f" />