### PR TITLE
Red Carpet + Traitors (new high weight mode)

### DIFF
--- a/Content.IntegrationTests/Tests/_ES/Masquerades/MasqueradeTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Masquerades/MasqueradeTests.cs
@@ -124,10 +124,12 @@ public sealed class MasqueradeRunTests : GameTest
         Destructive = true, // fuck it. We set the preset which is destructive.
     };
 
-    [TestCase("Random", 35)]
+    [TestCase("RandomTraitors", 35)]
     [TestCase("Freakshow", 35)]
     [TestCase("Freakshow", 21)]
     [TestCase("Showdown", 35)]
+    [TestCase("Traitors", 35)]
+    [TestCase("RedCarpet", 35)]
     public async Task TestMasqueradeStart(string protoStr, int userCount)
     {
         var proto = _proto.Index<ESMasqueradePrototype>(protoStr);

--- a/Resources/Prototypes/_ES/Masquerades/random.yml
+++ b/Resources/Prototypes/_ES/Masquerades/random.yml
@@ -1,6 +1,6 @@
 - type: esMasquerade
-  id: Random
-  name: Random
+  id: RandomTraitors
+  name: Random (Traitors)
   description: is a truly randomized traitorous experience
   weight: 10
   minPlayers: 1

--- a/Resources/Prototypes/_ES/Masquerades/random.yml
+++ b/Resources/Prototypes/_ES/Masquerades/random.yml
@@ -2,7 +2,7 @@
   id: RandomTraitors
   name: Random (Traitors)
   description: is a truly randomized traitorous experience
-  weight: 10
+  weight: 1
   minPlayers: 1
   gameRules: []
   masquerade: !type:MasqueradeRoleSet

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -1,7 +1,7 @@
 - type: esMasquerade
   id: RedCarpet
   name: Red Carpet
-  description: strands a party of VIPs with our harrowing crew.
+  description: strands a party of VIPs with our harrowing crew
   weight: 1
   minPlayers: 6
   gameRules: []

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -12,9 +12,9 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESVIP/ESCrewmember" # God help you.
     roles:
-      6: ["ESMarauder", "ESVIP", "#Oracles", "#Softsafes(2)", "#Gunners"] # 0 generic crew, 1 traitors
+      6: ["ESMarauder(2)", "ESVIP", "#Oracles", "#Softsafes", "#Gunners"] # 0 generic crew, 2 traitors
       7: ["ESVIP"]
-      8: ["#Traitors"] # 0 generic crew, 2 traitors.
+      8: ["#Softsafes"]
       9: ["ESVIP"] # The gang is here.
       10: ["#Jesters"]
       12: ["-ESMarauder", "#Traitors"] # 1 generic crew, 2 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -1,14 +1,10 @@
 - type: esMasquerade
   id: RedCarpet
   name: Red Carpet
-  description: Roll it out, if you can find any. A travelling group of VIPs was unfortunate enough to be stranded with you.
+  description: strands a party of VIPs with our harrowing crew.
   weight: 1
   minPlayers: 6
-  gameRules:
-  - ESTroupeRuleCrew
-  - ESTroupeRuleTraitor
-  - ESSchedulerRuleStationEventVote
-  - ESSchedulerRuleDegradationEventVote
+  gameRules: []
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESVIP/ESCrewmember" # God help you.
     roles:

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -8,12 +8,12 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESVIP/ESCrewmember" # God help you.
     roles:
-      6: ["ESMarauder(2)", "ESVIP", "#Oracles", "#Softsafes", "#Gunners"] # 0 generic crew, 2 traitors
+      6: ["ESMarauder", "ESInfiltrator", "ESVIP", "#Oracles", "#Softsafes", "#Gunners"] # 0 generic crew, 2 traitors
       7: ["ESVIP"]
       8: ["#Softsafes"]
       9: ["ESVIP"] # The gang is here.
       10: ["#Jesters"]
-      12: ["-ESMarauder", "#Traitors"] # 1 generic crew, 2 traitors.
+      12: ["-ESInfiltrator", "#Traitors"] # 1 generic crew, 2 traitors.
       14: ["#Gunners"] # 2 generic crew, 2 traitors.
       16: ["#Firmsafes"] # 3 generic crew, 2 traitors.
       18: ["#Traitors", "#Reaped"] # 3 generic crew, 3 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -1,0 +1,29 @@
+- type: esMasquerade
+  id: RedCarpet
+  name: Red Carpet
+  description: Roll it out, if you can find any. A travelling group of VIPs was unfortunate enough to be stranded with you.
+  weight: 1
+  minPlayers: 6
+  gameRules:
+  - ESTroupeRuleCrew
+  - ESTroupeRuleTraitor
+  - ESSchedulerRuleStationEventVote
+  - ESSchedulerRuleDegradationEventVote
+  masquerade: !type:MasqueradeRoleSet
+    defaultMask: "ESVIP/ESCrewmember" # God help you.
+    roles:
+      6: ["ESMarauder", "ESVIP", "#Oracles", "#Softsafes(2)", "#Gunners"] # 0 generic crew, 1 traitors
+      7: ["ESVIP"]
+      8: ["#Traitors"] # 0 generic crew, 2 traitors.
+      9: ["ESVIP"] # The gang is here.
+      10: ["#Jesters"]
+      12: ["-ESMarauder", "#Traitors"] # 1 generic crew, 2 traitors.
+      14: ["#Gunners"] # 2 generic crew, 2 traitors.
+      16: ["#Firmsafes"] # 3 generic crew, 2 traitors.
+      18: ["#Traitors", "#Reaped"] # 3 generic crew, 3 traitors.
+      20: ["#Softsafes(2)"]
+      22: ["#Jesters"] # 4 generic crew, 3 traitors.
+      24: ["#Firmsafes", "#Traitors"] # 4 generic crew, 4 traitors.
+      26: ["#Oracles"] # 5 generic crew, 4 traitors.
+      28: ["#Gunners"] # 6 generic crew, 4 traitors.
+      30: ["#Traitors"] # 7 generic crew, 5 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -8,10 +8,10 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESCrewmember" # God help you.
     roles:
-      6: ["ESMarauder(2)", "#Oracles", "#Softsafes", "#Gunners"] # 1 generic crew, 2 traitors
+      6: ["ESMarauder", "ESInfiltrator", "#Oracles", "#Softsafes", "#Gunners"] # 1 generic crew, 2 traitors
       8: ["#Softsafes"] # 2 generic crew, 2 traitors.
       10: ["#Jesters"] # 3 generic crew, 2 traitors.
-      12: ["-ESMarauder", "#Traitors"] # 4 generic crew, 2 traitors.
+      12: ["-ESInfiltrator", "#Traitors"] # 4 generic crew, 2 traitors.
       14: ["#Gunners", "#Softsafes"] # 4 generic crew, 2 traitors.
       16: ["#Firmsafes"] # 5 generic crew, 2 traitors.
       18: ["#Traitors", "#Reaped"] # 5 generic crew, 3 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -12,8 +12,8 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESCrewmember" # God help you.
     roles:
-      6: ["ESMarauder", "#Oracles", "#Softsafes(2)", "#Gunners"] # 1 generic crew, 1 traitors
-      8: ["#Traitors"] # 2 generic crew, 2 traitors.
+      6: ["ESMarauder(2)", "#Oracles", "#Softsafes", "#Gunners"] # 1 generic crew, 2 traitors
+      8: ["#Softsafes"] # 2 generic crew, 2 traitors.
       10: ["#Jesters"] # 3 generic crew, 2 traitors.
       12: ["-ESMarauder", "#Traitors"] # 4 generic crew, 2 traitors.
       14: ["#Gunners", "#Softsafes"] # 4 generic crew, 2 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -1,7 +1,7 @@
 - type: esMasquerade
   id: Traitors
   name: Traitors
-  description: standard, balanced cast of crew and traitors.
+  description: standard, balanced cast of crew and traitors
   weight: 10
   minPlayers: 6
   gameRules: []

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -1,0 +1,27 @@
+- type: esMasquerade
+  id: Traitors
+  name: Traitors
+  description: A standard, balanced cast of crew and traitors.
+  weight: 10
+  minPlayers: 6
+  gameRules:
+  - ESTroupeRuleCrew
+  - ESTroupeRuleTraitor
+  - ESSchedulerRuleStationEventVote
+  - ESSchedulerRuleDegradationEventVote
+  masquerade: !type:MasqueradeRoleSet
+    defaultMask: "ESCrewmember" # God help you.
+    roles:
+      6: ["ESMarauder", "#Oracles", "#Softsafes(2)", "#Gunners"] # 1 generic crew, 1 traitors
+      8: ["#Traitors"] # 2 generic crew, 2 traitors.
+      10: ["#Jesters"] # 3 generic crew, 2 traitors.
+      12: ["-ESMarauder", "#Traitors"] # 4 generic crew, 2 traitors.
+      14: ["#Gunners", "#Softsafes"] # 4 generic crew, 2 traitors.
+      16: ["#Firmsafes"] # 5 generic crew, 2 traitors.
+      18: ["#Traitors", "#Reaped"] # 5 generic crew, 3 traitors.
+      20: ["#Softsafes(2)"]
+      22: ["#Jesters", "#Softsafes"] # 5 generic crew, 3 traitors.
+      24: ["#Firmsafes", "#Traitors"] # 5 generic crew, 4 traitors.
+      26: ["#Oracles"] # 6 generic crew, 4 traitors.
+      28: ["#Gunners"] # 7 generic crew, 4 traitors.
+      30: ["#Traitors"] # 8 generic crew, 5 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -1,14 +1,10 @@
 - type: esMasquerade
   id: Traitors
   name: Traitors
-  description: A standard, balanced cast of crew and traitors.
+  description: standard, balanced cast of crew and traitors.
   weight: 10
   minPlayers: 6
-  gameRules:
-  - ESTroupeRuleCrew
-  - ESTroupeRuleTraitor
-  - ESSchedulerRuleStationEventVote
-  - ESSchedulerRuleDegradationEventVote
+  gameRules: []
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESCrewmember" # God help you.
     roles:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds two new masquerades, one to serve as the new "balanced traitors round" and another to devalue the VIP economy.
## Why / Balance
Random is inherently not a balanced masquerade, `Traitors` actively tries to be and is 100% worth bikeshedding a bit. Red Carpet is a variant on Traitors with an outsized excess of VIPs.

Will conflict with #721 