### PR TITLE
Last minute tweaks

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -473,7 +473,10 @@ namespace Content.Server.GameTicking
             SendStatusToAll();
             ReqWindowAttentionAll();
             UpdateLateJoinStatus();
-            AnnounceRound();
+            // ES START
+            // we hijack this
+            // AnnounceRound();
+            // ES END
             UpdateInfoText();
             SendRoundStartedDiscordMessage();
 
@@ -835,7 +838,10 @@ namespace Content.Server.GameTicking
             }
         }
 
-        private void AnnounceRound()
+        // ES START
+        // public
+        public void AnnounceRound()
+        // ES END
         {
             if (CurrentPreset == null) return;
 

--- a/Content.Server/_ES/Arrivals/ESArrivalsSystem.cs
+++ b/Content.Server/_ES/Arrivals/ESArrivalsSystem.cs
@@ -52,6 +52,7 @@ public sealed class ESArrivalsSystem : EntitySystem
 
         SubscribeLocalEvent<ESArrivalsShuttleComponent, FTLTagEvent>(OnShuttleTag);
         SubscribeLocalEvent<ESArrivalsShuttleComponent, FTLStartedEvent>(OnFTLStarted);
+        SubscribeLocalEvent<ESArrivalsShuttleComponent, FTLCompletedEvent>(OnFTLCompleted);
 
         SubscribeLocalEvent<PlayerSpawningEvent>(HandlePlayerSpawning, before: [typeof(SpawnPointSystem)]);
 
@@ -146,6 +147,11 @@ public sealed class ESArrivalsSystem : EntitySystem
         // EnsureComp<AutoOrientComponent>(ev.SpawnResult.Value);
         var passenger = EnsureComp<ESArrivalsPassengerComponent>(ev.SpawnResult.Value);
         passenger.Station = ev.Station.Value;
+    }
+
+    private void OnFTLCompleted(Entity<ESArrivalsShuttleComponent> ent, ref FTLCompletedEvent args)
+    {
+        _gameTicker.AnnounceRound();
     }
 
     private void SetupShuttle(Entity<ESStationArrivalsComponent> ent)

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
@@ -22,4 +22,4 @@
       - id: ESBasicDecalDirtMonospaceVariationPass
       - tableId: ESMaplightParallaxVariationTable
       - id: ESNightshiftVariationPass
-        prob: 0.15
+        prob: 0.20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

- nightshift chance slightly higher
- welcome announcement plays when arrivals ftl finishes, not when the round starts