### PR TITLE
Masquerade round end

### DIFF
--- a/Content.Server/GameTicking/Rules/GameRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/GameRuleSystem.cs
@@ -18,6 +18,11 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly MapSystem _map = default!;
 
+    // ES CHANGE: Ordering of round end text is important.
+    public virtual Type[]? RoundEndTextBefore => null;
+    public virtual Type[]? RoundEndTextAfter => null;
+    // END ES CHANGE
+
     public override void Initialize()
     {
         base.Initialize();
@@ -26,7 +31,9 @@ public abstract partial class GameRuleSystem<T> : EntitySystem where T : ICompon
         SubscribeLocalEvent<T, GameRuleAddedEvent>(OnGameRuleAdded);
         SubscribeLocalEvent<T, GameRuleStartedEvent>(OnGameRuleStarted);
         SubscribeLocalEvent<T, GameRuleEndedEvent>(OnGameRuleEnded);
-        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndTextAppend);
+        // ES CHANGE: Ordering of round end text is important.
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndTextAppend, before: RoundEndTextBefore, after: RoundEndTextAfter);
+        // END ES CHANGE
     }
 
     private void OnStartAttempt(RoundStartAttemptEvent args)

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.Roundend.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.Roundend.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.GameTicking;
+using Content.Shared.GameTicking.Components;
 
 namespace Content.Server._ES.Masks.Masquerades;
 
@@ -7,11 +8,9 @@ public sealed partial class ESMasqueradeSystem
 {
     [Dependency] private readonly ILocalizationManager _loc = default!;
 
-    private void OnRoundEndTextAppend(RoundEndTextAppendEvent ev)
+    protected override void AppendRoundEndText(EntityUid uid, ESMasqueradeRuleComponent component, GameRuleComponent gameRule, ref RoundEndTextAppendEvent ev)
     {
-        var rule = EntityQuery<ESMasqueradeRuleComponent>().SingleOrDefault();
-
-        if (rule?.Masquerade is not {} masquerade)
+        if (component.Masquerade is not { } masquerade)
             return;
 
         ev.AddLine(
@@ -22,6 +21,8 @@ public sealed partial class ESMasqueradeSystem
                 )
             );
 
-
+        // I just want like, a couple blanks.
+        ev.AddLine(string.Empty);
+        ev.AddLine(string.Empty);
     }
 }

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.Roundend.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.Roundend.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using Content.Server.GameTicking;
+
+namespace Content.Server._ES.Masks.Masquerades;
+
+public sealed partial class ESMasqueradeSystem
+{
+    [Dependency] private readonly ILocalizationManager _loc = default!;
+
+    private void OnRoundEndTextAppend(RoundEndTextAppendEvent ev)
+    {
+        var rule = EntityQuery<ESMasqueradeRuleComponent>().SingleOrDefault();
+
+        if (rule?.Masquerade is not {} masquerade)
+            return;
+
+        ev.AddLine(
+            Loc.GetString(
+                "es-roundend-masquerade-reveal",
+                ("masquerade", masquerade.LocName(_loc)),
+                ("description", masquerade.LocDescription(_loc))
+                )
+            );
+
+
+    }
+}

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
@@ -22,7 +22,7 @@ namespace Content.Server._ES.Masks.Masquerades;
 /// <summary>
 ///     This handles masquerade management and how they influence game flow.
 /// </summary>
-public sealed class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRuleComponent>
+public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRuleComponent>
 {
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
@@ -41,6 +41,7 @@ public sealed class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRuleComponen
 
         SubscribeLocalEvent<AssignLatejoinerToTroupeEvent>(OnAssignLatejoiner);
         SubscribeLocalEvent<AssignPlayersToTroupeEvent>(OnAssignPlayers);
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndTextAppend, before: [typeof(ESMaskSystem)]);
     }
 
     private void OnAssignPlayers(ref AssignPlayersToTroupeEvent ev)

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
@@ -34,6 +34,8 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
     // Icky global state.
     private ProtoId<ESMasqueradePrototype>? _forcedMasquerade = null;
 
+    public override Type[]? RoundEndTextBefore => [typeof(ESMaskSystem)];
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -41,7 +43,6 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
 
         SubscribeLocalEvent<AssignLatejoinerToTroupeEvent>(OnAssignLatejoiner);
         SubscribeLocalEvent<AssignPlayersToTroupeEvent>(OnAssignPlayers);
-        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEndTextAppend, before: [typeof(ESMaskSystem)]);
     }
 
     private void OnAssignPlayers(ref AssignPlayersToTroupeEvent ev)

--- a/Resources/Locale/en-US/_ES/masks/roundend.ftl
+++ b/Resources/Locale/en-US/_ES/masks/roundend.ftl
@@ -9,4 +9,5 @@ es-roundend-mask-player-summary = {$name} [color=gray]({$username})[/color] play
 }
 es-roundend-mask-player-group = [font size=14][color={$color}][bold]{$name}[/bold][/color][/font]
 
-es-roundend-masquerade-reveal = [font size=16]Annnd that's a wrap! Today's show was themed "{$masquerade}", which {$description}.
+es-roundend-masquerade-reveal = [font size=16]Annnd that's a wrap! Today's show was themed "{$masquerade}",
+                                which {$description}.[/font]

--- a/Resources/Locale/en-US/_ES/masks/roundend.ftl
+++ b/Resources/Locale/en-US/_ES/masks/roundend.ftl
@@ -8,3 +8,5 @@ es-roundend-mask-player-summary = {$name} [color=gray]({$username})[/color] play
     *[Other] with the following objectives:
 }
 es-roundend-mask-player-group = [font size=14][color={$color}][bold]{$name}[/bold][/color][/font]
+
+es-roundend-masquerade-reveal = [font size=16]Annnd that's a wrap! Today's show was themed "{$masquerade}", which {$description}.

--- a/Resources/Prototypes/_ES/Masquerades/freakshow.yml
+++ b/Resources/Prototypes/_ES/Masquerades/freakshow.yml
@@ -1,7 +1,7 @@
 - type: esMasquerade
   id: Freakshow
   name: Freakshow
-  description: Packs the round with almost nothing but high noise crew masks.
+  description: packs the round with almost nothing but high noise crew masks, no traitors in sight
   weight: 1
   minPlayers: 4
   gameRules: []

--- a/Resources/Prototypes/_ES/Masquerades/random.yml
+++ b/Resources/Prototypes/_ES/Masquerades/random.yml
@@ -1,7 +1,7 @@
 - type: esMasquerade
   id: Random
   name: Random
-  description: A truly random traitors round.
+  description: is a truly randomized traitorous experience
   weight: 10
   minPlayers: 1
   gameRules: []

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -1,7 +1,7 @@
 - type: esMasquerade
   id: Showdown
   name: Showdown
-  description: A real showdown, with many more guns than usual.
+  description: is a real showdown, with many more guns than usual
   weight: 1 # Not that common
   minPlayers: 6
   gameRules: []


### PR DESCRIPTION
Adds some round-end text describing the masquerade. I considered including the roles too but I'd need to manually wrap the list for it to be readable and you can also just look at the players.

<img width="707" height="590" alt="image" src="https://github.com/user-attachments/assets/f5369999-f5f6-40b3-a16e-003fececc6fd" />


Fixes #716