### PR TITLE
Add a new aura for oracles.

### DIFF
--- a/Resources/Locale/en-US/_ES/masks/crew/empath.ftl
+++ b/Resources/Locale/en-US/_ES/masks/crew/empath.ftl
@@ -1,3 +1,4 @@
+es-aura-oracle = immense wisdom, this one is an oracle too
 es-aura-killing-intent = dangerous killing intent
 es-aura-basic = neutral aura
 

--- a/Resources/Prototypes/_ES/Actions/Masks/empath.yml
+++ b/Resources/Prototypes/_ES/Actions/Masks/empath.yml
@@ -22,17 +22,26 @@
 
 # Default aura. Shown if nothing else is detected
 - type: esAura
-  id: ESBasic
+  id: Basic
   description: es-aura-basic
   popupType: Large
   priority: -1 # shown only by default
 
 # Killing intent. Used for anyone who wants to murder someone, even themselves!
 - type: esAura
-  id: ESKillingIntent
+  id: KillingIntent
   description: es-aura-killing-intent
   objectiveWhitelist:
     components:
     - ESKillTroupeObjective
     - ESKillTargetObjective
     - ESDetonateNukeObjective
+
+# Wise aura, for oracle identification. Oracles
+- type: esAura
+  id: Oracle
+  description: es-aura-oracle
+  objectiveWhitelist: {}
+  priority: 10 # A murderous oracle is still an oracle.
+  maskOverrides:
+  - ESEmpath


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This allows Empaths to identify each-other and other oracle-like roles, giving them a stronger base to build trust on.

## Why / Balance
Information economy in ES is currently very gimped, making social deduction harder than it should be. This gives oracles some extra info (who else is an oracle, without room for jesters or future not-seen-as-murderous traitors to interfere) and should help them band together.

## Media
<img width="617" height="168" alt="image" src="https://github.com/user-attachments/assets/29e956d7-ab2b-41ce-b5cd-2d0986af52f9" />

## Remarks
Tested this on a few masks, both oracles (empath) and non-oracles, all seems to be working.
