### PR TITLE
Subverter chip improvements

### DIFF
--- a/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
@@ -85,14 +85,11 @@ public sealed class ESAddMaskOnUseSystem : EntitySystem
 
         var toAddTroupe = _proto.Index(ent.Comp.MaskToAdd).Troupe;
 
-        if (!_mask.TryGetTroupeEntity(toAddTroupe, out var troupe))
-            return;
-
         if (_mask.GetTroupeOrNull((mind, mindComponent)) == toAddTroupe)
             return;
 
         _mask.RemoveMask((mind, mindComponent));
-        _mask.ApplyMask((mind, mindComponent), ent.Comp.MaskToAdd, troupe.Value);
+        _mask.ApplyMask((mind, mindComponent), ent.Comp.MaskToAdd, null);
 
         ent.Comp.Used = true;
         Dirty(ent);

--- a/Resources/Locale/en-US/_ES/masks/traitor/subverter.ftl
+++ b/Resources/Locale/en-US/_ES/masks/traitor/subverter.ftl
@@ -1,5 +1,5 @@
 ﻿es-subverter-chip-used = It's already been used!
 es-subverter-chip-implanting = Implanting subversion chip!
-es-subverter-chip-examined-usable = [color=green]This chip has not been used[/color]
-es-subverter-chip-examined-used = [color=red]This chip has been used[/color]
+es-subverter-chip-examined-usable = [color=green]This chip has not been used.[/color]
+es-subverter-chip-examined-used = [color=red]This chip has been used![/color]
 es-subverter-chip-not-crit = Target not crit!

--- a/Resources/Prototypes/_ES/Entities/Objects/Devices/subverter.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Devices/subverter.yml
@@ -2,7 +2,7 @@
   parent: [BaseItem, BaseSyndicateContraband]
   id: ESSubverterChip
   name: subverter chip
-  description: A brain altering chip used to recruit people to the syndicate.
+  description: A brain altering chip used to recruit people to the syndicate. When used on someone in a critical state, it will brainwash and convert them into a member of the Syndicate. No take-backs!
   suffix: ES
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Closes #686 
Closes #741 

lightly modifies the chip description to explain how to use it. Oops.

Changes the conversion logic so that it starts the rule if one doesn't exist. This means that if you use a subverter chip in a non-traitor round, it'll just start up the traitor rule and let them play as if it was one. Extremely funny.

Additionally fixes an extremely minor bug: in the event that the mask is added without a proper troupe entity, the troupe would roll objectives as if there were no members. This means that you could get a kill objective on yourself, which would be pretty damn stupid. Fixed it by just delaying when we "start" the rule until after we've added the player onto the troupe.

<img width="806" height="486" alt="image" src="https://github.com/user-attachments/assets/c4725cfb-5af0-4347-8e18-3d883752933a" />
