### PR TITLE
Meteor Event Redux

### DIFF
--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -119,4 +119,12 @@ public abstract class StationEventSystem<T> : GameRuleSystem<T> where T : ICompo
             }
         }
     }
+// ES START
+    public void SetStartAnnouncement(Entity<StationEventComponent?> ent, string? announcement)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+        ent.Comp.StartAnnouncement = announcement;
+    }
+// ES END
 }

--- a/Content.Server/_ES/StationEvents/Meteors/Components/ESAngleVoteComponent.cs
+++ b/Content.Server/_ES/StationEvents/Meteors/Components/ESAngleVoteComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared._ES.Voting.Components;
+
+namespace Content.Server._ES.StationEvents.Meteors.Components;
+
+/// <summary>
+/// <see cref="ESVoteComponent"/> for a random angle
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ESMeteorsRule))]
+public sealed partial class ESAngleVoteComponent : Component
+{
+    [DataField]
+    public int Count = 4;
+}

--- a/Content.Server/_ES/StationEvents/Meteors/Components/ESMeteorsRuleComponent.cs
+++ b/Content.Server/_ES/StationEvents/Meteors/Components/ESMeteorsRuleComponent.cs
@@ -1,0 +1,53 @@
+using Content.Shared.EntityTable.EntitySelectors;
+
+namespace Content.Server._ES.StationEvents.Meteors.Components;
+
+/// <summary>
+/// Used for a station event that shoots a few waves of meteors at the station.
+/// </summary>
+[RegisterComponent, AutoGenerateComponentPause]
+[Access(typeof(ESMeteorsRule))]
+public sealed partial class ESMeteorsRuleComponent : Component
+{
+    /// <summary>
+    /// Angle the meteors are launched from
+    /// </summary>
+    [DataField]
+    public Angle LaunchAngle;
+
+    /// <summary>
+    /// The meteors that are spawned each wave
+    /// </summary>
+    [DataField]
+    public EntityTableSelector MeteorTable = new NoneSelector();
+
+    /// <summary>
+    /// How fast the meteors fly
+    /// </summary>
+    [DataField]
+    public float MeteorVelocity = 10f;
+
+    /// <summary>
+    /// How many waves of meteors will spawn
+    /// </summary>
+    [DataField]
+    public int Waves = 3;
+
+    /// <summary>
+    /// When the next wave will occur
+    /// </summary>
+    [DataField, AutoPausedField]
+    public TimeSpan NextWaveTime;
+
+    /// <summary>
+    /// Minimum delay between waves
+    /// </summary>
+    [DataField]
+    public TimeSpan MinWaveDelay = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Maximum delay between waves
+    /// </summary>
+    [DataField]
+    public TimeSpan MaxWaveDelay = TimeSpan.FromSeconds(30);
+}

--- a/Content.Server/_ES/StationEvents/Meteors/ESMeteorsRule.cs
+++ b/Content.Server/_ES/StationEvents/Meteors/ESMeteorsRule.cs
@@ -1,0 +1,93 @@
+using System.Numerics;
+using Content.Server._ES.StationEvents.Meteors.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared._ES.Core;
+using Content.Shared._ES.Voting.Components;
+using Content.Shared._ES.Voting.Results;
+using Content.Shared.EntityTable;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Localizations;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+
+namespace Content.Server._ES.StationEvents.Meteors;
+
+public sealed class ESMeteorsRule : StationEventSystem<ESMeteorsRuleComponent>
+{
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
+    [Dependency] private readonly PhysicsSystem _physics = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESAngleVoteComponent, ESGetVoteOptionsEvent>(OnGetVoteOptions);
+        SubscribeLocalEvent<ESMeteorsRuleComponent, ESSynchronizedVotesCompletedEvent>(OnVotesCompleted);
+    }
+
+    private void OnGetVoteOptions(Entity<ESAngleVoteComponent> ent, ref ESGetVoteOptionsEvent args)
+    {
+        for (var i = 0; i < ent.Comp.Count; i++)
+        {
+            var angle = RobustRandom.NextAngle();
+            var readableAngle = angle.ToCompassAngle();
+            args.Options.Add(new ESAngleVoteOption
+            {
+                Angle = angle,
+                DisplayString = Loc.GetString("es-angle-vote-option-fmt", ("dir", ContentLocalizationManager.FormatDirection(angle.GetDir())), ("angle", (int) readableAngle.Degrees)),
+            });
+        }
+    }
+
+    private void OnVotesCompleted(Entity<ESMeteorsRuleComponent> ent, ref ESSynchronizedVotesCompletedEvent args)
+    {
+        if (!args.TryGetResult<ESAngleVoteOption>(0, out var angle))
+            return;
+
+        ent.Comp.LaunchAngle = angle.Angle;
+        SetStartAnnouncement(ent.Owner, Loc.GetString("es-station-event-meteor-swarm-start-announcement", ("dir", ContentLocalizationManager.FormatDirection(angle.Angle.GetDir()).ToLowerInvariant())));
+    }
+
+    protected override void Started(EntityUid uid, ESMeteorsRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        component.NextWaveTime = Timing.CurTime;
+    }
+
+    protected override void ActiveTick(EntityUid uid, ESMeteorsRuleComponent component, GameRuleComponent gameRule, float frameTime)
+    {
+        if (Timing.CurTime < component.NextWaveTime)
+            return;
+        component.NextWaveTime += RobustRandom.Next(component.MinWaveDelay, component.MaxWaveDelay);
+
+        if (!TryGetRandomStation(out var station) ||
+            StationSystem.GetLargestGrid(station.Value) is not { } grid)
+            return;
+
+        var xform = Transform(grid);
+        var mapId = xform.MapID;
+
+        var gridAABB = _physics.GetWorldAABB(grid);
+        var gridHalfExtent = gridAABB.Extents.Length() / 2;
+
+        foreach (var spawnProto in _entityTable.GetSpawns(component.MeteorTable))
+        {
+            var angle = (xform.LocalRotation + component.LaunchAngle.Opposite() - MathF.PI / 2).Opposite();
+
+            var distanceOffset = MathHelper.Lerp(gridHalfExtent + 100, gridHalfExtent + 150, RobustRandom.NextFloat());
+            var lateralOffset = gridAABB.MinDimension() * RobustRandom.NextFloat(-1, 1) / 2;
+            var offset = angle.RotateVec(new Vector2(distanceOffset, lateralOffset));
+
+            var spawnPosition = new MapCoordinates(gridAABB.Center + offset, mapId);
+            var meteor = Spawn(spawnProto, spawnPosition);
+            var physics = Comp<PhysicsComponent>(meteor);
+            _physics.ApplyLinearImpulse(meteor, -angle.ToVec() * component.MeteorVelocity * physics.Mass, body: physics);
+        }
+
+        if (--component.Waves <= 0)
+            ForceEndSelf(uid, gameRule);
+    }
+}

--- a/Content.Shared/_ES/Core/ESAngleHelpers.cs
+++ b/Content.Shared/_ES/Core/ESAngleHelpers.cs
@@ -1,0 +1,16 @@
+namespace Content.Shared._ES.Core;
+
+public static class ESAngleHelpers
+{
+    /// <summary>
+    /// Converts an angle to a "navigational angle" where true north is 0 degrees and as theta increases, it continues clockwise.
+    /// </summary>
+    public static Angle ToCompassAngle(this Angle angle)
+    {
+        var offsetAngle = Math.PI - angle.Theta;
+        if (offsetAngle < 0)
+            offsetAngle += Math.Tau;
+
+        return new Angle(offsetAngle % Math.Tau);
+    }
+}

--- a/Content.Shared/_ES/Core/ESBox2Helpers.cs
+++ b/Content.Shared/_ES/Core/ESBox2Helpers.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._ES.Core;
+
+public static class ESBox2Helpers
+{
+    public static float MinDimension(this Box2 box)
+    {
+        return Math.Min(box.Width, box.Height);
+    }
+}

--- a/Content.Shared/_ES/Random/ESRandomHelpers.cs
+++ b/Content.Shared/_ES/Random/ESRandomHelpers.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Destructible.Thresholds;
 using Robust.Shared.Random;
 
 namespace Content.Shared._ES.Random;
@@ -7,5 +8,10 @@ public static class ESRandomHelpers
     public static Color NextColor(this IRobustRandom random, bool withAlpha = false)
     {
         return new Color(random.NextByte(), random.NextByte(), random.NextByte(), withAlpha ? random.NextByte() : byte.MaxValue);
+    }
+
+    public static int Next(this IRobustRandom random, MinMax minMax)
+    {
+        return random.Next(minMax.Min, minMax.Max + 1);
     }
 }

--- a/Content.Shared/_ES/Voting/Components/ESVoteComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESVoteComponent.cs
@@ -82,7 +82,7 @@ public record struct ESGetVoteOptionsEvent()
     /// <summary>
     /// The options for voting.
     /// </summary>
-    public readonly List<ESVoteOption> Options = new();
+    public readonly HashSet<ESVoteOption> Options = new();
 }
 
 /// <summary>

--- a/Content.Shared/_ES/Voting/Results/ESAngleVoteOption.cs
+++ b/Content.Shared/_ES/Voting/Results/ESAngleVoteOption.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._ES.Voting.Results;
+
+[Serializable, NetSerializable]
+public sealed partial class ESAngleVoteOption : ESVoteOption
+{
+    [DataField]
+    public Angle Angle;
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ESAngleVoteOption other && Angle.Equals(other.Angle);
+    }
+
+    public override int GetHashCode()
+    {
+        return Angle.GetHashCode();
+    }
+}

--- a/Resources/Locale/en-US/_ES/station-events/meteors.ftl
+++ b/Resources/Locale/en-US/_ES/station-events/meteors.ftl
@@ -1,0 +1,4 @@
+es-station-event-meteor-swarm-start-announcement = Meteors have been detected on collision course with the station approaching from the {$dir}.
+es-angle-vote-option-fmt = {$dir} ({$angle}°)
+
+es-voter-query-string-meteors-direction = The direction meteors are coming from is:

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -45,7 +45,6 @@
     - id: ESStationEventSolarFlare
     - id: ESStationEventVentClog
     - id: ESStationEventMeteorSwarm
-    - id: ESStationEventSpaceDust
     - id: ESStationEventElectricalFire
 
 # Event Prototypes
@@ -219,45 +218,33 @@
 - type: entity
   parent: ESBaseStationEventDelayed
   id: ESStationEventMeteorSwarm
-  name: Meteor Swarm
+  name: Meteors
   description: Launch deadly meteors at the exterior of the station that smash through walls.
   components:
   - type: StationEvent
-    startAudio: null
     earliestStart: 30
-  - type: MeteorSwarm
-    announcementSound:
+    duration: null
+    startAudio:
       path: /Audio/_ES/Announcements/meteors.ogg
       params:
         volume: -4
-    meteors:
-      ESMeteor: 1
+    startAnnouncement: station-event-meteor-swarm-start-announcement
+  - type: ESMeteorsRule
+    meteorTable:
+      id: ESMeteor
+      amount: 4, 7
+  - type: ESSynchronizedVoteManager
+    votes:
+    - ESVoteMeteorDirection
 
-## Space Dust
 - type: entity
-  parent: ESBaseStationEventDelayed
-  id: ESStationEventSpaceDust
-  name: Space Dust
-  description: Send waves of space dust that batter the station from all sides.
+  id: ESVoteMeteorDirection
+  name: Which direction should the meteors come from?
   components:
-  - type: StationEvent
-    startAudio: null
-    earliestStart: 30
-  - type: MeteorSwarm
-    announcement: station-event-space-dust-start-announcement
-    announcementSound:
-      path: /Audio/_ES/Announcements/space_dust.ogg
-      params:
-        volume: -4
-    nonDirectional: true
-    meteors:
-      MeteorSpaceDust: 1
-    waves:
-      min: 2
-      max: 3
-    meteorsPerWave:
-      min: 8
-      max: 12
+  - type: ESVote
+    queryString: es-voter-query-string-meteors-direction
+    duration: 30
+  - type: ESAngleVote
 
 ## Electrical Fire
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
meteors now have stagehand integration for which direction they'll come from. the meteor announcement also now broadcasts the direction they're coming from.

also removes space dust for being very boring

bleh this took too long

Closes #715 
Closes #718 