### PR TITLE
Fix potential bug in troupe objective targeting

### DIFF
--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -165,7 +165,7 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         return true;
     }
 
-    public override void ApplyMask(Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId, Entity<ESTroupeRuleComponent>? troupe)
+    public override void ApplyMask(Entity<MindComponent> mind, ProtoId<ESMaskPrototype> maskId, Entity<ESTroupeRuleComponent>? troupe = null)
     {
         var mask = PrototypeManager.Index(maskId);
 

--- a/Content.Shared/_ES/Masks/ESMasqueradePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESMasqueradePrototype.cs
@@ -3,8 +3,6 @@ using Content.Shared._ES.Masks.Masquerades;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
-using YamlDotNet.Serialization.Utilities;
 
 namespace Content.Shared._ES.Masks;
 
@@ -79,8 +77,8 @@ public sealed partial class ESMasqueradePrototype : IPrototype, ISerializationHo
     /// <summary>
     ///     The gamerules to use for this masquerade.
     /// </summary>
-    [DataField(required: true, serverOnly: true)]
-    public IReadOnlyList<EntProtoId> GameRules { get; private set; } = default!;
+    [DataField(serverOnly: true)]
+    public IReadOnlyList<EntProtoId> GameRules { get; private set; } = [];
 
     [DataField(required: true, priority: 1)]
     public MasqueradeKind Masquerade { get; private set; } = default!;

--- a/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
@@ -86,7 +86,7 @@ public abstract class ESSharedMaskSystem : EntitySystem
                 {
                     if (!Mind.TryGetMind(actorComp.PlayerSession, out var mind, out var mindComp))
                         return;
-                    ApplyMask((mind, mindComp), mask, null);
+                    ApplyMask((mind, mindComp), mask);
                 },
             };
             args.Verbs.Add(verb);
@@ -284,7 +284,7 @@ public abstract class ESSharedMaskSystem : EntitySystem
     /// </remarks>
     public virtual void ApplyMask(Entity<MindComponent> mind,
         ProtoId<ESMaskPrototype> maskId,
-        Entity<ESTroupeRuleComponent>? troupe)
+        Entity<ESTroupeRuleComponent>? troupe = null)
     {
         // No Op
     }

--- a/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
@@ -89,7 +89,7 @@ public sealed class ESAddMaskOnUseSystem : EntitySystem
             return;
 
         _mask.RemoveMask((mind, mindComponent));
-        _mask.ApplyMask((mind, mindComponent), ent.Comp.MaskToAdd, null);
+        _mask.ApplyMask((mind, mindComponent), ent.Comp.MaskToAdd);
 
         ent.Comp.Used = true;
         Dirty(ent);


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #744 

There was a kind of obscure bug that could occur as the result of troupe rules being started before mask assignment was done. This results in situations where a troupe's objectives were created before all the members were assigned (as the rule was created after the first mask was applied) which meant that subsequent troupe members could be kill targets for themselves.

also does some very small tweaks in other parts because i got annoyed while testing some stuff.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
