### PR TITLE
Fix replays being broken

### DIFF
--- a/Resources/ConfigPresets/_ES/theater1.toml
+++ b/Resources/ConfigPresets/_ES/theater1.toml
@@ -4,6 +4,9 @@ hostname = "[EN][SRL] Ephemeral Space Theater I [US East]"
 [hub]
 tags = "lang:en,region:am_n_e"
 
+[replay]
+auto_record = true
+
 [whitelist]
 enabled = true
 prototype_list = "ESWhitelistDefault"


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
this class was cooked in a few different ways and would cause replays to break every time someone *checks notes* latejoined. 

so uh. I fixed it.

also enables auto record replays for theater 1 since i dont want to have to remember to turn it on every playtest

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
