### PR TITLE
Actual new player guidebook + other guidebook tweaks

### DIFF
--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -3,6 +3,7 @@ using Content.Client.Administration.Managers;
 using Content.Client.Gameplay;
 using Content.Client.Lobby;
 using Content.Client.RoundEnd;
+using Content.Client.UserInterface.Systems.Guidebook;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Prototypes;
@@ -177,6 +178,7 @@ namespace Content.Client.GameTicking.Managers
             _stateManager.RequestStateChange<LobbyState>();
             // ES START
             _startOpenAnimationTime = _timing.RealTime + TimeSpan.FromSeconds(0.5);
+            _userInterfaceManager.GetUIController<GuidebookUIController>().ToggleGuidebook();
             // ES END
         }
 

--- a/Content.Client/Guidebook/Controls/GuidebookRichPrototypeLink.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookRichPrototypeLink.cs
@@ -42,7 +42,7 @@ public sealed class GuidebookRichPrototypeLink : Control, IPrototypeLinkControl
     public void SetMessage(FormattedMessage message)
     {
         _message = message;
-        _richTextLabel.SetMessage(_message);
+        _richTextLabel.SetMessage(_message, tagsAllowed: null);
     }
 
     public IPrototype? LinkedPrototype { get; set; }

--- a/Content.Client/Guidebook/DocumentParsingManager.static.cs
+++ b/Content.Client/Guidebook/DocumentParsingManager.static.cs
@@ -82,7 +82,7 @@ public sealed partial class DocumentParsingManager
                     }
 
                     msg.Pop();
-                    rt.SetMessage(msg);
+                    rt.SetMessage(msg, tagsAllowed: null);
                     return rt;
                 },
                 TextParser)

--- a/Content.Client/Info/InfoSection.xaml.cs
+++ b/Content.Client/Info/InfoSection.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class InfoSection : BoxContainer
     {
         TitleLabel.Text = title;
         if (markup)
-            Content.SetMessage(FormattedMessage.FromMarkupOrThrow(text.Trim()));
+            Content.SetMessage(FormattedMessage.FromMarkupOrThrow(text.Trim()), tagsAllowed: null);
         else
             Content.SetMessage(text);
     }

--- a/Content.Client/Info/ServerInfo.cs
+++ b/Content.Client/Info/ServerInfo.cs
@@ -24,7 +24,7 @@ namespace Content.Client.Info
         }
         public void SetInfoBlob(string markup)
         {
-            _richTextLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(markup));
+            _richTextLabel.SetMessage(FormattedMessage.FromMarkupOrThrow(markup), tagsAllowed: null);
         }
     }
 }

--- a/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
+++ b/Content.Client/UserInterface/Systems/Guidebook/GuidebookUIController.cs
@@ -211,9 +211,12 @@ public sealed class GuidebookUIController : UIController, IOnStateEntered<LobbyS
         }
         _guideWindow.UpdateGuides(guides, rootEntries, forceRoot, selected);
 
+        // ES START
+        // only expand to depth 1
         // Expand up to depth-2.
         _guideWindow.Tree.SetAllExpanded(false);
-        _guideWindow.Tree.SetAllExpanded(true, 1);
+        _guideWindow.Tree.SetAllExpanded(true, 0);
+        // ES END
 
         _guideWindow.OpenCenteredRight();
     }

--- a/Resources/ConfigPresets/_ES/base.toml
+++ b/Resources/ConfigPresets/_ES/base.toml
@@ -40,3 +40,6 @@ grid_fill = false
 [tips]
 dataset = "ESTips"
 login_dataset = "ESTips"
+
+[server]
+default_guide = "ESNewPlayerES"

--- a/Resources/Locale/en-US/_ES/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_ES/guidebook/guides.ftl
@@ -1,3 +1,7 @@
 # Troupes & Masks
 es-guide-entry-troupes-and-masks = Troupes & Masks
 es-guide-entry-crew = Crew
+
+# New player
+es-guide-entry-newplayer = New to SS14
+es-guide-entry-newplayer-es = New to Ephemeral Space

--- a/Resources/Prototypes/_ES/Guidebook/masks.yml
+++ b/Resources/Prototypes/_ES/Guidebook/masks.yml
@@ -1,6 +1,7 @@
 - type: guideEntry
   id: ESTroupesAndMasks
   hidden: false
+  priority: 5
   name: es-guide-entry-troupes-and-masks
   text: "/ServerInfo/_ES/Guidebook/Masks/TroupesAndMasks.xml"
   children:

--- a/Resources/Prototypes/_ES/Guidebook/newplayer.yml
+++ b/Resources/Prototypes/_ES/Guidebook/newplayer.yml
@@ -1,19 +1,25 @@
 - type: guideEntry
+  id: ESNewPlayerES
+  hidden: false
+  name: es-guide-entry-newplayer-es
+  priority: 0
+  text: "/ServerInfo/_ES/Guidebook/NewPlayer/NewPlayerES.xml"
+
+- type: guideEntry
   id: ESNewPlayer
   hidden: false
-  name: guide-entry-newplayer
-  priority: 0
+  name: es-guide-entry-newplayer
+  priority: 1
   text: "/ServerInfo/_ES/Guidebook/NewPlayer/NewPlayer.xml"
   children:
   - ESControls
+  - ESRadio
 
 - type: guideEntry
   id: ESControls
   hidden: false
   name: guide-entry-controls
   text: "/ServerInfo/_ES/Guidebook/NewPlayer/Controls/Controls.xml"
-  children:
-  - ESRadio
 
 - type: guideEntry
   id: ESRadio

--- a/Resources/Prototypes/_ES/Guidebook/references.yml
+++ b/Resources/Prototypes/_ES/Guidebook/references.yml
@@ -8,8 +8,8 @@
   - ESChemicals
   - ESDrinks
   - ESFoodRecipes
+  - ESSpaceLaw
   - ESWriting
-  - Lawsets
 
 - type: guideEntry
   id: ESDrinks

--- a/Resources/Prototypes/_ES/Guidebook/station.yml
+++ b/Resources/Prototypes/_ES/Guidebook/station.yml
@@ -7,7 +7,6 @@
   children:
   - ESJobs
   - ESSurvival
-  - ESTroupesAndMasks
   - ESGlossary
 
 - type: guideEntry

--- a/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
@@ -1,45 +1,42 @@
 <Document>
-# Welcome to Ephemeral Space!
+  # Welcome to Space Station 14!
 
-Things might seem a little strange right now if you're used to regular Space Station 14 gameplay.
+  You've just begun your shift aboard a Nanotrasen space station.
+  You and your fellow crewmates are tasked with working together, surviving, and having fun!
 
-In Ephemeral Space, [bold]you start the game in the lobby[/bold], which is an entire world unto itself. Here, you are a theatergoer attending the performance of an immersive play themed around a chaotic space station environment. In the theater (the lobby), you can explore the area, chat with other theatergoers about the upcoming performance, and interact with various objects.
+  [bold]Make sure to follow all server rules.[/bold] You can ask questions or report rule breaks to the [color=#EB2D3A][bold]admin team[/bold][/color] by using the [bold]admin help menu[/bold]. ([italic]accessible by pressing [/italic][color=yellow][bold][keybind="OpenAHelp"/][/bold][/color])
 
-[bold]In order to ready up, or join the performance if it's already started, head down past the curtains separating the main theater area and the lobby, and walk onto the stage.[/bold] If you'd prefer to observe instead, take a seat in the audience by clicking on an open chair.
+  More detailed guides about [italic]specific jobs[/italic] and [italic]mechanics[/italic] can be found [textlink="here." link="SS14"/]
 
-[bold]Make sure to follow all server rules.[/bold] You can ask questions or report rule breaks to the [color=#EB2D3A][bold]admin team[/bold][/color] by using the [bold]admin help menu[/bold]. ([italic]accessible by pressing [/italic][color=yellow][bold][keybind="OpenAHelp"/][/bold][/color])
+  This guide can be reopened at any time using [color=yellow][bold][keybind="OpenGuidebook"][/bold][/color].
 
-More detailed guides about [italic]specific jobs[/italic] and [italic]mechanics[/italic] can be found [textlink="here." link="SS14"/]
+  ## Basic Controls
+  The following are the controls you'll need for regular gameplay:
 
-This guide can be reopened at any time using [color=yellow][bold][keybind="OpenGuidebook"][/bold][/color].
+  - Run using [color=yellow][bold][keybind="MoveUp"][keybind="MoveLeft"][keybind="MoveDown"][keybind="MoveRight"][/bold][/color]. Hold down [color=yellow][bold][keybind="Walk"][/bold][/color] to walk
 
-## Basic Controls
-The following are the controls you'll need for regular gameplay:
+  - Examine the world around you with [color=yellow][bold][keybind="ExamineEntity"][/bold][/color]
 
-- Run using [color=yellow][bold][keybind="MoveUp"][keybind="MoveLeft"][keybind="MoveDown"][keybind="MoveRight"][/bold][/color]. Hold down [color=yellow][bold][keybind="Walk"][/bold][/color] to walk
+  - Interact with the world using [color=yellow][bold][keybind="Use"][/bold][/color]
 
-- Examine the world around you with [color=yellow][bold][keybind="ExamineEntity"][/bold][/color]
+  - Hovering over an entity and pressing [color=yellow][bold][keybind="UseSecondary"][/bold][/color] shows the [italic]context menu[/italic], which contains additional interactions
 
-- Interact with the world using [color=yellow][bold][keybind="Use"][/bold][/color]
+  - Swap hands using [color=yellow][bold][keybind="SwapHands"][/bold][/color] and activate the currently held item with [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color]
 
-- Hovering over an entity and pressing [color=yellow][bold][keybind="UseSecondary"][/bold][/color] shows the [italic]context menu[/italic], which contains additional interactions
+  - Drop held items with [color=yellow][bold][keybind="Drop"][/bold][/color] or throw them using [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color]
 
-- Swap hands using [color=yellow][bold][keybind="SwapHands"][/bold][/color] and activate the currently held item with [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color]
+  - Pull and release things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]
 
-- Drop held items with [color=yellow][bold][keybind="Drop"][/bold][/color] or throw them using [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color]
+  A more comprehensive list can be found on the [textlink="controls" link="Controls"] page.
 
-- Pull and release things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]
+  ## What is SS14?
+  Space Station 14 is a multiplayer game about paranoia and chaos on a space station and a remake of the cult-classic Space Station 13.
 
-A more comprehensive list can be found on the [textlink="controls" link="Controls"] page.
+  Join dozens of other players on an intricately designed and simulated space station, immersing yourself in roleplay and dealing with threats along the way.
 
-## What is SS14?
-Space Station 14 is a multiplayer game about paranoia and chaos on a space station and a remake of the cult-classic Space Station 13.
+  SS14 is an [italic]open-source game[/italic] developed by people [bold]just like you![/bold]
+  It receives [color=lime]daily updates[/color] and may at times be [color=#EB2D3A][bold]unstable.[/bold][/color]
 
-Join dozens of other players on an intricately designed and simulated space station, immersing yourself in roleplay and dealing with threats along the way.
-
-SS14 is an [italic]open-source game[/italic] developed by people [bold]just like you![/bold]
-It receives [color=lime]daily updates[/color] and may at times be [color=#EB2D3A][bold]unstable.[/bold][/color]
-
-[italic]If you want to report bugs or help with development, join the discord and learn how to get started.[/italic]
+  [italic]If you want to report bugs or help with development, join the discord and learn how to get started.[/italic]
 
 </Document>

--- a/Resources/ServerInfo/_ES/Guidebook/NewPlayer/NewPlayer.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/NewPlayer/NewPlayer.xml
@@ -1,35 +1,27 @@
 <Document>
-# Welcome to Ephemeral Space!
+  # Welcome to Space Station 14!
 
-Things might seem a little strange right now if you're used to regular Space Station 14 gameplay.
+  More detailed guides about [italic]specific jobs[/italic] and [italic]mechanics[/italic] can be found [textlink="here." link="SS14"/]
 
-In Ephemeral Space, [bold]you start the game in the lobby[/bold], which is an entire world unto itself. Here, you are a theatergoer attending the performance of an immersive play themed around a chaotic space station environment. In the theater (the lobby), you can explore the area, chat with other theatergoers about the upcoming performance, and interact with various objects.
+  This guide can be reopened at any time using [color=yellow][bold][keybind="OpenGuidebook"][/bold][/color].
 
-[bold]In order to ready up, or join the performance if it's already started, head down past the curtains separating the main theater area and the lobby, and walk onto the stage.[/bold] If you'd prefer to observe instead, take a seat in the audience by clicking on an open chair.
+  ## Basic Controls
+  The following are the controls you'll need for regular gameplay:
 
-[bold]Make sure to follow all server rules.[/bold] You can ask questions or report rule breaks to the [color=#EB2D3A][bold]admin team[/bold][/color] by using the [bold]admin help menu[/bold]. ([italic]accessible by pressing [/italic][color=yellow][bold][keybind="OpenAHelp"/][/bold][/color])
+  - Run using [color=yellow][bold][keybind="MoveUp"][keybind="MoveLeft"][keybind="MoveDown"][keybind="MoveRight"][/bold][/color]. Hold down [color=yellow][bold][keybind="Walk"][/bold][/color] to walk
 
-More detailed guides about [italic]specific jobs[/italic] and [italic]mechanics[/italic] can be found [textlink="here." link="ESSS14"/]
+  - Examine the world around you with [color=yellow][bold][keybind="ExamineEntity"][/bold][/color]
 
-This guide can be reopened at any time using [color=yellow][bold][keybind="OpenGuidebook"][/bold][/color].
+  - Interact with the world using [color=yellow][bold][keybind="Use"][/bold][/color]
 
-## Basic Controls
-The following are the controls you'll need for regular gameplay:
+  - Hovering over an entity and pressing [color=yellow][bold][keybind="UseSecondary"][/bold][/color] shows the [italic]context menu[/italic], which contains additional interactions
 
-- Run using [color=yellow][bold][keybind="MoveUp"][keybind="MoveLeft"][keybind="MoveDown"][keybind="MoveRight"][/bold][/color]. Hold down [color=yellow][bold][keybind="Walk"][/bold][/color] to walk
+  - Swap hands using [color=yellow][bold][keybind="SwapHands"][/bold][/color] and activate the currently held item with [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color]
 
-- Examine the world around you with [color=yellow][bold][keybind="ExamineEntity"][/bold][/color]
+  - Drop held items with [color=yellow][bold][keybind="Drop"][/bold][/color] or throw them using [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color]
 
-- Interact with the world using [color=yellow][bold][keybind="Use"][/bold][/color]
+  - Pull and release things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]
 
-- Hovering over an entity and pressing [color=yellow][bold][keybind="UseSecondary"][/bold][/color] shows the [italic]context menu[/italic], which contains additional interactions
-
-- Swap hands using [color=yellow][bold][keybind="SwapHands"][/bold][/color] and activate the currently held item with [color=yellow][bold][keybind="ActivateItemInHand"][/bold][/color]
-
-- Drop held items with [color=yellow][bold][keybind="Drop"][/bold][/color] or throw them using [color=yellow][bold][keybind="ThrowItemInHand"][/bold][/color]
-
-- Pull and release things with [color=yellow][bold][keybind="TryPullObject"][/bold][/color] and [color=yellow][bold][keybind="ReleasePulledObject"][/bold][/color]
-
-A more comprehensive list can be found on the [textlink="controls" link="ESControls"] page.
+  A more comprehensive list can be found on the [textlink="controls" link="Controls"] page.
 
 </Document>

--- a/Resources/ServerInfo/_ES/Guidebook/NewPlayer/NewPlayerES.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/NewPlayer/NewPlayerES.xml
@@ -1,0 +1,27 @@
+<Document>
+  # Welcome to Ephemeral Space!
+
+  [color=red][bold]Please read, even if you've played ES before!! Very important information here I promise[/color][/bold]
+
+  Things might seem a little strange right now if you're used to regular Space Station 14 gameplay.
+
+  In Ephemeral Space, [bold]you start the game in the lobby[/bold], which is an entire world unto itself. Here, you are a theatergoer attending the performance of an immersive play themed around a chaotic space station environment. In the theater (the lobby), you can explore the area, chat with other theatergoers about the upcoming performance, and interact with various objects.
+
+  [bold]In order to ready up, or join the performance if it's already started, head down past the curtains separating the main theater area and the lobby, and walk onto the stage.[/bold] If you'd prefer to observe instead, take a seat in the audience by clicking on an open chair.
+
+  Beyond that, let's talk about some very important differences between Ephemeral Space and regular servers that you should know before playing.
+
+  - Our ruleset is [bold]very[/bold] different. You should give it a read, and note what [italic]isn't[/italic] there--this server is intended to be much more of an open playground for roleplay and player expression, and our goal is to just design around bad gameplay rather than using rules.
+  - When the round starts, you'll be given a [textlink="mask" link="ESTroupesAndMasks"]--a hidden role which gives you unique objectives, abilities, or items, and defines your round. You are also part of a [textlink="troupe" link="ESTroupesAndMasks"], or a collection of players with shared central objectives. The two troupes currently are [bold]crew[/bold] and [bold]traitors[/bold].
+  - The character menu is very important here, and you should check it to see your mask objectives and troupe objectives. You can do so using [keybind="OpenCharacterMenu"].
+  - Rather than ending with the emergency shuttle, rounds on Ephemeral Space can end in one of three ways at the moment: a [bold]crew win[/bold], where they complete the telescience objectives and teleport the station to safety; a [bold]traitor win[/bold], where they complete their objectives and detonate the nuke; and a [bold]round fail[/bold], where both groups take too much time and the radstorm kills everybody on the station.
+  - Once dead, [bold]you cannot return to the round[/bold] and do not immediately become a ghost. Instead, you're sent to the lobby, and can become a [bold]stagehand[/bold] by interacting with an NPC below the lobby's stage. This allows you to observe as normal, vote on station events, and see all character's masks and objectives using an action.
+
+  Furthermore, we have some new controls that you should be aware of:
+  - [keybind="ESHoldToFace"] points your character in the direction of your cursor, without having to enable combat mode.
+  - [keybind="ESToggleFlashlight"] toggles your PDA flashlight, or opens a radial menu allowing you to toggle any lights you're carrying. These used to be actions.
+  - [keybind="ESToggleInternals"] toggles your internals if applicable. This used to be an action, though clicking the alert still works.
+  - Walking has been moved to space by default, but you may have already rebound this key.
+
+  [color=lavender]Enjoy the show![/color]
+</Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

- separated new player guides into "new to SS14" (and reverted it to the upstream one) and "new to ES" (the new default guide, opens when you enter the lobby)
- made guidebooks only open to depth 1 because it looks way less cluttered and better
- moved some guides around generally for easier use

had to cherrypick upstream markup fix because lol

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="1340" height="725" alt="image" src="https://github.com/user-attachments/assets/37b4d3a5-44ea-4668-9a93-4b34f05587e7" />
