### PR TITLE
Fix dungen preload/arrivals/centcom spawning on release

### DIFF
--- a/Resources/ConfigPresets/_ES/base.toml
+++ b/Resources/ConfigPresets/_ES/base.toml
@@ -35,6 +35,10 @@ maximum_width = 15
 # No gridfill
 [shuttle]
 grid_fill = false
+arrivals_planet = false
+
+[procgen]
+preload = false
 
 # Tips
 [tips]

--- a/Resources/Prototypes/_ES/Entities/Stations/base.yml
+++ b/Resources/Prototypes/_ES/Entities/Stations/base.yml
@@ -68,19 +68,11 @@
   - BaseStationCargo
   - BaseStationJobsSpawning
   - BaseStationRecords
-  - BaseStationGateway
-  - BaseStationShuttles
-  - BaseStationCentcomm
   - BaseStationAlertLevels
-  - BaseStationMagnet
-  - BaseStationExpeditions
-  - BaseStationSalvageJobs
-  - BaseStationSiliconLawCrewsimov
   - BaseStationAllEventsEligible
   - BaseStationNanotrasen
   - BaseStationDeliveries
   - ESBaseStationArrivals
-  - ESBaseStationEvacuation
   - ESBaseStationStoreroom
   - ESBaseStationTelesci
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

noticed while testing in release, this doesnt change anything functionally really but just makes less useless stuff spawn

also removes station comps for stuff like salvage and magnet and expeds etc etc etc also doesnt affect anything

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
