### PR TITLE
Fix misc loadouts

### DIFF
--- a/Resources/Prototypes/_ES/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -18,7 +18,6 @@
     shoes: ClothingShoesColorWhite
     eyes: ClothingEyesGlassesMeson
     id: AtmosPDA
-    gloves: ClothingHandsGlovesColorYellow
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
     jumpsuit: ClothingUniformJumpsuitAtmos

--- a/Resources/Prototypes/_ES/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Engineering/station_engineer.yml
@@ -19,7 +19,6 @@
     shoes: ClothingShoesColorOrange
     eyes: ClothingEyesGlassesMeson
     id: EngineerPDA
-    gloves: ClothingHandsGlovesColorYellow
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
     head: ClothingHeadHatHardhatYellow

--- a/Resources/Prototypes/_ES/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Science/scientist.yml
@@ -15,7 +15,6 @@
   equipment:
     shoes: ClothingShoesChef
     id: SciencePDA
-    gloves: ClothingHandsGlovesLatex
     neck: ClothingNeckTieSci
     ears: ClothingHeadsetScience
     jumpsuit: ClothingUniformJumpsuitScientist

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
@@ -33,4 +33,5 @@
     pocket1: ESWeaponHybridTaser
   storage:
     back:
+    - ESBoxSurvival
     - Flash


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #780 

- Secoffs get their survival box
- Scientists, engies, and atmos techs no longer spawn with gloves

i know the gloves change was for consistency but i just dont like latex with the base sci outfit + I think it's better to make engi go in and get insuls since they're useful for various shittery and traitorness roundstart.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
