### PR TITLE
Traitor equipment tweaks

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/equipment_caches.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/equipment_caches.yml
@@ -21,3 +21,6 @@
     - id: ESCrateCacheTraitorAssassin
     - id: ESCrateCacheTraitorInfiltrator
     - id: ESCrateCacheTraitorSubverter
+      weight: 0.5
+    - id: ESTraitorCacheTraitorDemolitionist
+      weight: 0.5

--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/equipment_caches.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/equipment_caches.yml
@@ -22,5 +22,5 @@
     - id: ESCrateCacheTraitorInfiltrator
     - id: ESCrateCacheTraitorSubverter
       weight: 0.5
-    - id: ESTraitorCacheTraitorDemolitionist
+    - id: ESCrateCacheTraitorDemolitionist
       weight: 0.5

--- a/Resources/Prototypes/_ES/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Fills/Crates/caches.yml
@@ -26,7 +26,8 @@
     - id: ESMagazine9mm
     - id: ESSleepyPen
       amount: 2
-    - id: EmpGrenade
+    - id: SmokeGrenade
+      amount: 2
 
 # Infiltrator
 - type: entity
@@ -45,7 +46,7 @@
     all:
     - id: ClothingBackpackChameleonFill
     - id: ESEmag
-    - id: SmokeGrenade
+    - id: C4
       amount: 2
 
 # Marauder


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #803 
Closes #807 
Closes #771 

- merc can now get demolitionist cache
- chance of a merc getting a subverter cache is lower
- assassins now get 2 smoke grenades instead of 1 emp
- infiltrators now get 2 C4 instead of 2 smoke grenades

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
