### PR TITLE
Widely remove job weights from everyone except captain and assistant.

### DIFF
--- a/Resources/Prototypes/_ES/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Civilian/assistant.yml
@@ -3,6 +3,7 @@
   name: ESjob-name-assistant
   description: ESjob-description-assistant
   playTimeTracker: ESJobAssistant
+  weight: -99999 # pick these guys last we don't need more of them.
   startingGear: ESAssistantGear
   icon: "JobIconPassenger"
   supervisors: job-supervisors-everyone

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/captain.yml
@@ -3,7 +3,7 @@
   name: ESjob-name-captain
   description: ESjob-description-captain
   playTimeTracker: ESJobCaptain
-  weight: 20
+  weight: 20 # The only guy with a higher weight, he is picked first for objective protection reasons.
   startingGear: ESCaptainGear
   icon: "JobIconCaptain"
   joinNotifyCrew: true

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_personnel.yml
@@ -3,7 +3,6 @@
   name: ESjob-name-hop
   description: ESjob-description-hop
   playTimeTracker: ESJobHeadOfPersonnel
-  weight: 20
   startingGear: ESHoPGear
   icon: "JobIconHeadOfPersonnel"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
@@ -3,7 +3,6 @@
   name: ESjob-name-hos
   description: ESjob-description-hos
   playTimeTracker: ESJobHeadOfSecurity
-  weight: 10
   startingGear: ESHoSGear
   icon: "JobIconHeadOfSecurity"
   supervisors: job-supervisors-captain

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
@@ -3,7 +3,6 @@
   name: ESjob-name-warden
   description: ESjob-description-warden
   playTimeTracker: ESJobWarden
-  weight: 5
   startingGear: ESWardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Removes the weights (pick priority) from most jobs, so people get railroaded into departments less. Adds a very, very low weight to assistant so the game prefers you job'd to jobless.

Also adds newlines because rider did so automatically.