### PR TITLE
Sabotage fixes and features

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -68,13 +68,15 @@ public sealed class RadioSystem : EntitySystem
 
         // pick 1 memory for the message
         // we don't distort it here, because its probably already distorted
-        var msg = _random.Pick(memory.SpeechMemories).Message;
-
-        foreach (var channel in keys.Channels)
+        if (memory.SpeechMemories.Count != 0)
         {
-            SendRadioMessage(ent.Owner, msg, channel, ent.Owner);
-        }
+            var msg = _random.Pick(memory.SpeechMemories).Message;
 
+            foreach (var channel in keys.Channels)
+            {
+                SendRadioMessage(ent.Owner, msg, channel, ent.Owner);
+            }
+        }
         args.Handled = true;
     }
 

--- a/Content.Shared/_ES/Masks/Traitor/Components/ESSabotageTargetComponent.cs
+++ b/Content.Shared/_ES/Masks/Traitor/Components/ESSabotageTargetComponent.cs
@@ -1,5 +1,4 @@
 using Robust.Shared.GameStates;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared._ES.Masks.Traitor.Components;
 
@@ -15,10 +14,4 @@ public sealed partial class ESSabotageTargetComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan SabotageTime = TimeSpan.FromSeconds(10);
-
-    /// <summary>
-    /// Troupe that is able to sabotage this object
-    /// </summary>
-    [DataField]
-    public ProtoId<ESTroupePrototype> SabotageTroupe = "ESTraitor";
 }

--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -167,8 +167,6 @@
   description: es-mask-vandal-desc
   color: tomato
   weight: 0.2
-  mindComponents:
-  - type: ESCanAlwaysSabotage
   objectives:
     all:
     - pick:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #687 
Closes #776 
Closes #779 

- fixes a bug where a degradation event on a tcomm server with no saved messagess would throw an exception. the visible result of this is that it would not register as complete.
- prevents doing multiple sabotages at once (i saw you, traitor sabotaging ID card and comms in bridge simultaneously)
- mild fuego change: prevents vandals and traitors from sabotaging things they don't have objectives for. I think this could be a bit lame but also i dont want an emag game knowledge situation where you have to memorize sabotage targets for game advantage. additionally, it's confusing for roles to have sabotage (which is explicitly like an objective-oriented thing) that doesn't actually complete any real objective.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
