### PR TITLE
Toast spawner changes + syringe gun

### DIFF
--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.0.0
   forkId: ""
   forkVersion: ""
-  time: 01/06/2026 01:13:52
-  entityCount: 14536
+  time: 01/06/2026 01:47:19
+  entityCount: 14539
 maps:
 - 3
 grids:
@@ -62922,13 +62922,6 @@ entities:
     - type: Transform
       pos: -10.5,-18.5
       parent: 2
-- proto: Hypospray
-  entities:
-  - uid: 1277
-    components:
-    - type: Transform
-      pos: 6.5,4.5
-      parent: 2
 - proto: IngotGold
   entities:
   - uid: 2215
@@ -63698,6 +63691,13 @@ entities:
     - type: Transform
       pos: 10.5,-36.5
       parent: 2
+- proto: LauncherSyringe
+  entities:
+  - uid: 11520
+    components:
+    - type: Transform
+      pos: 6.4526405,4.72605
+      parent: 2
 - proto: Lighter
   entities:
   - uid: 8046
@@ -64281,6 +64281,23 @@ entities:
     components:
     - type: Transform
       pos: 6.7048693,9.728001
+      parent: 2
+- proto: MiniSyringe
+  entities:
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 6.4853315,4.397655
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      pos: 6.62885,4.397655
+      parent: 2
+  - uid: 1277
+    components:
+    - type: Transform
+      pos: 6.767739,4.399701
       parent: 2
 - proto: Mirror
   entities:

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 270.0.0
   forkId: ""
   forkVersion: ""
-  time: 01/04/2026 00:57:16
-  entityCount: 14610
+  time: 01/06/2026 01:13:52
+  entityCount: 14536
 maps:
 - 3
 grids:
@@ -37280,16 +37280,6 @@ entities:
       parent: 2
 - proto: ESMarkerSpawnRegionMaintenance
   entities:
-  - uid: 541
-    components:
-    - type: Transform
-      pos: 12.5,-24.5
-      parent: 2
-  - uid: 544
-    components:
-    - type: Transform
-      pos: 11.5,-24.5
-      parent: 2
   - uid: 2547
     components:
     - type: Transform
@@ -37359,31 +37349,6 @@ entities:
     components:
     - type: Transform
       pos: -59.5,6.5
-      parent: 2
-  - uid: 11520
-    components:
-    - type: Transform
-      pos: -67.5,12.5
-      parent: 2
-  - uid: 11521
-    components:
-    - type: Transform
-      pos: -66.5,12.5
-      parent: 2
-  - uid: 11522
-    components:
-    - type: Transform
-      pos: -63.5,12.5
-      parent: 2
-  - uid: 11523
-    components:
-    - type: Transform
-      pos: -63.5,5.5
-      parent: 2
-  - uid: 11524
-    components:
-    - type: Transform
-      pos: -62.5,5.5
       parent: 2
   - uid: 11526
     components:
@@ -37580,26 +37545,6 @@ entities:
     - type: Transform
       pos: -13.5,6.5
       parent: 2
-  - uid: 11573
-    components:
-    - type: Transform
-      pos: -9.5,9.5
-      parent: 2
-  - uid: 11574
-    components:
-    - type: Transform
-      pos: -9.5,8.5
-      parent: 2
-  - uid: 11575
-    components:
-    - type: Transform
-      pos: -10.5,8.5
-      parent: 2
-  - uid: 11576
-    components:
-    - type: Transform
-      pos: -8.5,8.5
-      parent: 2
   - uid: 11577
     components:
     - type: Transform
@@ -37705,21 +37650,6 @@ entities:
     - type: Transform
       pos: 7.5,14.5
       parent: 2
-  - uid: 11598
-    components:
-    - type: Transform
-      pos: 12.5,17.5
-      parent: 2
-  - uid: 11599
-    components:
-    - type: Transform
-      pos: 12.5,18.5
-      parent: 2
-  - uid: 11600
-    components:
-    - type: Transform
-      pos: 11.5,17.5
-      parent: 2
   - uid: 11601
     components:
     - type: Transform
@@ -37739,66 +37669,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,13.5
-      parent: 2
-  - uid: 11605
-    components:
-    - type: Transform
-      pos: 23.5,18.5
-      parent: 2
-  - uid: 11606
-    components:
-    - type: Transform
-      pos: 23.5,17.5
-      parent: 2
-  - uid: 11607
-    components:
-    - type: Transform
-      pos: 22.5,17.5
-      parent: 2
-  - uid: 11608
-    components:
-    - type: Transform
-      pos: 22.5,18.5
-      parent: 2
-  - uid: 11609
-    components:
-    - type: Transform
-      pos: 24.5,18.5
-      parent: 2
-  - uid: 11610
-    components:
-    - type: Transform
-      pos: 24.5,17.5
-      parent: 2
-  - uid: 11611
-    components:
-    - type: Transform
-      pos: 26.5,13.5
-      parent: 2
-  - uid: 11612
-    components:
-    - type: Transform
-      pos: 26.5,12.5
-      parent: 2
-  - uid: 11613
-    components:
-    - type: Transform
-      pos: 26.5,11.5
-      parent: 2
-  - uid: 11614
-    components:
-    - type: Transform
-      pos: 27.5,13.5
-      parent: 2
-  - uid: 11615
-    components:
-    - type: Transform
-      pos: 27.5,12.5
-      parent: 2
-  - uid: 11616
-    components:
-    - type: Transform
-      pos: 27.5,11.5
       parent: 2
   - uid: 11617
     components:
@@ -38155,36 +38025,6 @@ entities:
     - type: Transform
       pos: -23.5,-36.5
       parent: 2
-  - uid: 11715
-    components:
-    - type: Transform
-      pos: -38.5,-33.5
-      parent: 2
-  - uid: 11716
-    components:
-    - type: Transform
-      pos: -38.5,-34.5
-      parent: 2
-  - uid: 11717
-    components:
-    - type: Transform
-      pos: -37.5,-33.5
-      parent: 2
-  - uid: 11718
-    components:
-    - type: Transform
-      pos: -37.5,-34.5
-      parent: 2
-  - uid: 11719
-    components:
-    - type: Transform
-      pos: -36.5,-33.5
-      parent: 2
-  - uid: 11720
-    components:
-    - type: Transform
-      pos: -36.5,-34.5
-      parent: 2
   - uid: 11721
     components:
     - type: Transform
@@ -38194,36 +38034,6 @@ entities:
     components:
     - type: Transform
       pos: -42.5,-35.5
-      parent: 2
-  - uid: 11723
-    components:
-    - type: Transform
-      pos: -50.5,-37.5
-      parent: 2
-  - uid: 11725
-    components:
-    - type: Transform
-      pos: -49.5,-37.5
-      parent: 2
-  - uid: 11726
-    components:
-    - type: Transform
-      pos: -49.5,-38.5
-      parent: 2
-  - uid: 11728
-    components:
-    - type: Transform
-      pos: -48.5,-37.5
-      parent: 2
-  - uid: 11729
-    components:
-    - type: Transform
-      pos: -48.5,-38.5
-      parent: 2
-  - uid: 11731
-    components:
-    - type: Transform
-      pos: -50.5,-38.5
       parent: 2
   - uid: 11732
     components:
@@ -38289,66 +38099,6 @@ entities:
     components:
     - type: Transform
       pos: -59.5,-32.5
-      parent: 2
-  - uid: 11747
-    components:
-    - type: Transform
-      pos: -48.5,-26.5
-      parent: 2
-  - uid: 11748
-    components:
-    - type: Transform
-      pos: -48.5,-27.5
-      parent: 2
-  - uid: 11749
-    components:
-    - type: Transform
-      pos: -49.5,-26.5
-      parent: 2
-  - uid: 11750
-    components:
-    - type: Transform
-      pos: -49.5,-27.5
-      parent: 2
-  - uid: 11751
-    components:
-    - type: Transform
-      pos: -50.5,-26.5
-      parent: 2
-  - uid: 11752
-    components:
-    - type: Transform
-      pos: -50.5,-27.5
-      parent: 2
-  - uid: 11753
-    components:
-    - type: Transform
-      pos: -51.5,-26.5
-      parent: 2
-  - uid: 11754
-    components:
-    - type: Transform
-      pos: -51.5,-27.5
-      parent: 2
-  - uid: 11755
-    components:
-    - type: Transform
-      pos: -51.5,-25.5
-      parent: 2
-  - uid: 11756
-    components:
-    - type: Transform
-      pos: -50.5,-25.5
-      parent: 2
-  - uid: 11757
-    components:
-    - type: Transform
-      pos: -49.5,-25.5
-      parent: 2
-  - uid: 11758
-    components:
-    - type: Transform
-      pos: -48.5,-25.5
       parent: 2
   - uid: 11762
     components:
@@ -38459,36 +38209,6 @@ entities:
     components:
     - type: Transform
       pos: -70.5,-24.5
-      parent: 2
-  - uid: 11791
-    components:
-    - type: Transform
-      pos: -67.5,10.5
-      parent: 2
-  - uid: 11792
-    components:
-    - type: Transform
-      pos: -66.5,10.5
-      parent: 2
-  - uid: 11793
-    components:
-    - type: Transform
-      pos: -65.5,10.5
-      parent: 2
-  - uid: 11794
-    components:
-    - type: Transform
-      pos: -64.5,10.5
-      parent: 2
-  - uid: 11795
-    components:
-    - type: Transform
-      pos: -63.5,10.5
-      parent: 2
-  - uid: 11797
-    components:
-    - type: Transform
-      pos: -65.5,12.5
       parent: 2
   - uid: 11798
     components:
@@ -38629,91 +38349,6 @@ entities:
     components:
     - type: Transform
       pos: 11.5,-9.5
-      parent: 2
-  - uid: 11841
-    components:
-    - type: Transform
-      pos: -5.5,16.5
-      parent: 2
-  - uid: 11842
-    components:
-    - type: Transform
-      pos: -5.5,15.5
-      parent: 2
-  - uid: 11843
-    components:
-    - type: Transform
-      pos: -4.5,16.5
-      parent: 2
-  - uid: 11844
-    components:
-    - type: Transform
-      pos: -4.5,15.5
-      parent: 2
-  - uid: 11845
-    components:
-    - type: Transform
-      pos: -3.5,16.5
-      parent: 2
-  - uid: 11849
-    components:
-    - type: Transform
-      pos: 8.5,17.5
-      parent: 2
-  - uid: 11850
-    components:
-    - type: Transform
-      pos: 7.5,17.5
-      parent: 2
-  - uid: 11863
-    components:
-    - type: Transform
-      pos: 26.5,-3.5
-      parent: 2
-  - uid: 11864
-    components:
-    - type: Transform
-      pos: 26.5,-4.5
-      parent: 2
-  - uid: 11865
-    components:
-    - type: Transform
-      pos: 26.5,-5.5
-      parent: 2
-  - uid: 11866
-    components:
-    - type: Transform
-      pos: 27.5,-3.5
-      parent: 2
-  - uid: 11867
-    components:
-    - type: Transform
-      pos: 27.5,-4.5
-      parent: 2
-  - uid: 11868
-    components:
-    - type: Transform
-      pos: 27.5,-5.5
-      parent: 2
-  - uid: 11872
-    components:
-    - type: Transform
-      pos: -63.5,6.5
-      parent: 2
-  - uid: 11873
-    components:
-    - type: Transform
-      pos: -62.5,4.5
-      parent: 2
-  - uid: 11874
-    components:
-    - type: Transform
-      pos: -62.5,6.5
-      parent: 2
-  - uid: 11875
-    components:
-    - type: Transform
-      pos: -63.5,4.5
       parent: 2
   - uid: 12874
     components:
@@ -38989,11 +38624,6 @@ entities:
     components:
     - type: Transform
       pos: 15.5,-39.5
-      parent: 2
-  - uid: 14586
-    components:
-    - type: Transform
-      pos: 10.5,-24.5
       parent: 2
 - proto: ESNegentropyAccumulator
   entities:

--- a/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
@@ -4,14 +4,14 @@
   id: ESMagazine9mm
   result: ESMagazine9mm
   materials:
-    Steel: 145
+    Steel: 400
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESSpeedLoader357
   result: ESSpeedLoader357
   materials:
-    Steel: 190
+    Steel: 500
 
 # Shotgun
 
@@ -37,3 +37,12 @@
   materials:
     Steel: 190
     Plastic: 100
+
+# Misc.
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: ESMiniSyringe
+  result: MiniSyringe
+  materials:
+    Steel: 200

--- a/Resources/Prototypes/_ES/Lathe/packs.yml
+++ b/Resources/Prototypes/_ES/Lathe/packs.yml
@@ -130,6 +130,7 @@
   - ESShellShotgunBeanbag
   - ESShellShotgunBuckshot
   - ESShellShotgunSlug
+  - ESMiniSyringe
 
 # Service
 - type: latheRecipePack


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Makes the maint spawners a bit easier to access to make them less hard to find for new players.

Replaces the hypospray with a syringe gun and adds mini-syringes to the autolathe. Also makes mags more expensive because they weren't enough before.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
