### PR TITLE
Disallow non-tanks in Suit Storage slot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -16,7 +16,9 @@
     quickEquip: false
     slots:
     - back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
 
 - type: entity
   parent: BaseStringInstrumentClothing

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -791,7 +791,9 @@
     sprite: Objects/Fun/card_sword.rsi
     slots:
     - Back
-    - SuitStorage
+# ES START
+    # - SuitStorage
+# ES END
   - type: StaminaDamageOnHit
     damage: 6
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -159,7 +159,9 @@
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     slots:
       - Back
-      - SuitStorage
+# ES START
+      # - SuitStorage
+# ES END
   - type: Item
     sprite: Objects/Tanks/Jetpacks/captain.rsi
     size: Normal
@@ -202,7 +204,9 @@
       sprite: Objects/Tanks/Jetpacks/mini.rsi
       slots:
         - Back
-        - suitStorage
+# ES START
+        # - suitStorage
+# ES END
         - Belt
     - type: GasTank
       outputPressure: 42.6
@@ -273,7 +277,9 @@
     sprite: Objects/Tanks/Jetpacks/void.rsi
     slots:
       - Back
-      - suitStorage
+# ES START
+      # - suitStorage
+# ES END
       - Belt
 
 # Filled void

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -46,7 +46,9 @@
     sprite: Objects/Weapons/Guns/Basic/kinetic_accelerator.rsi
     quickEquip: false
     slots:
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
     - Belt
   - type: UseDelay
     delay: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -11,7 +11,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: Gun
     fireRate: 2
@@ -118,7 +120,9 @@
     quickEquip: false
     slots:
     - Belt
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
 
 - type: entity
   id: BaseWeaponPowerCellSmall
@@ -553,7 +557,9 @@
     sprite: Objects/Weapons/Guns/Battery/disabler.rsi
     quickEquip: false
     slots:
-      - suitStorage
+# ES START
+      # - suitStorage
+# ES END
       - Belt
   - type: BatteryAmmoProvider
     proto: BulletDisabler

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Bow/bow.yml
@@ -13,7 +13,9 @@
     quickEquip: false
     slots:
       - Back
-      - suitStorage
+# ES START
+      # - suitStorage
+# ES END
   - type: Wieldable
     wieldSound:
       path: /Audio/Items/bow_pull.ogg

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -15,7 +15,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: Wieldable
     unwieldOnUse: false
   - type: GunWieldBonus

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -35,7 +35,9 @@
     sprite: Objects/Weapons/Guns/Launchers/china_lake.rsi
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: Item
     size: Huge
     shape:
@@ -75,7 +77,9 @@
     sprite: Objects/Weapons/Guns/Launchers/hydra_launcher.rsi
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: Item
     size: Huge
   - type: AmmoCounter

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -24,7 +24,9 @@
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
     quickEquip: false
     slots:
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
     - Belt
   - type: Gun
     fireRate: 6

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -20,7 +20,9 @@
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
     quickEquip: false
     slots:
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
     - Belt
   - type: AmmoCounter
   - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -15,7 +15,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: Gun
     fireRate: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -15,7 +15,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: Gun
     minAngle: 2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -18,7 +18,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: Gun
     fireRate: 2
@@ -65,7 +67,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -16,7 +16,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: Gun
     fireRate: 0.75

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/flare_gun.yml
@@ -40,7 +40,9 @@
     quickEquip: false
     slots:
     - Belt
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: Appearance
   - type: Gun
     fireRate: 8

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -125,7 +125,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: AmmoCounter
   - type: UseDelayOnShoot
   - type: UseDelay
@@ -229,7 +231,9 @@
     quickEquip: false
     slots:
     - Back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: UseDelay
     delay: 1.9
   - type: BasicEntityAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/spear.yml
@@ -54,7 +54,9 @@
     quickEquip: false
     slots:
     - back
-    - suitStorage
+# ES START
+    # - suitStorage
+# ES END
   - type: Construction
     graph: Spear
     node: spear

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -193,7 +193,9 @@
     sprite: Objects/Weapons/Melee/claymore.rsi
     slots:
     - Back
-    - SuitStorage #Bigger than the other swords, easier to strap to your suit.
+# ES START
+    # - SuitStorage #Bigger than the other swords, easier to strap to your suit.
+# ES END
   - type: DisarmMalus
 
 #Other/Weird


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Removes `SuitStorage` from allowed inventory slots of most (if not, all) non-tank items, allowing only internals tanks to be equipped on the suit storage slot.

Initially I was going to also remove the suit storage slot from non-suit outer clothing items, but I feel that may be better for a separate PR (if that is even desired after restricting the inventory slot to only tanks.)

Resolves #805.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
N/A
