### PR TITLE
minor gun balance changes

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/energy.yml
@@ -44,7 +44,7 @@
       path: /Audio/_ES/Weapons/Guns/Hits/sear.ogg
     damage:
       types:
-        Heat: 18
+        Heat: 22
 
 - type: entity
   name: weak energy bolt

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/energy.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/energy.yml
@@ -33,7 +33,7 @@
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
-    projectileSpeed: 20
+    projectileSpeed: 22.5
   - type: BatteryAmmoProvider
     proto: ESEnergyBolt
     fireCost: 70
@@ -71,7 +71,7 @@
       path: /Audio/_ES/Weapons/Guns/Gunshots/taser.ogg
     soundEmpty:
       path: /Audio/_ES/Weapons/Guns/Empty/empty.ogg
-    projectileSpeed: 20
+    projectileSpeed: 22.5
   - type: BatteryAmmoProvider
     proto: ESTaserBolt
     fireCost: 200
@@ -129,7 +129,7 @@
     availableModes:
     - Burst
     shotsPerBurst: 3
-    projectileSpeed: 20
+    projectileSpeed: 22.5
     fireRate: 3
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/energy.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/energy.yml
@@ -128,15 +128,16 @@
     selectedMode: Burst
     availableModes:
     - Burst
-    shotsPerBurst: 2
+    shotsPerBurst: 3
     projectileSpeed: 20
+    fireRate: 3
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
     soundEmpty:
       path: /Audio/_ES/Weapons/Guns/Empty/empty.ogg
   - type: BatteryAmmoProvider
     proto: ESEnergyBoltCaptain
-    fireCost: 70
+    fireCost: 48
   - type: BatterySelfRecharger
     autoRechargeRate: 5
   - type: StaticPrice

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
@@ -14,7 +14,7 @@
     storedOffset: -2,0
     size: Huge
     shape:
-    - 0,0,7,1
+    - 0,0,7,1 # only fits in a duffel
     sprite: _ES/Objects/Weapons/Guns/shotgun_inhands_64x.rsi
   - type: Clothing
     sprite: _ES/Objects/Weapons/Guns/shotgun.rsi
@@ -27,7 +27,7 @@
     soundInsert:
       path: /Audio/_ES/Weapons/Guns/MagIn/shotgun_insert.ogg
   - type: Gun
-    fireRate: 2
+    fireRate: 1.5
     soundGunshot:
       path: /Audio/_ES/Weapons/Guns/Gunshots/shotgun_shot.ogg
     soundEmpty:
@@ -35,7 +35,7 @@
     availableModes:
     - SemiAuto
   - type: GunSpreadModifier
-    spread: 0.6
+    spread: 1.5
 
 - type: entity
   parent: [ESWeaponShotgun, BaseSecurityBartenderContraband]

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
@@ -67,6 +67,8 @@
       path: /Audio/_ES/Weapons/Guns/Gunshots/doublebarrel_shot.ogg
     soundEmpty:
       path: /Audio/_ES/Weapons/Guns/Empty/empty.ogg
+  - type: GunSpreadModifier
+    spread: 1
 
 - type: entity
   parent: ESWeaponDoubleBarrelShotgun


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
tweaks some gun stats to address minor balancing concerns.

- riot shotguns shoot slower and have a much wider spread, making them a lot more specialized. the lower fire rate might feel pretty bad but we are going to learn if that is the case in about 11 hours
- the energy rifle now does a lot more damage and has slightly faster projectile speed. it was not very good before but should be very energy-efficient per mag hopefully
- the caps laser shoots a volley of 3 lasers instead of 2 to make it feel more unique, and can shoot more lasers overall to compensate

## Media
[Content.Client_sH0nzDYfCa.webm](https://github.com/user-attachments/assets/3ff04ee2-59ce-4db8-9954-cd1be86d54da)
