### PR TITLE
chloral/knockout medipen buff

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -68,10 +68,12 @@
       - !type:MovementSpeedModifier
         walkSpeedModifier: 0.65
         sprintSpeedModifier: 0.65
+# ES Start
       - !type:ModifyStatusEffect
-        effectProto: StatusEffectDrowsiness
-        time: 4
-        type: Update
+        effectProto: StatusEffectForcedSleeping
+        time: 15
+        delay: 15
+# ES End
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -80,6 +82,7 @@
         damage:
           types:
             Poison: 1.5
+
 
 - type: reagent
   id: GastroToxin

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -83,7 +83,6 @@
           types:
             Poison: 1.5
 
-
 - type: reagent
   id: GastroToxin
   name: reagent-name-gastrotoxin


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Buffs chloral hydrate in order to make the knockout medipen better. It now uses ForcedSleep instead of drowsiness, meaning that you will go to sleep after a fixed amount of time & not be able to just wake up randomly.

The fixed sleep seems to last about 28~ seconds with current values at 10u.

## Media
[Content.Client_y0ohQZOWhO.webm](https://github.com/user-attachments/assets/123c8983-63c5-4d5a-80d5-4a1ee1b19a0d)
