### PR TITLE
Stagehand chat notification system

### DIFF
--- a/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -1,8 +1,8 @@
 using Content.Server.Chat.Managers;
 using Content.Server.KillTracking;
+using Content.Shared._ES.Objectives.Components;
 using Content.Shared._ES.Stagehand.Components;
 using Content.Shared.Chat;
-using Content.Shared.Players;
 using JetBrains.Annotations;
 using Robust.Server.Player;
 using Robust.Shared.Network;
@@ -23,14 +23,16 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<KillReportedEvent>(OnKillReported);
+        SubscribeLocalEvent<ESObjectiveProgressChangedEvent>(OnObjectiveProgressChanged);
     }
 
-    private void OnKillReported(KillReportedEvent ev)
+    private void OnKillReported(ref KillReportedEvent ev)
     {
         if (!TryComp<ActorComponent>(ev.Entity, out var actor))
             return;
 
         string? msg = null;
+        var severity = ESStagehandNotificationSeverity.Medium;
 
         if (ev.Suicide)
         {
@@ -56,6 +58,7 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
             if (!_player.TryGetSessionById(player.PlayerId, out var attackerSession) || attackerSession.AttachedEntity is not { } attackerEnt)
                 return;
 
+            severity = ESStagehandNotificationSeverity.High;
             msg = Loc.GetString("es-stagehand-notification-kill-player",
                 ("entity", ev.Entity),
                 ("username", actor.PlayerSession.Name),
@@ -64,7 +67,49 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
         }
 
         if (msg != null)
-            SendStagehandNotification(msg);
+            SendStagehandNotification(msg, severity);
+    }
+
+    private void OnObjectiveProgressChanged(ref ESObjectiveProgressChangedEvent ev)
+    {
+        LocId? msgId;
+
+        switch (ev)
+        {
+            // Only announce relevant situations
+            // just completed
+            case { NewProgress: >= 1f, OldProgress: < 1f }:
+                msgId = "es-stagehand-notification-objective-completed";
+                break;
+            // failed (1 -> <1, technically reversible so multiple msgs could spawn but cant think of any situations where that would actually occur?)
+            case { NewProgress: < 1f, OldProgress: >= 1f }:
+                msgId = "es-stagehand-notification-objective-failed";
+                break;
+            default:
+                return;
+        }
+
+        if (msgId == null)
+            return;
+
+        // since we know it's significant, figure out the holding entity
+        EntityUid? foundHolder = null;
+        var query = EntityQueryEnumerator<ESObjectiveHolderComponent>();
+        while (query.MoveNext(out var uid, out var holder))
+        {
+            if (!holder.OwnedObjectives.Contains(ev.Objective.Owner))
+                continue;
+
+            // this assumes only one holder can own an objective, which I think is true right now, and the purpose of owned objectives anyway?
+            foundHolder = uid;
+            break;
+        }
+
+        if (foundHolder is null)
+            return;
+
+        var resolvedMessage = Loc.GetString(msgId, ("entity", foundHolder.Value), ("objective", ev.Objective.Owner));
+        SendStagehandNotification(resolvedMessage);
     }
 
     /// <summary>
@@ -75,11 +120,11 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
     [PublicAPI]
     public void SendStagehandNotification(string msg, ESStagehandNotificationSeverity severity = ESStagehandNotificationSeverity.Medium)
     {
-        var voters = new List<INetChannel>();
+        var stagehands = new List<INetChannel>();
         var query = EntityQueryEnumerator<ESStagehandComponent, ActorComponent>();
         while (query.MoveNext(out _, out _, out var actor))
         {
-            voters.Add(actor.PlayerSession.Channel);
+            stagehands.Add(actor.PlayerSession.Channel);
         }
 
         var locId = severity switch
@@ -90,7 +135,7 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
         };
 
         var wrappedMsg = Loc.GetString(locId, ("message", msg));
-        _chat.ChatMessageToMany(ChatChannel.Server, msg, wrappedMsg, default, false, true, voters, Color.Plum);
+        _chat.ChatMessageToMany(ChatChannel.Server, msg, wrappedMsg, default, false, true, stagehands, Color.Plum);
     }
 }
 

--- a/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -57,15 +57,22 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
         }
         else if (ev.Primary is KillPlayerSource player)
         {
-            if (!_player.TryGetSessionById(player.PlayerId, out var attackerSession) || attackerSession.AttachedEntity is not { } attackerEnt)
-                return;
-
             severity = ESStagehandNotificationSeverity.High;
-            msg = Loc.GetString("es-stagehand-notification-kill-player",
-                ("entity", ev.Entity),
-                ("username", actor.PlayerSession.Name),
-                ("attacker", attackerEnt),
-                ("attackerUsername", attackerSession.Name));
+            if (!_player.TryGetSessionById(player.PlayerId, out var attackerSession) ||
+                attackerSession.AttachedEntity is not { } attackerEnt)
+            {
+                msg = Loc.GetString("es-stagehand-notification-kill-player-unknown",
+                    ("entity", ev.Entity),
+                    ("username", actor.PlayerSession.Name));
+            }
+            else
+            {
+                msg = Loc.GetString("es-stagehand-notification-kill-player",
+                    ("entity", ev.Entity),
+                    ("username", actor.PlayerSession.Name),
+                    ("attacker", attackerEnt),
+                    ("attackerUsername", attackerSession.Name));
+            }
         }
 
         if (msg != null)

--- a/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -1,0 +1,105 @@
+using Content.Server.Chat.Managers;
+using Content.Server.KillTracking;
+using Content.Shared._ES.Stagehand.Components;
+using Content.Shared.Chat;
+using Content.Shared.Players;
+using JetBrains.Annotations;
+using Robust.Server.Player;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Content.Server._ES.Stagehand;
+
+/// <summary>
+///     Handles sending stagehand notifications for various non-stagehand events ingame: objective completions, deaths, etc.
+/// </summary>
+public sealed class ESStagehandNotificationsSystem : EntitySystem
+{
+    [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<KillReportedEvent>(OnKillReported);
+    }
+
+    private void OnKillReported(KillReportedEvent ev)
+    {
+        if (!TryComp<ActorComponent>(ev.Entity, out var actor))
+            return;
+
+        string? msg = null;
+
+        if (ev.Suicide)
+        {
+            msg = Loc.GetString("es-stagehand-notification-kill-suicide",
+                ("entity", ev.Entity),
+                ("username", actor.PlayerSession.Name));
+        }
+        else if (ev.Primary is KillEnvironmentSource)
+        {
+            msg = Loc.GetString("es-stagehand-notification-kill-environment",
+                ("entity", ev.Entity),
+                ("username", actor.PlayerSession.Name));
+        }
+        else if (ev.Primary is KillNpcSource npc)
+        {
+            msg = Loc.GetString("es-stagehand-notification-kill-npc",
+                ("entity", ev.Entity),
+                ("username", actor.PlayerSession.Name),
+                ("attacker", npc.NpcEnt));
+        }
+        else if (ev.Primary is KillPlayerSource player)
+        {
+            if (!_player.TryGetSessionById(player.PlayerId, out var attackerSession) || attackerSession.AttachedEntity is not { } attackerEnt)
+                return;
+
+            msg = Loc.GetString("es-stagehand-notification-kill-player",
+                ("entity", ev.Entity),
+                ("username", actor.PlayerSession.Name),
+                ("attacker", attackerEnt),
+                ("attackerUsername", attackerSession.Name));
+        }
+
+        if (msg != null)
+            SendStagehandNotification(msg);
+    }
+
+    /// <summary>
+    ///     Sends a notification message to all currently active stagehands, formatted correctly.
+    /// </summary>
+    /// <param name="msg">An already-resolved string to use as the message.</param>
+    /// <param name="severity">The severity of this notification, defaulting to medium (regular size)</param>
+    [PublicAPI]
+    public void SendStagehandNotification(string msg, ESStagehandNotificationSeverity severity = ESStagehandNotificationSeverity.Medium)
+    {
+        var voters = new List<INetChannel>();
+        var query = EntityQueryEnumerator<ESStagehandComponent, ActorComponent>();
+        while (query.MoveNext(out _, out _, out var actor))
+        {
+            voters.Add(actor.PlayerSession.Channel);
+        }
+
+        var locId = severity switch
+        {
+            ESStagehandNotificationSeverity.Low => "es-stagehand-notification-wrap-message-low",
+            ESStagehandNotificationSeverity.Medium => "es-stagehand-notification-wrap-message-medium",
+            _ => "es-stagehand-notification-wrap-message-high",
+        };
+
+        var wrappedMsg = Loc.GetString(locId, ("message", msg));
+        _chat.ChatMessageToMany(ChatChannel.Server, msg, wrappedMsg, default, false, true, voters, Color.Plum);
+    }
+}
+
+/// <summary>
+///     Determines the font size and styling of the message sent to stagehands.
+/// </summary>
+public enum ESStagehandNotificationSeverity : byte
+{
+    Low,
+    Medium,
+    High
+}

--- a/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chat.Managers;
 using Content.Server.KillTracking;
+using Content.Shared._ES.Objectives;
 using Content.Shared._ES.Objectives.Components;
 using Content.Shared._ES.Stagehand.Components;
 using Content.Shared.Chat;
@@ -15,6 +16,7 @@ namespace Content.Server._ES.Stagehand;
 /// </summary>
 public sealed class ESStagehandNotificationsSystem : EntitySystem
 {
+    [Dependency] private readonly ESSharedObjectiveSystem _objectives = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
 
@@ -93,22 +95,10 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
             return;
 
         // since we know it's significant, figure out the holding entity
-        EntityUid? foundHolder = null;
-        var query = EntityQueryEnumerator<ESObjectiveHolderComponent>();
-        while (query.MoveNext(out var uid, out var holder))
-        {
-            if (!holder.OwnedObjectives.Contains(ev.Objective.Owner))
-                continue;
-
-            // this assumes only one holder can own an objective, which I think is true right now, and the purpose of owned objectives anyway?
-            foundHolder = uid;
-            break;
-        }
-
-        if (foundHolder is null)
+        if (!_objectives.TryFindObjectiveHolder((ev.Objective.Owner, ev.Objective.Comp), out var holder))
             return;
 
-        var resolvedMessage = Loc.GetString(msgId, ("entity", foundHolder.Value), ("objective", ev.Objective.Owner));
+        var resolvedMessage = Loc.GetString(msgId, ("entity", holder.Value), ("objective", ev.Objective.Owner));
         SendStagehandNotification(resolvedMessage);
     }
 

--- a/Content.Shared/_ES/Objectives/Components/ESObjectiveHolderComponent.cs
+++ b/Content.Shared/_ES/Objectives/Components/ESObjectiveHolderComponent.cs
@@ -6,7 +6,6 @@ namespace Content.Shared._ES.Objectives.Components;
 /// Denotes an entity that can have objectives associated with it.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
-[Access(typeof(ESSharedObjectiveSystem), Other = AccessPermissions.None)]
 public sealed partial class ESObjectiveHolderComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_ES/Objectives/Components/ESObjectiveHolderComponent.cs
+++ b/Content.Shared/_ES/Objectives/Components/ESObjectiveHolderComponent.cs
@@ -6,6 +6,7 @@ namespace Content.Shared._ES.Objectives.Components;
 /// Denotes an entity that can have objectives associated with it.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+[Access(typeof(ESSharedObjectiveSystem), Other = AccessPermissions.None)]
 public sealed partial class ESObjectiveHolderComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
+++ b/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
@@ -100,7 +100,7 @@ public abstract partial class ESSharedObjectiveSystem : EntitySystem
         ent.Comp.Progress = newProgress;
 
         var afterEv = new ESObjectiveProgressChangedEvent((ent, ent.Comp), oldProgress, newProgress);
-        RaiseLocalEvent(ent, ref afterEv);
+        RaiseLocalEvent(ent, ref afterEv, true);
 
         Dirty(ent);
     }

--- a/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
+++ b/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
@@ -359,6 +359,34 @@ public abstract partial class ESSharedObjectiveSystem : EntitySystem
         return true;
     }
 
+    /// <summary>
+    ///     Tries to find an <see cref="ESObjectiveHolderComponent"/>
+    ///     This is kind of inefficient, so you should avoid doing this when possible (and try to just pass around the holder separately, if you already know it)
+    /// </summary>
+    public bool TryFindObjectiveHolder(Entity<ESObjectiveComponent?> objective, [NotNullWhen(true)] out Entity<ESObjectiveHolderComponent>? holder)
+    {
+        if (!Resolve(objective.Owner, ref objective.Comp))
+        {
+            holder = null;
+            return false;
+        }
+
+        Entity<ESObjectiveHolderComponent>? foundHolder = null;
+        var query = EntityQueryEnumerator<ESObjectiveHolderComponent>();
+        while (query.MoveNext(out var uid, out var potentialHolder))
+        {
+            if (!potentialHolder.OwnedObjectives.Contains(objective.Owner))
+                continue;
+
+            // this assumes only one holder can own an objective, which I think is true right now, and the purpose of owned objectives anyway?
+            foundHolder = (uid, potentialHolder);
+            break;
+        }
+
+        holder = foundHolder;
+        return holder != null;
+    }
+
     public string GetObjectiveString(Entity<ESObjectiveComponent?> ent)
     {
         if (!Resolve(ent, ref ent.Comp))

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -1,0 +1,9 @@
+es-stagehand-notification-wrap-message-low = [font size=10][italic]{$message}[/italic][/font]
+es-stagehand-notification-wrap-message-medium = [font size=12]{$message}[/font]
+es-stagehand-notification-wrap-message-high = [font size=14][bold]{$message}[/bold][/font]
+
+es-stagehand-notification-kill-suicide = {$entity} ({$username}) committed suicide!
+es-stagehand-notification-kill-environment = {$entity} ({$username}) was killed by the environment!
+es-stagehand-notification-kill-npc = {$entity} ({$username}) was killed by a non-player {$attacker}!
+es-stagehand-notification-kill-player = {$entity} ({$username}) was killed by {$playerEnt} ({$attackerUsername})!
+

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -6,6 +6,7 @@ es-stagehand-notification-kill-suicide = {$entity} ({$username}) committed suici
 es-stagehand-notification-kill-environment = {$entity} ({$username}) was killed by the environment!
 es-stagehand-notification-kill-npc = {$entity} ({$username}) was killed by a non-player {$attacker}!
 es-stagehand-notification-kill-player = {$entity} ({$username}) was killed by {$playerEnt} ({$attackerUsername})!
+es-stagehand-notification-kill-player-unknown = {$entity} ({$username}) was killed by an unknown player!
 
 es-stagehand-notification-objective-completed = {$entity} successfully completed their objective "{$objective}"!
 es-stagehand-notification-objective-failed = {$entity} failed their objective "{$objective}"!

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -7,3 +7,5 @@ es-stagehand-notification-kill-environment = {$entity} ({$username}) was killed 
 es-stagehand-notification-kill-npc = {$entity} ({$username}) was killed by a non-player {$attacker}!
 es-stagehand-notification-kill-player = {$entity} ({$username}) was killed by {$playerEnt} ({$attackerUsername})!
 
+es-stagehand-notification-objective-completed = {$entity} successfully completed their objective "{$objective}"!
+es-stagehand-notification-objective-failed = {$entity} failed their objective "{$objective}"!

--- a/Resources/Prototypes/_ES/GameRules/troupes.yml
+++ b/Resources/Prototypes/_ES/GameRules/troupes.yml
@@ -8,6 +8,7 @@
 
 - type: entity
   parent: ESBaseTroupeRule
+  name: The Crew
   id: ESTroupeRuleCrew
   components:
   - type: ESTroupeRule
@@ -19,6 +20,7 @@
 - type: entity
   parent: ESBaseTroupeRule
   id: ESTroupeRuleTraitor
+  name: The Traitors
   components:
   - type: ESTroupeRule
     troupe: ESTraitor


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

- generic thing for sending stagehands messages about stuf that happens in round
- handlers for kill reporting + objective completion/failing yaay

sus things
- querying all handlers to get the one that owns an objective. its weird but uhh theres not that many of them and it only happens when an objective for sure completes/fails, not just when progress is updated at all, so its not too bad? we dont store this data anywhere else i think
- removed access from objectivehodler im sorry this shit doesnt do anything and doesnt help
- had to give the gamerules names since they are the objective holders. pretty sure thats fine

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="455" height="133" alt="image" src="https://github.com/user-attachments/assets/e5e475b1-8f4d-43bc-910f-e0cad536ebae" />
<img width="444" height="117" alt="image" src="https://github.com/user-attachments/assets/8c43e0f0-184b-4e22-9a18-12e865fe8b5c" />
