### PR TITLE
Semi-revert some light tweaks

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_fixtures.yml
@@ -12,7 +12,7 @@
   suffix: ES, Departments
   components:
   - type: PointLight
-    color: "#ccc2be"
+    color: "#ece2dd"
     energy: 1.45
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeDepartment
@@ -28,7 +28,7 @@
   suffix: ES, Nightshift
   components:
   - type: PointLight
-    color: "#7b5e50"
+    color: "#8f6e5d"
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeNightshift
   - type: DeviceNetwork
@@ -43,7 +43,7 @@
   suffix: ES, Hallway
   components:
   - type: PointLight
-    color: "#7f8082"
+    color: "#828281"
   - type: PoweredLight
     hasLampOnSpawn: ESLightTubeHallway
   - type: DeviceNetwork

--- a/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Lighting/light_tubes.yml
@@ -5,7 +5,7 @@
   suffix: ES, Department
   components:
   - type: LightBulb
-    color: "#ccc2be"
+    color: "#ece2dd"
     glowColorOverride: "#ffffff"
     lightEnergy: 1.45
     lightSoftness: 2
@@ -16,8 +16,8 @@
   suffix: ES, Nightshift
   components:
   - type: LightBulb
-    color: "#7b5e50"
-    glowColorOverride: "#d8753d"
+    color: "#8f6e5d"
+    glowColorOverride: "#e9732b"
     lightEnergy: 1.45
     lightSoftness: 2
 
@@ -29,6 +29,6 @@
   suffix: ES, Hallway
   components:
   - type: LightBulb
-    color: "#6c6d6f"
-    glowColorOverride: "#cccccc"
+    color: "#828281"
+    glowColorOverride: "#aaaaaa"
     lightSoftness: 2


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

mostly undoes the changes to regular lighting in #638 (hallway lights are a bit darker than they were before that pr but not nearly as dim as they were after

makes nightshift a bit brighter (there was like one complaint idk i think this still looks pretty good)

closes #701 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="960" height="960" alt="2026-1-09_23 55 57" src="https://github.com/user-attachments/assets/6537666a-c5ac-4556-bf52-22b149c34c9d" />
<img width="960" height="960" alt="2026-1-09_23 55 25" src="https://github.com/user-attachments/assets/ac7d3e5d-7793-4382-8ee3-852a02a947e9" />

