### PR TITLE
Fix chameleon prototypes being wack

### DIFF
--- a/Content.Client/Implants/UI/ChameleonControllerMenu.xaml.cs
+++ b/Content.Client/Implants/UI/ChameleonControllerMenu.xaml.cs
@@ -40,7 +40,9 @@ public sealed partial class ChameleonControllerMenu : FancyWindow
         _sprite = _entityManager.System<SpriteSystem>();
         _job = _entityManager.System<JobSystem>();
 
-        _outfits = _prototypeManager.EnumeratePrototypes<ChameleonOutfitPrototype>();
+// ES START
+        _outfits = _prototypeManager.EnumeratePrototypes<ChameleonOutfitPrototype>().Where(p => !p.Hidden);
+// ES END
 
         UpdateGrid();
     }
@@ -57,7 +59,9 @@ public sealed partial class ChameleonControllerMenu : FancyWindow
         // Department name -> UI element holding that department.
         var departments = new Dictionary<string, BoxContainer>();
 
-        departments.Add(UnknownDepartment, CreateDepartment(UnknownDepartment));
+// ES START
+        //departments.Add(UnknownDepartment, CreateDepartment(UnknownDepartment));
+// ES END
 
         // Go through every outfit and add them to the correct department.
         foreach (var outfit in _outfits)
@@ -80,6 +84,10 @@ public sealed partial class ChameleonControllerMenu : FancyWindow
             }
             else
             {
+// ES START
+                if (!departments.ContainsKey(UnknownDepartment))
+                    departments.Add(UnknownDepartment, CreateDepartment(UnknownDepartment));
+// ES END
                 departments[UnknownDepartment].AddChild(outfitButton);
             }
         }

--- a/Content.Server/Implants/ChameleonControllerSystem.cs
+++ b/Content.Server/Implants/ChameleonControllerSystem.cs
@@ -48,6 +48,10 @@ public sealed class ChameleonControllerSystem : SharedChameleonControllerSystem
     private void ChangeChameleonClothingToOutfit(EntityUid user, ProtoId<ChameleonOutfitPrototype> outfit)
     {
         var outfitPrototype = _proto.Index(outfit);
+// ES START
+        if (outfitPrototype.Hidden)
+            return;
+// ES END
 
         _proto.Resolve(outfitPrototype.Job, out var jobPrototype);
         _proto.Resolve(outfitPrototype.StartingGear, out var startingGearPrototype);

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -14,6 +14,11 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+// ES START
+using Content.Shared._ES.Clothing.Chameleon.Components;
+using Content.Shared.Implants;
+using Content.Shared.Prototypes;
+// ES END
 
 namespace Content.Shared.Clothing.EntitySystems;
 
@@ -174,12 +179,26 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
         if (proto.Abstract || proto.HideSpawnMenu)
             return false;
 
-        // check if it is marked as valid chameleon target
-        if (!proto.TryGetComponent(out TagComponent? tag, Factory) || !_tag.HasTag(tag, WhitelistChameleonTag))
+// ES START
+        var validClothes = _proto.EnumeratePrototypes<ChameleonOutfitPrototype>()
+            .Where(p => p is { Hidden: false, Job: not null })
+            .Select(p => _proto.Index(p.Job!))
+            .Where(j => j.StartingGear != null)
+            .SelectMany(j => _proto.Index(j.StartingGear)!.Equipment.Values)
+            .ToHashSet();
+        if (!validClothes.Contains(proto) && !proto.HasComponent<ESChameleonClothingWhitelistComponent>())
             return false;
 
-        if (requiredTag != null && !_tag.HasTag(tag, requiredTag))
+        if (proto.HasComponent<ESChameleonClothingBlacklistComponent>())
             return false;
+
+        // // check if it is marked as valid chameleon target
+        // if (!proto.TryGetComponent(out TagComponent? tag, Factory) || !_tag.HasTag(tag, WhitelistChameleonTag))
+        //     return false;
+        //
+        // if (requiredTag != null && !_tag.HasTag(tag, requiredTag))
+        //     return false;
+// ES END
 
         // check if it's valid clothing
         if (!proto.TryGetComponent(out ClothingComponent? clothing, Factory))

--- a/Content.Shared/Implants/ChameleonOutfitPrototype.cs
+++ b/Content.Shared/Implants/ChameleonOutfitPrototype.cs
@@ -61,4 +61,8 @@ public sealed partial class ChameleonOutfitPrototype : IPrototype
     /// </summary>
     [DataField]
     public Dictionary<string, EntProtoId> Equipment { get; set; } = new();
+// ES START
+    [DataField]
+    public bool Hidden = true;
+// ES END
 }

--- a/Content.Shared/_ES/Clothing/Chameleon/Components/ESChameleonClothingBlacklistComponent.cs
+++ b/Content.Shared/_ES/Clothing/Chameleon/Components/ESChameleonClothingBlacklistComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Clothing.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Clothing.Chameleon.Components;
+
+/// <summary>
+/// Marker component for blacklisting clothes from <see cref="ChameleonClothingComponent"/>
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESChameleonClothingBlacklistComponent : Component;

--- a/Content.Shared/_ES/Clothing/Chameleon/Components/ESChameleonClothingWhitelistComponent.cs
+++ b/Content.Shared/_ES/Clothing/Chameleon/Components/ESChameleonClothingWhitelistComponent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.Clothing.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Clothing.Chameleon.Components;
+
+/// <summary>
+/// Marker component for whitelisting clothes for <see cref="ChameleonClothingComponent"/>
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESChameleonClothingWhitelistComponent : Component;

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -30,6 +30,9 @@
         color: "#9C0DE1"
   - type: Fiber
     fiberColor: fibers-purple
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Red Gloves
 - type: entity
@@ -59,6 +62,9 @@
         color: "#940000"
   - type: Fiber
     fiberColor: fibers-red
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Blue Gloves
 - type: entity
@@ -120,6 +126,9 @@
         color: "#3CB57C"
   - type: Fiber
     fiberColor: fibers-teal
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Brown Gloves
 - type: entity
@@ -149,6 +158,9 @@
         color: "#723A02"
   - type: Fiber
     fiberColor: fibers-brown
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Grey Gloves
 - type: entity
@@ -178,6 +190,9 @@
         color: "#999999"
   - type: Fiber
     fiberColor: fibers-grey
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Green Gloves
 - type: entity
@@ -207,6 +222,9 @@
         color: "#5ABF2F"
   - type: Fiber
     fiberColor: fibers-green
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Light Brown Gloves
 - type: entity
@@ -236,6 +254,9 @@
         color: "#C09F72"
   - type: Fiber
     fiberColor: fibers-light-brown
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Orange Gloves
 - type: entity
@@ -265,6 +286,9 @@
         color: "#EF8100"
   - type: Fiber
     fiberColor: fibers-orange
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # White Gloves
 - type: entity
@@ -294,6 +318,9 @@
         color: "#EAE8E8"
   - type: Fiber
     fiberColor: fibers-white
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Black Gloves
 # TECHNICALLY, if you ported the worn state to the RSI, this could be greyscaled, but I do not really feel like doing that.
@@ -341,6 +368,9 @@
   - type: Fiber
     fiberMaterial: fibers-insulative
     fiberColor: fibers-yellow
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Budget Insulated Gloves
 - type: entity
@@ -368,6 +398,9 @@
   - type: Fiber
     fiberMaterial: fibers-insulative-frayed
     fiberColor: fibers-yellow
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Conductive Insulated Gloves
 - type: entity
@@ -377,3 +410,6 @@
   components:
   - type: Insulated
     coefficient: 5 # zap em good
+# ES START
+  - type: ESChameleonClothingBlacklist
+# ES END

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -391,6 +391,9 @@
   description:  A cursed pair of cluwne hands.
   components:
   - type: Unremoveable
+# ES START
+  - type: ESChameleonClothingBlacklist
+# ES END
 
 - type: entity
   parent: [ClothingHandsButcherable, BaseSyndicateContraband]

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -280,6 +280,7 @@
       shader: unshaded
       visible: false
       map: [ "light" ]
+  - type: ESChameleonClothingWhitelist
 # ES End
   - type: Clothing
     sprite: Clothing/Head/Helmets/firehelmet.rsi

--- a/Resources/Prototypes/Entities/Clothing/Head/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/specific.yml
@@ -14,7 +14,9 @@
       sprite: Clothing/Head/Hats/beret.rsi
     - type: ChameleonClothing
       slot: [HEAD]
-      default: ClothingHeadHatBeret
+# ES START
+      default: ClothingHeadHatHardhatYellow
+# ES END
 
 - type: entity
   parent: ClothingHeadHatFedoraBrown

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -76,6 +76,9 @@
   - type: HideLayerClothing
     slots:
     - Tail
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]

--- a/Resources/Prototypes/Entities/Clothing/Shoes/color.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/color.yml
@@ -73,7 +73,7 @@
     - state: icon
 # ES Start
 # Consistency with new nitrile gloves
-      color: "#4da3ff"    
+      color: "#4da3ff"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -85,6 +85,7 @@
       - state: inhand-right
         color: "#4da3ff"
       - state: soles-inhand-right
+  - type: ESChameleonClothingWhitelist
   - type: Clothing
     sprite: Clothing/Shoes/color.rsi
     clothingVisuals:
@@ -105,7 +106,7 @@
     sprite: Clothing/Shoes/color.rsi
     layers:
     - state: icon
-      color: "#723A02"    
+      color: "#723A02"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -136,7 +137,7 @@
     sprite: Clothing/Shoes/color.rsi
     layers:
     - state: icon
-      color: "#5ABF2F"    
+      color: "#5ABF2F"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -155,6 +156,9 @@
       - state: equipped-FEET
         color: "#5ABF2F"
       - state: soles-equipped-FEET
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Orange Shoes
 - type: entity
@@ -167,7 +171,7 @@
     sprite: Clothing/Shoes/color.rsi
     layers:
     - state: icon
-      color: "#EF8100"    
+      color: "#EF8100"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -198,7 +202,7 @@
     sprite: Clothing/Shoes/color.rsi
     layers:
     - state: icon
-      color: "#940000"    
+      color: "#940000"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -217,6 +221,9 @@
       - state: equipped-FEET
         color: "#940000"
       - state: soles-equipped-FEET
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Yellow Shoes
 - type: entity
@@ -229,7 +236,7 @@
     sprite: Clothing/Shoes/color.rsi
     layers:
     - state: icon
-      color: "#EBE216"    
+      color: "#EBE216"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -248,6 +255,9 @@
       - state: equipped-FEET
         color: "#EBE216"
       - state: soles-equipped-FEET
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Purple Shoes
 - type: entity
@@ -260,7 +270,7 @@
     sprite: Clothing/Shoes/color.rsi
     layers:
     - state: icon
-      color: "#9C0DE1"    
+      color: "#9C0DE1"
     - state: soles-icon
   - type: Item
     inhandVisuals:
@@ -279,3 +289,6 @@
       - state: equipped-FEET
         color: "#9C0DE1"
       - state: soles-equipped-FEET
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/color_jumpsuits.yml
@@ -24,6 +24,9 @@
       jumpsuit:
       - state: equipped-INNERCLOTHING
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Grey Jumpsuit
 - type: entity
@@ -55,6 +58,9 @@
       - state: equipped-INNERCLOTHING
         color: "#b3b3b3"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Black Jumpsuit
 - type: entity
@@ -86,6 +92,9 @@
       - state: equipped-INNERCLOTHING
         color: "#3f3f3f"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Blue Jumpsuit
 - type: entity
@@ -112,6 +121,7 @@
       - state: inhand-right
         color: "#8cc4ff"
       - state: trinkets-inhand-right
+  - type: ESChameleonClothingWhitelist
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/color.rsi
     clothingVisuals:
@@ -151,6 +161,9 @@
       - state: equipped-INNERCLOTHING
         color: "#3285ba"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Teal Jumpsuit
 - type: entity
@@ -182,6 +195,9 @@
       - state: equipped-INNERCLOTHING
         color: "#77f3b7"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Green Jumpsuit
 - type: entity
@@ -213,6 +229,9 @@
       - state: equipped-INNERCLOTHING
         color: "#9ed63a"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
  # Dark Green Jumpsuit
 - type: entity
@@ -244,6 +263,9 @@
       - state: equipped-INNERCLOTHING
         color: "#007923"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Orange Jumpsuit
 - type: entity
@@ -275,6 +297,9 @@
       - state: equipped-INNERCLOTHING
         color: "#ff8c19"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Pink Jumpsuit
 - type: entity
@@ -306,6 +331,9 @@
       - state: equipped-INNERCLOTHING
         color: "#ffa69b"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Red Jumpsuit
 - type: entity
@@ -337,6 +365,9 @@
       - state: equipped-INNERCLOTHING
         color: "#eb0c07"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Yellow Jumpsuit
 - type: entity
@@ -368,6 +399,9 @@
       - state: equipped-INNERCLOTHING
         color: "#ffe14d"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Purple Jumpsuit
 - type: entity
@@ -399,6 +433,9 @@
       - state: equipped-INNERCLOTHING
         color: "#9f70cc"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Light Brown Jumpsuit
 - type: entity
@@ -430,6 +467,9 @@
       - state: equipped-INNERCLOTHING
         color: "#c59431"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Brown Jumpsuit
 - type: entity
@@ -461,6 +501,9 @@
       - state: equipped-INNERCLOTHING
         color: "#a17229"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Maroon Jumpsuit
 - type: entity
@@ -492,6 +535,9 @@
       - state: equipped-INNERCLOTHING
         color: "#cc295f"
       - state: trinkets-equipped-INNERCLOTHING
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END
 
 # Rainbow Jumpsuit
 - type: entity
@@ -504,3 +550,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/rainbow.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/rainbow.rsi
+# ES START
+  - type: ESChameleonClothingWhitelist
+# ES END

--- a/Resources/Prototypes/_ES/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -53,93 +53,29 @@
     sprite: _ES/Clothing/Uniforms/Jumpsuit/ru_color.rsi
 
 - type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorWhite ]
-  id: ESClothingUniformJumpsuitRussianColorWhite
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorGrey ]
+  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformBase ]
   id: ESClothingUniformJumpsuitRussianColorGrey
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorBlack ]
-  id: ESClothingUniformJumpsuitRussianColorBlack
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorBlue ]
-  id: ESClothingUniformJumpsuitRussianColorBlue
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorDarkBlue ]
-  id: ESClothingUniformJumpsuitRussianColorDarkBlue
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorTeal ]
-  id: ESClothingUniformJumpsuitRussianColorTeal
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorGreen ]
-  id: ESClothingUniformJumpsuitRussianColorGreen
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorDarkGreen ]
-  id: ESClothingUniformJumpsuitRussianColorDarkGreen
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorOrange ]
-  id: ESClothingUniformJumpsuitRussianColorOrange
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorPink ]
-  id: ESClothingUniformJumpsuitRussianColorPink
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorRed ]
-  id: ESClothingUniformJumpsuitRussianColorRed
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorYellow ]
-  id: ESClothingUniformJumpsuitRussianColorYellow
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorPurple ]
-  id: ESClothingUniformJumpsuitRussianColorPurple
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorLightBrown ]
-  id: ESClothingUniformJumpsuitRussianColorLightBrown
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorBrown ]
-  id: ESClothingUniformJumpsuitRussianColorBrown
-
-- type: entity
-  parent: [ ESBaseClothingUniformJumpsuitRussian, ClothingUniformJumpsuitColorMaroon ]
-  id: ESClothingUniformJumpsuitRussianColorMaroon
-
-# Janitor
-- type: entity
-  parent: ClothingUniformJumpsuitJanitor
-  id: ESClothingUniformJumpsuitRussianJanitor
-  suffix: ES, Russian
+  name: soviet jumpsuit
+  description: A tasteful grey jumpsuit that reminds you of the good old days.
   components:
   - type: Sprite
-    sprite: _ES/Clothing/Uniforms/Jumpsuit/ru_janitor.rsi
-  - type: Clothing
-    sprite: _ES/Clothing/Uniforms/Jumpsuit/ru_janitor.rsi
-
-# Security
-- type: entity
-  parent: ClothingUniformJumpsuitSec
-  id: ClothingUniformJumpsuitRussianSec
-  suffix: ES, Russian
-  components:
-  - type: Sprite
-    sprite: _ES/Clothing/Uniforms/Jumpsuit/ru_security.rsi
-  - type: Clothing
-    sprite: _ES/Clothing/Uniforms/Jumpsuit/ru_security.rsi
+    layers:
+    - state: icon
+      color: "#b3b3b3"
+    - state: trinkets-icon
   - type: Item
     inhandVisuals:
       left:
       - state: inhand-left
+        color: "#b3b3b3"
+      - state: trinkets-inhand-left
       right:
       - state: inhand-right
+        color: "#b3b3b3"
+      - state: trinkets-inhand-right
+  - type: Clothing
+    clothingVisuals:
+      jumpsuit:
+      - state: equipped-INNERCLOTHING
+        color: "#b3b3b3"
+      - state: trinkets-equipped-INNERCLOTHING

--- a/Resources/Prototypes/_ES/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Misc/implanters.yml
@@ -8,3 +8,13 @@
   - type: Implanter
     implant: ESMicroBombImplant
     deleteImplanterOnImplant: true
+
+- type: entity
+  parent: BaseImplantOnlyImplanterSyndi
+  id: ESChameleonControllerImplanter
+  name: chameleon controller implanter
+  description: This implanter disintegrates on use.
+  components:
+  - type: Implanter
+    implant: ChameleonControllerImplant
+    deleteImplanterOnImplant: true

--- a/Resources/Prototypes/_ES/Fills/Bags/backpacks.yml
+++ b/Resources/Prototypes/_ES/Fills/Bags/backpacks.yml
@@ -1,0 +1,17 @@
+- type: entity
+  parent: ClothingBackpackChameleon
+  id: ESClothingBackpackChameleonFill
+  suffix: ES, Fill, Chameleon
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase:
+        all:
+        - id: ChameleonPDA
+        - id: ClothingUniformJumpsuitChameleon
+        - id: ClothingOuterChameleon
+        - id: ClothingHeadHatChameleon
+        - id: ClothingHandsChameleon
+        - id: ClothingHeadsetChameleon
+        - id: ClothingShoesChameleon
+        - id: ESChameleonControllerImplanter

--- a/Resources/Prototypes/_ES/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Fills/Crates/caches.yml
@@ -44,7 +44,7 @@
   id: ESTraitorCacheInfiltrator
   table:
     all:
-    - id: ClothingBackpackChameleonFill
+    - id: ESClothingBackpackChameleonFill
     - id: ESEmag
     - id: C4
       amount: 2

--- a/Resources/Prototypes/_ES/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Cargo/cargo_technician.yml
@@ -24,3 +24,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESCargoTechnician
+  job: ESCargoTechnician
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Civilian/assistant.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Civilian/assistant.yml
@@ -21,3 +21,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESAssistant
+  job: ESAssistant
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Civilian/clown.yml
@@ -43,3 +43,8 @@
     - ESBoxHug
     - RubberStampClown
     - CrayonRainbow
+
+- type: chameleonOutfit
+  id: ESClown
+  job: ESClown
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Civilian/reporter.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Civilian/reporter.yml
@@ -22,3 +22,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESReporter
+  job: ESReporter
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/captain.yml
@@ -34,3 +34,8 @@
     back:
     - ESBoxSurvival
     - Flash
+
+- type: chameleonOutfit
+  id: ESCaptain
+  job: ESCaptain
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_personnel.yml
@@ -56,3 +56,8 @@
     back:
     - ESBoxSurvival
     - Flash
+
+- type: chameleonOutfit
+  id: ESHeadOfPersonnel
+  job: ESHeadOfPersonnel
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
@@ -44,3 +44,8 @@
     back:
     - ESBoxSurvival
     - Flash
+
+- type: chameleonOutfit
+  id: ESHeadOfSecurity
+  job: ESHeadOfSecurity
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -25,3 +25,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESAtmosphericTechnician
+  job: ESAtmosphericTechnician
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Engineering/station_engineer.yml
@@ -28,3 +28,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESStationEngineer
+  job: ESStationEngineer
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Medical/chemist.yml
@@ -26,3 +26,8 @@
   storage:
     back:
     - ESBoxSurvivalMedical
+
+- type: chameleonOutfit
+  id: ESChemist
+  job: ESChemist
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Medical/medical_doctor.yml
@@ -27,3 +27,8 @@
   storage:
     back:
     - ESBoxSurvivalMedical
+
+- type: chameleonOutfit
+  id: ESMedicalDoctor
+  job: ESMedicalDoctor
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Science/scientist.yml
@@ -23,3 +23,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESScientist
+  job: ESScientist
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/detective.yml
@@ -35,3 +35,8 @@
     - Flash
     - ForensicPad
     - ForensicScanner
+
+- type: chameleonOutfit
+  id: ESDetective
+  job: ESDetective
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
@@ -32,3 +32,8 @@
     back:
     - ESBoxSurvival
     - Flash
+
+- type: chameleonOutfit
+  id: ESSecurityOfficer
+  job: ESSecurityOfficer
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
@@ -35,3 +35,8 @@
     back:
     - ESBoxSurvival
     - Flash
+
+- type: chameleonOutfit
+  id: ESWarden
+  job: ESWarden
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Service/bartender.yml
@@ -27,3 +27,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESBartender
+  job: ESBartender
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Service/botanist.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Service/botanist.yml
@@ -27,3 +27,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESBotanist
+  job: ESBotanist
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Service/chef.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Service/chef.yml
@@ -28,3 +28,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESChef
+  job: ESChef
+  hidden: false

--- a/Resources/Prototypes/_ES/Roles/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Service/janitor.yml
@@ -28,3 +28,8 @@
   storage:
     back:
     - ESBoxSurvival
+
+- type: chameleonOutfit
+  id: ESJanitor
+  job: ESJanitor
+  hidden: false

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -216,6 +216,26 @@ SpawnPointDetective: ESSpawnPointDetective
 # 2025-12-29
 Autolathe: ESAutolathe
 
+# 2026-11-1
+# Removing old soviet jumpsuits from station v station days
+ESClothingUniformJumpsuitRussianColorWhite: null
+ESClothingUniformJumpsuitRussianColorBlack: null
+ESClothingUniformJumpsuitRussianColorBlue: null
+ESClothingUniformJumpsuitRussianColorDarkBlue: null
+ESClothingUniformJumpsuitRussianColorTeal: null
+ESClothingUniformJumpsuitRussianColorGreen: null
+ESClothingUniformJumpsuitRussianColorDarkGreen: null
+ESClothingUniformJumpsuitRussianColorOrange: null
+ESClothingUniformJumpsuitRussianColorPink: null
+ESClothingUniformJumpsuitRussianColorRed: null
+ESClothingUniformJumpsuitRussianColorYellow: null
+ESClothingUniformJumpsuitRussianColorPurple: null
+ESClothingUniformJumpsuitRussianColorLightBrown: null
+ESClothingUniformJumpsuitRussianColorBrown: null
+ESClothingUniformJumpsuitRussianColorMaroon: null
+ESClothingUniformJumpsuitRussianJanitor: null
+ClothingUniformJumpsuitRussianSec: null
+
 # ES END
 
 # 2023-07-03


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #600 

Bunch of changes regarding chameleon clothes:
- Removed out chameleon outfits from upstream and replaced them with custom ES ones for jobs
- Removed all non-ES clothing from chameleon clothes. This basically is everything that isn't worn by a job + colored clothing
- Removed the chameleon scarf, mask, and glasses from the bundle. this is because these items are either functionally useless or not worn by meaningful amounts of jobs. (shoutout neck slot, used by only 2 jobs)
- Made the chameleon controlled implant delete on implant
- migrated out a handful of old jumpsuits we weren't using.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
