### PR TITLE
Masquerade balance changes.

### DIFF
--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeRuleComponent.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeRuleComponent.cs
@@ -24,4 +24,10 @@ public sealed partial class ESMasqueradeRuleComponent : Component
     ///     The randomizer created from the initial seed and used for all role selection and latejoins.
     /// </summary>
     public SmallRandom Rng = default!;
+
+    /// <summary>
+    ///     The masks assigned in this masquerade, if any.
+    ///     This may also be influenced by the impersonated masquerade, for the masks actually in-game, query it.
+    /// </summary>
+    public List<ProtoId<ESMaskPrototype>>? AssignedMasks = null;
 }

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
@@ -248,7 +248,7 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
                     {
                         report.AppendLine(Loc.GetString(masquerade.StartupNewsArticleMaskEntry,
                             ("count", masks.Value),
-                            ("mask", masks.Key.ToString())));
+                            ("mask", Loc.GetString(_proto.Index(masks.Key).Name))));
                     }
 
                     _news.TryAddNews(ent,

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
@@ -236,7 +236,10 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
                     // and other places I wish the game had a Single<>() helper for "I really want to assume singleton".
                     var query = EntityQueryEnumerator<StationDataComponent>();
 
-                    if (!query.MoveNext(out var ent, out var comp))
+                    if (!query.MoveNext(out var ent, out _))
+                        return;
+
+                    if (component.Deleted)
                         return;
 
                     var report = new StringBuilder();

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
@@ -1,17 +1,22 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Rules;
+using Content.Server.MassMedia.Systems;
 using Content.Server.Mind;
+using Content.Server.Station.Systems;
 using Content.Shared._Citadel.Utilities;
 using Content.Shared._ES.Masks;
 using Content.Shared._ES.Masks.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Mind;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Station.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server._ES.Masks.Masquerades;
@@ -24,8 +29,11 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly ITimerManager _timer = default!;
     [Dependency] private readonly ESMaskSystem _mask = default!;
     [Dependency] private readonly MindSystem _mind = default!;
+    [Dependency] private readonly NewsSystem _news = default!;
+    [Dependency] private readonly StationSystem _station = default!;
 
     // Icky global state.
     private ProtoId<ESMasqueradePrototype>? _forcedMasquerade;
@@ -54,6 +62,23 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
         {
             Log.Error($"Failed to assign masks for masquerade {rule.Masquerade!.ID}!");
             return;
+        }
+
+        if (rule.Masquerade.ImpersonateMasquerade is { } impersonate)
+        {
+            var proto = _proto.Index(impersonate);
+
+            if (!proto.Masquerade.TryGetMasks(ev.Players.Count, rule.Rng, _proto, out var impersonationMasks))
+            {
+                Log.Error($"Failed to assign impersonation masks for masquerade {rule.Masquerade!.ID}!");
+                return;
+            }
+
+            rule.AssignedMasks = impersonationMasks;
+        }
+        else
+        {
+            rule.AssignedMasks = masks.ShallowClone();
         }
 
         DebugTools.AssertEqual(masks.Count, ev.Players.Count, "Player count mismatched mask count, shit broke.");
@@ -191,14 +216,44 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
         component.Rng = component.Seed.IntoRandomizer();
         component.Masquerade = SelectMasquerade(GameTicker.ReadyPlayerCount());
 
-        if (component.Masquerade is null)
+        if (component.Masquerade is not {} masquerade)
             return;
 
-        _chat.SendAdminAlert($"Upcoming masquerade is {component.Masquerade.ID}.");
+        _chat.SendAdminAlert($"Upcoming masquerade is {masquerade.ID}.");
 
-        foreach (var rule in component.Masquerade.GameRules)
+        foreach (var rule in masquerade.GameRules)
         {
             GameTicker.StartGameRule(rule);
+        }
+
+        // If we do news, run the news.
+        if (masquerade.StartupNewsArticleTime is { } time)
+        {
+            Timer.Spawn(time,
+                () =>
+                {
+                    // Find The Station. Only one.
+                    // and other places I wish the game had a Single<>() helper for "I really want to assume singleton".
+                    var query = EntityQueryEnumerator<StationDataComponent>();
+
+                    if (!query.MoveNext(out var ent, out var comp))
+                        return;
+
+                    var report = new StringBuilder();
+
+                    foreach (var masks in component.AssignedMasks!.CountBy(x => x))
+                    {
+                        report.AppendLine(Loc.GetString(masquerade.StartupNewsArticleMaskEntry,
+                            ("count", masks.Value),
+                            ("mask", masks.Key.ToString())));
+                    }
+
+                    _news.TryAddNews(ent,
+                        Loc.GetString(masquerade.StartupNewsArticleTitle),
+                        Loc.GetString(masquerade.StartupNewsArticleContents, ("maskEntries", report)),
+                        out _,
+                        enforceLimits: false);
+                });
         }
     }
 

--- a/Content.Shared/_ES/Masks/ESMasqueradePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESMasqueradePrototype.cs
@@ -72,6 +72,24 @@ public sealed partial class ESMasqueradePrototype : IPrototype, ISerializationHo
         set => Masquerade.MaxPlayers = value;
     }
 
+    [DataField]
+    public TimeSpan? StartupNewsArticleTime = TimeSpan.FromSeconds(60);
+
+    [DataField]
+    public LocId StartupNewsArticleTitle = "es-news-masks-report-title";
+
+    [DataField]
+    public LocId StartupNewsArticleContents = "es-news-masks-report-body";
+
+    [DataField]
+    public LocId StartupNewsArticleMaskEntry = "es-news-masks-entry";
+
+    /// <summary>
+    ///     A masquerade to impersonate, if any. This tells the game to "act like this other masquerade" for things
+    ///     like the startup news article. For example, Freakshow impersonates Traitors and simply lies about the masks.
+    /// </summary>
+    [DataField]
+    public ProtoId<ESMasqueradePrototype>? ImpersonateMasquerade = null;
 
     // Due to this being shared, we can't rely on GamePresetPrototype... please don't make typos :3
     /// <summary>

--- a/Content.Shared/_ES/Masks/ESMasqueradePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESMasqueradePrototype.cs
@@ -72,15 +72,31 @@ public sealed partial class ESMasqueradePrototype : IPrototype, ISerializationHo
         set => Masquerade.MaxPlayers = value;
     }
 
+    /// <summary>
+    ///     How long after roundstart/rule startup should the news be broadcast.
+    /// </summary>
     [DataField]
     public TimeSpan? StartupNewsArticleTime = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    ///     The title to use for the roundstart news article.
+    /// </summary>
     [DataField]
     public LocId StartupNewsArticleTitle = "es-news-masks-report-title";
 
+    /// <summary>
+    ///     The contents to use for the roundstart news article.
+    /// </summary>
     [DataField]
     public LocId StartupNewsArticleContents = "es-news-masks-report-body";
 
+    /// <summary>
+    ///     The mask entry loc string to use for the roundstart news.
+    /// </summary>
+    /// <remarks>
+    ///     Fluent is responsible for pluralizing the mask names, so if you want to hide how many of each mask there is
+    ///     use this.
+    /// </remarks>
     [DataField]
     public LocId StartupNewsArticleMaskEntry = "es-news-masks-entry";
 

--- a/Resources/Locale/en-US/_ES/news/masks-report.ftl
+++ b/Resources/Locale/en-US/_ES/news/masks-report.ftl
@@ -1,0 +1,13 @@
+es-news-masks-report-title = NT Psychics Report
+es-news-masks-report-body =
+    The Nanotrasen Sponsored Psychics Team (NSPT) has opted to release their analysis of your crew to improve your odds of survival.
+    We believe your personalities, in no particular order, to fit the following archetypes:
+    {$maskEntries}
+
+    We have no information on who is who, so work together and identify eachother's archetypes to identify the threat.
+    Good luck. NSPT out.
+
+es-news-masks-entry = - {$count ->
+        [one] {$mask}
+        *[other] {$mask} ({$count})
+    }

--- a/Resources/Prototypes/_ES/MaskSets/falsetraitors.yml
+++ b/Resources/Prototypes/_ES/MaskSets/falsetraitors.yml
@@ -1,0 +1,5 @@
+- type: esMaskSet
+  id: FalseTraitors # Traitor impersonating crew roles.
+  masks:
+    ESVandal: 1
+    ESMercenary: 0.5

--- a/Resources/Prototypes/_ES/Masquerades/freakshow.yml
+++ b/Resources/Prototypes/_ES/Masquerades/freakshow.yml
@@ -3,23 +3,31 @@
   name: Freakshow
   description: packs the round with almost nothing but high noise crew masks, no traitors in sight
   weight: 1
-  minPlayers: 4
+  minPlayers: 6
   gameRules: []
+  impersonateMasquerade: Traitors
   masquerade: !type:MasqueradeRoleSet
-    defaultMask: "ESCrewmember"
+    defaultMask: "#Jesters"
     roles:
-      4: ["#Jesters", "ESVandal", "#Oracles"] # 1 generic crew.
-      5: ["ESMercenary"]
-      6: ["#Firmsafes"]
-      8: ["#Jesters", "#Freaks"]
-      10: ["#CrewGunners"] # 2 generic crew.
-      11: ["ESVandal"]
-      13: ["#CrewGunners(2)"]
-      15: ["-ESMercenary", "#Jesters(2)"] # 3 generic crew.
-      18: ["ESPhantom", "#Firmsafes", "#Reaped"] # 3 generic crew. If there isn't already a phantom, make sure of it.
-      20: ["#Oracles"] # You can finally have another oracle. 5 generic crew.
-      23: ["#Freaks", "#Firmsafes"] # 6 generic crew.
-      25: ["#CrewGunners", "#Freaks(2)"] # 5 generic crew. The freaks are banding together.
-      27: ["#Jesters"] # 6 generic crew.
-      30: ["#Jesters", "#Oracles"] # This is kind of a problem. I hope the oracles don't lose their mind here.
-
+      6: ["#Jesters(3)", "#Softsafes", "ESVandal", "ESMercenary"] # 0 generic crew
+      7: ["ESMartyr"]
+      8: ["#Softsafes"]
+      9: ["#CrewGunners"]
+      10: ["ESPhantom"]
+      11: ["#Softsafes"]
+      13: ["#Jesters"]  # 0 generic crew
+      14: ["ESEmpath"]
+      16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
+      17: ["#Reaped"]
+      18: ["ESArmsDealer"]
+      19: ["#Jesters"] # 1 generic crew, 4 traitors.
+      20: ["#Softsafes"]
+      21: ["#Jesters"] # 1 generic crew, 4 traitors.
+      22: ["#Softsafes"]
+      24: ["#CrewGunners"] # 2 generic crew, 4 traitors.
+      25: ["#Jesters"] # 2 generic crew, 5 traitors.
+      26: ["#Jesters"]
+      28: ["#CrewGunners"] # 3 generic crew, 5 traitors.
+      29: ["#Softsafes"]
+      30: ["#Reaped"]
+      31: ["#Jesters(2)"] # 3 generic crew, 6 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/freakshow.yml
+++ b/Resources/Prototypes/_ES/Masquerades/freakshow.yml
@@ -9,7 +9,7 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "#Jesters"
     roles:
-      6: ["#Jesters(2)", "#Freaks", "#Softsafes", "ESVandal", "ESMercenary"] # 0 generic crew
+      6: ["#Jesters(3)", "#Softsafes", "ESVandal", "ESMercenary"] # 0 generic crew
       7: ["ESMartyr"]
       8: ["#Softsafes"]
       9: ["#CrewGunners"]
@@ -20,13 +20,13 @@
       16: ["#Firmsafes"] # 1 generic crew
       17: ["#Reaped"]
       18: ["ESArmsDealer"]
-      19: ["#Freaks"] # 1 generic crew
+      19: ["#Jesters"] # 1 generic crew
       20: ["#Softsafes"]
-      21: ["#Freaks"] # 1 generic crew
+      21: ["#Jesters"] # 1 generic crew
       22: ["#Softsafes"]
       24: ["#CrewGunners"] # 2 generic crew
       25: ["#Jesters"] # 2 generic crew, 5 traitors.
-      26: ["#Freaks"]
+      26: ["#Jesters"]
       28: ["#CrewGunners"] # 3 generic crew
       29: ["#Softsafes"]
       30: ["#Reaped"]

--- a/Resources/Prototypes/_ES/Masquerades/freakshow.yml
+++ b/Resources/Prototypes/_ES/Masquerades/freakshow.yml
@@ -9,24 +9,24 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "#Jesters"
     roles:
-      6: ["#Jesters(3)", "#Softsafes", "ESVandal", "ESMercenary"] # 0 generic crew
+      6: ["#Jesters(2)", "#Freaks", "#Softsafes", "ESVandal", "ESMercenary"] # 0 generic crew
       7: ["ESMartyr"]
       8: ["#Softsafes"]
       9: ["#CrewGunners"]
       10: ["ESPhantom"]
       11: ["#Softsafes"]
-      13: ["#Jesters"]  # 0 generic crew
+      13: ["#Freaks"]  # 0 generic crew
       14: ["ESEmpath"]
       16: ["#Firmsafes"] # 1 generic crew
       17: ["#Reaped"]
       18: ["ESArmsDealer"]
-      19: ["#Jesters"] # 1 generic crew
+      19: ["#Freaks"] # 1 generic crew
       20: ["#Softsafes"]
-      21: ["#Jesters"] # 1 generic crew
+      21: ["#Freaks"] # 1 generic crew
       22: ["#Softsafes"]
       24: ["#CrewGunners"] # 2 generic crew
       25: ["#Jesters"] # 2 generic crew, 5 traitors.
-      26: ["#Jesters"]
+      26: ["#Freaks"]
       28: ["#CrewGunners"] # 3 generic crew
       29: ["#Softsafes"]
       30: ["#Reaped"]

--- a/Resources/Prototypes/_ES/Masquerades/freakshow.yml
+++ b/Resources/Prototypes/_ES/Masquerades/freakshow.yml
@@ -17,17 +17,17 @@
       11: ["#Softsafes"]
       13: ["#Jesters"]  # 0 generic crew
       14: ["ESEmpath"]
-      16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
+      16: ["#Firmsafes"] # 1 generic crew
       17: ["#Reaped"]
       18: ["ESArmsDealer"]
-      19: ["#Jesters"] # 1 generic crew, 4 traitors.
+      19: ["#Jesters"] # 1 generic crew
       20: ["#Softsafes"]
-      21: ["#Jesters"] # 1 generic crew, 4 traitors.
+      21: ["#Jesters"] # 1 generic crew
       22: ["#Softsafes"]
-      24: ["#CrewGunners"] # 2 generic crew, 4 traitors.
+      24: ["#CrewGunners"] # 2 generic crew
       25: ["#Jesters"] # 2 generic crew, 5 traitors.
       26: ["#Jesters"]
-      28: ["#CrewGunners"] # 3 generic crew, 5 traitors.
+      28: ["#CrewGunners"] # 3 generic crew
       29: ["#Softsafes"]
       30: ["#Reaped"]
-      31: ["#Jesters(2)"] # 3 generic crew, 6 traitors.
+      31: ["#Jesters(2)"] # 3 generic crew

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -6,25 +6,27 @@
   minPlayers: 6
   gameRules: []
   masquerade: !type:MasqueradeRoleSet
-    defaultMask: "ESVIP/ESCrewmember" # God help you.
+    defaultMask: "ESCrewmember/ESVIP"
     roles:
-      6: ["ESMarauder", "ESInfiltrator", "ESVIP", "#Oracles", "#Softsafes", "#Gunners"] # 0 generic crew, 2 traitors
-      7: ["ESVIP"]
-      8: ["#Softsafes"]
-      9: ["ESVIP"] # The gang is here.
-      10: ["#Jesters"]
-      11: ["-ESInfiltrator", "#Traitors"] # 0 generic crew, 2 traitors.
-      13: ["#Traitors"] # 1 generic crew, 3 traitors.
-      14: ["#Gunners"] # 2 generic crew, 3 traitors.
-      16: ["#Firmsafes"] # 3 generic crew, 3 traitors.
-      18: ["#Reaped"] # 4 generic crew, 4 traitors.
-      19: ["#Traitors"] # 4 generic crew, 4 traitors.
-      20: ["#Softsafes"]
-      21: ["-#Traitors", "#PowerTraitors"] # 5 generic crew, 4 traitors.
-      22: ["#Jesters"] # 5 generic crew, 4 traitors.
-      24: ["#Firmsafes"] # 5 generic crew, 4 traitors.
-      25: ["#Traitors"] # 5 generic crew, 5 traitors.
-      26: ["#Oracles"] # 5 generic crew, 5 traitors.
-      28: ["#Gunners"] # 6 generic crew, 5 traitors.
-      30: ["#Oracles"] # 7 generic crew, 5 traitors.
-      31: ["#Traitors"] # 7 generic crew, 6 traitors.
+      6: ["ESMarauder", "ESInfiltrator", "ESInsider", "ESVIP", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
+      7: ["ESMartyr"]
+      8: ["ESVIP"]
+      9: ["ESVeteran"]
+      10: ["ESPhantom"]
+      11: ["ESVIP"]
+      13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
+      14: ["ESEmpath"]
+      16: ["ESArmsDealer"] # 1 generic crew, 3 traitors.
+      17: ["#Reaped"]
+      18: ["ESVIP"]
+      19: ["ESMarauder"] # 1 generic crew, 4 traitors.
+      20: ["ESVIP"]
+      21: ["#Jesters", "-ESMarauder", "#PowerTraitors"] # 1 generic crew, 4 traitors.
+      22: ["ESVIP"]
+      24: ["#Gunners"] # 2 generic crew, 4 traitors.
+      25: ["ESMarauder"] # 2 generic crew, 5 traitors.
+      26: ["ESInsider"]
+      28: ["#Gunners"] # 3 generic crew, 5 traitors.
+      29: ["ESVIP"]
+      30: ["#Reaped"]
+      31: ["#Traitors", "ESInsider"] # 3 generic crew, 6 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -3,22 +3,28 @@
   name: Showdown
   description: is a real showdown, with many more guns than usual
   weight: 1 # Not that common
-  minPlayers: 6
+  minPlayers: 8
   gameRules: []
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESCrewmember"
     roles:
-      6: ["ESMarauder(2)", "#Gunners(2)", "ESVIP/ESFruitVendor", "ESSurvivalist"] # 0 generic crew, 2 traitors
-      8: ["-ESMarauder", "#Traitors", "#Oracles"] # 1 generic crew, 2 traitors
-      10: ["#Traitors"] # 1 generic crew, 3 traitors.
-      11: ["ESArmsDealer"] # Guarantee an arms dealer, this is definitely balanced around an armed crew.
-      13: ["#Reaped"] # 2 generic crew, 3 traitors.
-      15: ["#PowerTraitors", "ESMercenary"] # 2 generic crew, 4 traitors.
+      8: ["ESMarauder(2)", "ESVandal", "ESMercenary" "ESVIP/ESFruitVendor", "ESArmsDealer", "ESInsider", "#Softsafes"] # 0 generic crew, 2 traitors
+      9: ["#Gunners"]
+      10: ["ESInfiltrator"] # 0 generic crew, 3 traitors.
+      11: ["ESArmsDealer"] # Guarantee another arms dealer, this is definitely balanced around an armed crew.
+      12: ["ESPhantom"] # Guaranteed phantom for the silly value.
+      13: ["ESMartyr"]
+      14: ["ESEmpath"]
+      15: ["#PowerTraitors"] # 0 generic crew, 4 traitors.
       16: ["#Firmsafes"]
-      17: ["#Traitors"] # 2 generic crew, 5 traitors.
-      18: ["#Oracles"] # 2 generic crew, 5 traitors.
-      20: ["#Traitors"] # 3 generic crew, 6 traitors.
-      22: ["#Gunners"] # 4 generic crew, 6 traitors.
-      25: ["#Jesters(2)", "#PowerTraitors"] # 4 generic crew, 7 traitors.
+      17: ["#Traitors"] # 0 generic crew, 5 traitors.
+      18: ["#FalseTraitors"] # 0 generic crew, 5 traitors.
+      20: ["#Traitors"] # 1 generic crew, 6 traitors.
+      21: ["ESInsider"]
+      22: ["#Gunners"] # 1 generic crew, 6 traitors.
+      24: ["#Jesters(2)"]
+      25: ["#PowerTraitors"] # 1 generic crew, 7 traitors.
       26: ["#Freaks"]
-      30: ["#Softsafes(2)", "#Traitors"] # 5 generic crew, 8 traitors.
+      27: ["#Softsafes"]
+      28: ["ESEmpath"]
+      30: ["#Traitors"] # 2 generic crew, 8 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -8,7 +8,7 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESCrewmember"
     roles:
-      8: ["ESMarauder(2)", "ESVandal", "ESMercenary" "ESVIP/ESFruitVendor", "ESArmsDealer", "ESInsider", "#Softsafes"] # 0 generic crew, 2 traitors
+      8: ["ESMarauder(2)", "ESVandal", "ESMercenary", "ESVIP/ESFruitVendor", "ESArmsDealer", "ESInsider", "#Softsafes"] # 0 generic crew, 2 traitors
       9: ["#Gunners"]
       10: ["ESInfiltrator"] # 0 generic crew, 3 traitors.
       11: ["ESArmsDealer"] # Guarantee another arms dealer, this is definitely balanced around an armed crew.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -8,22 +8,25 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "ESCrewmember"
     roles:
-      6: ["#Traitors", "ESInfiltrator", "#Oracles", "#Softsafes", "#Gunners"] # 1 generic crew, 2 traitors
-      8: ["#Softsafes"] # 2 generic crew, 2 traitors.
-      10: ["#Jesters"] # 3 generic crew, 2 traitors.
-      11: ["-ESInfiltrator", "#Traitors"] # 3 generic crew, 2 traitors.
-      13: ["#Traitors"]  # 4 generic crew, 3 traitors.
-      14: ["#Gunners"] # 4 generic crew, 3 traitors.
-      16: ["#Firmsafes"] # 5 generic crew, 3 traitors.
-      17: ["#Reaped"] # 5 generic crew, 4 traitors.
-      18: ["#Softsafes"] # 5 generic crew, 4 traitors.
-      19: ["#Traitors"] # 5 generic crew, 4 traitors.
-      20: ["#Softsafes"] # 5 generic crew, 4 traitors.
-      21: ["#Jesters", "-#Traitors", "#PowerTraitors"] # 5 generic crew, 4 traitors.
-      22: ["#Softsafes"] # 5 generic crew, 4 traitors.
-      24: ["#Gunners"] # 6 generic crew, 4 traitors.
-      25: ["#Traitors"] # 6 generic crew, 5 traitors.
-      26: ["#Oracles"] # 6 generic crew, 5 traitors.
-      28: ["#Gunners"] # 7 generic crew, 5 traitors.
-      30: ["#Reaped"] # 8 generic crew, 5 traitors
-      31: ["#Traitors", "#Oracles"] # 7 generic crew, 6 traitors.
+      6: ["ESMarauder", "ESInfiltrator", "ESInsider", "#Softsafes", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
+      7: ["ESMartyr"]
+      8: ["#Softsafes"]
+      9: ["ESVeteran"]
+      10: ["ESPhantom"]
+      11: ["#Softsafes"]
+      13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
+      14: ["ESEmpath"]
+      16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
+      17: ["#Reaped"]
+      18: ["ESArmsDealer"]
+      19: ["ESMarauder"] # 1 generic crew, 4 traitors.
+      20: ["#Softsafes"]
+      21: ["#Jesters", "-ESMarauder", "#PowerTraitors"] # 1 generic crew, 4 traitors.
+      22: ["#Softsafes"]
+      24: ["#Gunners"] # 2 generic crew, 4 traitors.
+      25: ["ESMarauder"] # 2 generic crew, 5 traitors.
+      26: ["ESInsider"]
+      28: ["#Gunners"] # 3 generic crew, 5 traitors.
+      29: ["#Softsafes"]
+      30: ["#Reaped"]
+      31: ["#Traitors", "ESInsider"] # 3 generic crew, 6 traitors.


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
- Rebalance masquerades again to have a more predefined roster alongside the random roles.
- Completely rethink freakshow, it is now jesters. A lot of jesters. It's really jesters.
- Introduce roundstart news reports. 
- Introduce masquerade impersonation, and make Freakshow use it for the above. Freakshow will give a mask roster that makes sense for Traitors instead of revealing itself.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
