### PR TITLE
Nerf autolathe ammo production

### DIFF
--- a/Resources/Locale/en-US/_ES/lathe/recipes.ftl
+++ b/Resources/Locale/en-US/_ES/lathe/recipes.ftl
@@ -1,4 +1,4 @@
 # Ammo
 
-lathe-recipe-magazine-9mm-empty-name = 9mm magazine (empty)
-lathe-recipe-speedloader-357-empty-name = .357 speed loader (empty)
+es-lathe-recipe-magazine-9mm-empty-name = 9mm magazine (empty)
+es-lathe-recipe-speedloader-357-empty-name = .357 speed loader (empty)

--- a/Resources/Locale/en-US/_ES/lathe/recipes.ftl
+++ b/Resources/Locale/en-US/_ES/lathe/recipes.ftl
@@ -1,0 +1,4 @@
+# Ammo
+
+lathe-recipe-magazine-9mm-empty-name = 9mm magazine (empty)
+lathe-recipe-speedloader-357-empty-name = .357 speed loader (empty)

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/magazines.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/magazines.yml
@@ -44,3 +44,11 @@
   components:
   - type: BallisticAmmoProvider
     proto: ESRound9mm
+
+- type: entity
+  parent: ESMagazine9mm
+  id: ESMagazine9mmEmpty
+  suffix: empty
+  components:
+  - type: BallisticAmmoProvider
+    proto: null

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/speedloaders.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/speedloaders.yml
@@ -46,3 +46,11 @@
       right:
       - state: inhand-right-mag
       - state: inhand-right-ammo
+
+- type: entity
+  parent: ESSpeedLoader357
+  id: ESSpeedLoader357Empty
+  suffix: empty
+  components:
+  - type: BallisticAmmoProvider
+    proto: null

--- a/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
@@ -1,17 +1,37 @@
 # Handgun
 - type: latheRecipe
   parent: BaseAmmoRecipe
-  id: ESMagazine9mm
-  result: ESMagazine9mm
+  id: ESMagazine9mmEmpty
+  result: ESMagazine9mmEmpty
+  icon: # Manually specifies an icon because it needs to show as empty
+    sprite: _ES/Objects/Weapons/Guns/Ammunition/9mm_mag.rsi
+    state: base
   materials:
     Steel: 400
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
-  id: ESSpeedLoader357
-  result: ESSpeedLoader357
+  id: ESSpeedLoader357Empty
+  result: ESSpeedLoader357Empty
+  icon: # Manually specifies an icon because it needs to show as empty
+    sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
+    state: base
   materials:
     Steel: 500
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: ESRound9mm
+  result: ESRound9mm
+  materials:
+    Steel: 50
+
+- type: latheRecipe
+  parent: BaseAmmoRecipe
+  id: ESRound357
+  result: ESRound357
+  materials:
+    Steel: 50
 
 # Shotgun
 

--- a/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
@@ -2,7 +2,7 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESMagazine9mmEmpty
-  name: 9mm magazine (empty)
+  name: lathe-recipe-magazine-9mm-empty-name
   result: ESMagazine9mmEmpty
   icon: # Manually specifies an icon because it needs to show as empty
     sprite: _ES/Objects/Weapons/Guns/Ammunition/9mm_mag.rsi
@@ -13,7 +13,7 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESSpeedLoader357Empty
-  name: .357 speed loader (empty)
+  name: lathe-recipe-speedloader-357-empty-name
   result: ESSpeedLoader357Empty
   icon: # Manually specifies an icon because it needs to show as empty
     sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi

--- a/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
@@ -2,7 +2,7 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESMagazine9mmEmpty
-  name: lathe-recipe-magazine-9mm-empty-name
+  name: es-lathe-recipe-magazine-9mm-empty-name
   result: ESMagazine9mmEmpty
   icon: # Manually specifies an icon because it needs to show as empty
     sprite: _ES/Objects/Weapons/Guns/Ammunition/9mm_mag.rsi
@@ -13,7 +13,7 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESSpeedLoader357Empty
-  name: lathe-recipe-speedloader-357-empty-name
+  name: es-lathe-recipe-speedloader-357-empty-name
   result: ESSpeedLoader357Empty
   icon: # Manually specifies an icon because it needs to show as empty
     sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi

--- a/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/ammunition.yml
@@ -2,6 +2,7 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESMagazine9mmEmpty
+  name: 9mm magazine (empty)
   result: ESMagazine9mmEmpty
   icon: # Manually specifies an icon because it needs to show as empty
     sprite: _ES/Objects/Weapons/Guns/Ammunition/9mm_mag.rsi
@@ -12,6 +13,7 @@
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESSpeedLoader357Empty
+  name: .357 speed loader (empty)
   result: ESSpeedLoader357Empty
   icon: # Manually specifies an icon because it needs to show as empty
     sprite: Objects/Weapons/Guns/Ammunition/SpeedLoaders/Magnum/magnum_speed_loader.rsi
@@ -24,14 +26,14 @@
   id: ESRound9mm
   result: ESRound9mm
   materials:
-    Steel: 50
+    Steel: 200
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
   id: ESRound357
   result: ESRound357
   materials:
-    Steel: 50
+    Steel: 200
 
 # Shotgun
 

--- a/Resources/Prototypes/_ES/Lathe/packs.yml
+++ b/Resources/Prototypes/_ES/Lathe/packs.yml
@@ -125,8 +125,10 @@
 - type: latheRecipePack
   id: ESAmmunition
   recipes:
-  - ESMagazine9mm
-  - ESSpeedLoader357
+  - ESMagazine9mmEmpty
+  - ESRound9mm
+  - ESSpeedLoader357Empty
+  - ESRound357
   - ESShellShotgunBeanbag
   - ESShellShotgunBuckshot
   - ESShellShotgunSlug


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Resolves #899.

The autolathe now produces bullets individually, in line with shotgun shells. Magazines and speedloaders produced by the autolathe are also now empty.

Values are as follows:
- Magazines, speedloaders, and all bullets take 5 seconds to produce (standardized with shotgun shells)
- 9mm Magazine (empty) costs 4 steel
- 9mm Round costs 2 steel per bullet
- .357 Speedloader (empty) costs 5 steel
- .357 Round costs 2 steel per bullet

I suspect that the values will be tweaked later anyways, so I didn't put too much deliberation into them for now. However, this is pretty unambiguously intended to make it more difficult for anyone to acquire large amounts of ammo.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="377" height="224" alt="image" src="https://github.com/user-attachments/assets/96f9ee30-6e91-4985-8a44-aa53f2ebaa1f" />
