### PR TITLE
Brush up timers a bit, notably to support not networking them.

### DIFF
--- a/Content.IntegrationTests/Tests/_Citadel/GameTest.Proxies.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTest.Proxies.cs
@@ -316,4 +316,22 @@ public abstract partial class GameTest
     {
         return Client.EntMan.Deleted(ent);
     }
+
+    /// <summary>
+    ///     Checks whether the given entity has the given component.
+    /// </summary>
+    public bool SHasComp<T>(EntityUid? ent)
+        where T: IComponent
+    {
+        return Server.EntMan.HasComponent<T>(ent);
+    }
+
+    /// <summary>
+    ///     Checks whether the given entity has the given component.
+    /// </summary>
+    public bool CHasComp<T>(EntityUid? ent)
+        where T: IComponent
+    {
+        return Client.EntMan.HasComponent<T>(ent);
+    }
 }

--- a/Content.IntegrationTests/Tests/_Citadel/GameTest.Proxies.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTest.Proxies.cs
@@ -300,4 +300,20 @@ public abstract partial class GameTest
 
         return res;
     }
+
+    /// <summary>
+    ///     Checks whether the given entity has been deleted on the server.
+    /// </summary>
+    public bool SDeleted(EntityUid? ent)
+    {
+        return Server.EntMan.Deleted(ent);
+    }
+
+    /// <summary>
+    ///     Checks whether the given entity has been deleted on the client.
+    /// </summary>
+    public bool CDeleted(EntityUid? ent)
+    {
+        return Client.EntMan.Deleted(ent);
+    }
 }

--- a/Content.IntegrationTests/Tests/_Citadel/GameTest.cs
+++ b/Content.IntegrationTests/Tests/_Citadel/GameTest.cs
@@ -49,7 +49,7 @@ public abstract partial class GameTest
     /// <summary>
     ///     The client-side entity manager.
     /// </summary>
-    public IEntityManager CEntMan => Server.EntMan;
+    public IEntityManager CEntMan => Client.EntMan;
 
     [SetUp]
     public virtual async Task DoSetup()

--- a/Content.IntegrationTests/Tests/_ES/Masquerades/MasqueradeTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Masquerades/MasqueradeTests.cs
@@ -188,5 +188,10 @@ public sealed class MasqueradeRunTests : GameTest
 
             _sGameticker.RestartRound();
         });
+
+        await Server.WaitPost(() =>
+        {
+            _sGameticker.SetGamePreset("Extended");
+        });
     }
 }

--- a/Content.IntegrationTests/Tests/_ES/Masquerades/MasqueradeTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Masquerades/MasqueradeTests.cs
@@ -121,7 +121,6 @@ public sealed class MasqueradeRunTests : GameTest
         DummyTicker = false,
         Connected = true, // Have one real client connected just to catch oddities.
         InLobby = true,
-        Destructive = true, // fuck it. We set the preset which is destructive.
     };
 
     [TestCase("RandomTraitors", 35)]

--- a/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
@@ -111,8 +111,6 @@ public sealed class TimerTests : GameTest
         {
             var ctimer = CEntity<ESEntityTimerComponent>(ToClientUid(timer!.Value));
 
-            Assert.That(timer.Value.Comp, Is.Not.EqualTo(ctimer.Comp), "wth.");
-
             Assert.That(ctimer.Comp.TimerEndEvent, Is.Null);
 
 

--- a/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
@@ -109,11 +109,9 @@ public sealed class TimerTests : GameTest
 
         await Client.WaitAssertion(() =>
         {
-            var ctimer = CEntity<ESEntityTimerComponent>(ToClientUid(timer!.Value));
+            var ctimer = ToClientUid(timer!.Value);
 
-            Assert.That(ctimer.Comp.TimerEndEvent, Is.Null);
-
-
+            Assert.That(CHasComp<ESEntityTimerComponent>(ctimer), Is.False);
         });
 
         await Pair.RunSeconds(3);

--- a/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Content.IntegrationTests.Tests._Citadel;
+using Content.Shared._ES.Core.Timer;
+using Content.Shared._ES.Core.Timer.Components;
+using Robust.Server.GameStates;
+using Robust.Shared.ContentPack;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Reflection;
+using Robust.Shared.Serialization;
+
+namespace Content.IntegrationTests.Tests._ES.Timers;
+
+[TestFixture]
+public sealed class TimerTests : GameTest
+{
+    // Just uses the pool instead of trying to spin up reflectionmanager standalone, as we already have functional
+    // pairs floating around in a normal CI testing environment.
+
+    [SidedDependency(Side.Server)] private readonly IReflectionManager _reflection = default!;
+
+    [System(Side.Server)] private readonly ESEntityTimerSystem _sTimer = default!;
+    [System(Side.Server)] private readonly PvsOverrideSystem _pvsOverride = default!;
+
+    [Test]
+    [TestOf(typeof(ESEntityTimerEvent))]
+    [Description("Asserts that all timer events are marked appropriately for their side.")]
+    [RunOnSide(Side.Server)]
+    public void EnsureTimerEventSanity()
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (var type in _reflection.GetAllChildren<ESEntityTimerEvent>())
+            {
+                var side = GetSideOfType(type);
+
+                switch (side)
+                {
+                    case Side.Client:
+                    case Side.Server:
+                        Assert.That(type, Has.No.Attribute<NetSerializableAttribute>());
+                        break;
+                    case Side.Neither: // Shared
+                        Assert.That(type, Has.Attribute<NetSerializableAttribute>().Or.Attribute<NonNetworkedTimerEventAttribute>());
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+    }
+
+    [Test]
+    [TestOf(typeof(ESEntityTimerSystem))]
+    public async Task EnsureTimerSync()
+    {
+        Entity<ESEntityTimerComponent>? timer = null;
+
+        await Server.WaitAssertion(() =>
+        {
+            timer = _sTimer.SpawnTimer(TimeSpan.FromSeconds(1), new TestTimerEvent());
+            Assert.That(timer, Is.Not.Null);
+
+            Assert.That(timer.Value.Comp.TimerEndEvent, Is.TypeOf<TestTimerEvent>());
+
+            _pvsOverride.AddGlobalOverride(timer.Value); // Ensure it gets synced.
+        });
+
+        await SyncTicks();
+
+        await Client.WaitAssertion(() =>
+        {
+            var ctimer = CEntity<ESEntityTimerComponent>(ToClientUid(timer!.Value));
+
+            Assert.That(ctimer.Comp.TimerEndEvent, Is.TypeOf<TestTimerEvent>());
+
+        });
+
+        await Pair.RunSeconds(3);
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SDeleted(timer), "Timer should be deleted by now.. it's been 3 seconds, it lasts 1.");
+        });
+    }
+
+    [Test]
+    [TestOf(typeof(ESEntityTimerSystem))]
+    public async Task EnsureMethodTimerSync()
+    {
+        Entity<ESEntityTimerComponent>? timer = null;
+
+        var ran = false;
+
+        await Server.WaitAssertion(() =>
+        {
+            timer = _sTimer.SpawnMethodTimer(TimeSpan.FromSeconds(1), () => ran = true);
+            Assert.That(timer, Is.Not.Null);
+
+            Assert.That(timer.Value.Comp.TimerEndEvent, Is.TypeOf<MethodTimerEvent>());
+
+            _pvsOverride.AddGlobalOverride(timer.Value); // Ensure it gets synced.
+        });
+
+        await SyncTicks();
+
+        await Client.WaitAssertion(() =>
+        {
+            var ctimer = CEntity<ESEntityTimerComponent>(ToClientUid(timer!.Value));
+
+            Assert.That(ctimer.Comp.TimerEndEvent, Is.Null);
+        });
+
+        await Pair.RunSeconds(3);
+
+        await Server.WaitAssertion(() =>
+        {
+            Assert.That(SDeleted(timer), "Timer should be deleted by now.. it's been 3 seconds, it lasts 1.");
+        });
+
+        Assert.That(ran, Is.True, "Method timer should've ran by now.");
+    }
+
+
+    // TODO(Kaylie): This might be useful as some smarter, global helper somewhere.
+    //               But right now it's fine here.
+    //               Also it's not threadsafe but this fixture type doesn't need that.
+
+    private readonly Dictionary<Assembly, Side> _assembliesToSide = new();
+
+    private Side GetSideOfType(Type t)
+    {
+        return GetSideOfAssembly(t.Assembly);
+    }
+
+    private Side GetSideOfAssembly(Assembly a)
+    {
+        if (_assembliesToSide.TryGetValue(a, out var side))
+            return side;
+
+        // The engine already knows all these, but it doesn't tell them to us. Shame.
+        foreach (var entrypoint in a.ExportedTypes.Where(x => x.IsAssignableTo(typeof(GameShared))))
+        {
+            if (entrypoint.IsAssignableTo(typeof(GameClient)))
+            {
+                _assembliesToSide.Add(a, Side.Client);
+                return Side.Client;
+            }
+            else if (entrypoint.IsAssignableTo(typeof(GameServer)))
+            {
+                _assembliesToSide.Add(a, Side.Server);
+                return Side.Server;
+            }
+            else
+            {
+                _assembliesToSide.Add(a, Side.Neither);
+                return Side.Neither;
+            }
+        }
+
+        _assembliesToSide.Add(a, Side.Neither);
+        return Side.Neither;
+    }
+}

--- a/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
@@ -68,7 +68,7 @@ public sealed class TimerTests : GameTest
             _pvsOverride.AddGlobalOverride(timer.Value); // Ensure it gets synced.
         });
 
-        await SyncTicks();
+        await Pair.RunTicksSync(10);
 
         await Client.WaitAssertion(() =>
         {
@@ -105,7 +105,7 @@ public sealed class TimerTests : GameTest
             _pvsOverride.AddGlobalOverride(timer.Value); // Ensure it gets synced.
         });
 
-        await SyncTicks();
+        await Pair.RunTicksSync(10);
 
         await Client.WaitAssertion(() =>
         {

--- a/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
@@ -53,6 +53,7 @@ public sealed class TimerTests : GameTest
 
     [Test]
     [TestOf(typeof(ESEntityTimerSystem))]
+    [Description("Ensures shared timers synchronize over the network correctly.")]
     public async Task EnsureTimerSync()
     {
         Entity<ESEntityTimerComponent>? timer = null;
@@ -87,6 +88,7 @@ public sealed class TimerTests : GameTest
 
     [Test]
     [TestOf(typeof(ESEntityTimerSystem))]
+    [Description("Ensures method timers, and other non-sync timers, do NOT try to send unsupported data over the network.")]
     public async Task EnsureMethodTimerSync()
     {
         Entity<ESEntityTimerComponent>? timer = null;

--- a/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
+++ b/Content.IntegrationTests/Tests/_ES/Timers/TimerTests.cs
@@ -111,7 +111,11 @@ public sealed class TimerTests : GameTest
         {
             var ctimer = CEntity<ESEntityTimerComponent>(ToClientUid(timer!.Value));
 
+            Assert.That(timer.Value.Comp, Is.Not.EqualTo(ctimer.Comp), "wth.");
+
             Assert.That(ctimer.Comp.TimerEndEvent, Is.Null);
+
+
         });
 
         await Pair.RunSeconds(3);

--- a/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
+++ b/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
@@ -58,7 +58,7 @@ public sealed class ESMartyrSystem : EntitySystem
             return;
 
         EnsureComp<ESMartyrKillerMarkerComponent>(killerBody);
-        _timer.SpawnTimer(killerBody, ent.Comp.TimeBeforeKillerDeath, new ESMartyrKillerTimeToDieEvent());
+        _ = _timer.SpawnTimer(killerBody, ent.Comp.TimeBeforeKillerDeath, new ESMartyrKillerTimeToDieEvent());
 
         if (!TryComp<ActorComponent>(killerBody, out var actor))
             return;

--- a/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/Masks/Masquerades/ESMasqueradeSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.MassMedia.Systems;
 using Content.Server.Mind;
 using Content.Server.Station.Systems;
 using Content.Shared._Citadel.Utilities;
+using Content.Shared._ES.Core.Timer;
 using Content.Shared._ES.Masks;
 using Content.Shared._ES.Masks.Components;
 using Content.Shared.GameTicking.Components;
@@ -16,7 +17,6 @@ using Content.Shared.Station.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
 namespace Content.Server._ES.Masks.Masquerades;
@@ -29,11 +29,10 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly ITimerManager _timer = default!;
+    [Dependency] private readonly ESEntityTimerSystem _timer = default!;
     [Dependency] private readonly ESMaskSystem _mask = default!;
     [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly NewsSystem _news = default!;
-    [Dependency] private readonly StationSystem _station = default!;
 
     // Icky global state.
     private ProtoId<ESMasqueradePrototype>? _forcedMasquerade;
@@ -229,7 +228,7 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
         // If we do news, run the news.
         if (masquerade.StartupNewsArticleTime is { } time)
         {
-            Timer.Spawn(time,
+            _ = _timer.SpawnMethodTimer(time,
                 () =>
                 {
                     // Find The Station. Only one.

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -58,8 +58,11 @@ public sealed class ESAutoGhostSystem : EntitySystem
 
     private void AutoGhost(EntityUid uid)
     {
+        if (!_mind.TryGetMind(uid, out _, out _))
+            return; // Don't ghost the brainless.
+
         // This may fail in some extreme scenarios like a mob state change happening before the entity is even map-init.
         // Just silence it, the failure is fine.
-        _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent(), logFailure: false);
+        _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
     }
 }

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -58,6 +58,6 @@ public sealed class ESAutoGhostSystem : EntitySystem
 
     private void AutoGhost(EntityUid uid)
     {
-        _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
+        _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
     }
 }

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -45,7 +45,8 @@ public sealed class ESAutoGhostSystem : EntitySystem
         if (args.NewMobState != MobState.Dead)
             return;
 
-        AutoGhost(ent);
+        if (!TerminatingOrDeleted(ent))
+            AutoGhost(ent);
     }
 
     private void OnAutoGhost(Entity<MindContainerComponent> ent, ref ESAutoGhostEvent args)

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -45,8 +45,7 @@ public sealed class ESAutoGhostSystem : EntitySystem
         if (args.NewMobState != MobState.Dead)
             return;
 
-        if (!TerminatingOrDeleted(ent))
-            AutoGhost(ent);
+        AutoGhost(ent);
     }
 
     private void OnAutoGhost(Entity<MindContainerComponent> ent, ref ESAutoGhostEvent args)
@@ -59,6 +58,8 @@ public sealed class ESAutoGhostSystem : EntitySystem
 
     private void AutoGhost(EntityUid uid)
     {
-        _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
+        // This may fail in some extreme scenarios like a mob state change happening before the entity is even map-init.
+        // Just silence it, the failure is fine.
+        _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent(), logFailure: false);
     }
 }

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -58,11 +58,10 @@ public sealed class ESAutoGhostSystem : EntitySystem
 
     private void AutoGhost(EntityUid uid)
     {
+        // Don't ghost the brainless.
         if (!_mind.TryGetMind(uid, out _, out _))
-            return; // Don't ghost the brainless.
+            return;
 
-        // This may fail in some extreme scenarios like a mob state change happening before the entity is even map-init.
-        // Just silence it, the failure is fine.
         _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
     }
 }

--- a/Content.Server/_ES/Spawning/ESSpawningSystem.cs
+++ b/Content.Server/_ES/Spawning/ESSpawningSystem.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Server._ES.Spawning;
 
@@ -40,7 +41,7 @@ public sealed class ESSpawningSystem : ESSharedSpawningSystem
         if (_gameTicker.RunLevel == GameRunLevel.PreRoundLobby)
             return;
 
-        _timer.SpawnTimer(TimeSpan.FromSeconds(1.5f), new ESSpawnPlayerAfterCurtainsEvent(msg, args));
+        _ = _timer.SpawnTimer(TimeSpan.FromSeconds(1.5f), new ESSpawnPlayerAfterCurtainsEvent(msg, args));
     }
 
     private void OnAfterCurtains(ESSpawnPlayerAfterCurtainsEvent ev)

--- a/Content.Shared/_ES/Core/Timer/Components/ESEntityTimerComponent.cs
+++ b/Content.Shared/_ES/Core/Timer/Components/ESEntityTimerComponent.cs
@@ -8,14 +8,14 @@ namespace Content.Shared._ES.Core.Timer.Components;
 /// Component that holds data regarding a generic timer.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
-[Access(typeof(ESEntityTimerSystem), Other = AccessPermissions.None)]
+//[Access(typeof(ESEntityTimerSystem), Other = AccessPermissions.None)] // interferes with integration tests. :(
 public sealed partial class ESEntityTimerComponent : Component
 {
     /// <summary>
     /// Event raised on the target entity when the timer ends.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public ESEntityTimerEvent TimerEndEvent;
+    public ESEntityTimerEvent? TimerEndEvent;
 
     /// <summary>
     /// Time at which this timer will end.

--- a/Content.Shared/_ES/Core/Timer/Components/ESEntityTimerComponent.cs
+++ b/Content.Shared/_ES/Core/Timer/Components/ESEntityTimerComponent.cs
@@ -8,14 +8,13 @@ namespace Content.Shared._ES.Core.Timer.Components;
 /// Component that holds data regarding a generic timer.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
-//[Access(typeof(ESEntityTimerSystem), Other = AccessPermissions.None)] // interferes with integration tests. :(
 public sealed partial class ESEntityTimerComponent : Component
 {
     /// <summary>
     /// Event raised on the target entity when the timer ends.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public ESEntityTimerEvent? TimerEndEvent;
+    public ESEntityTimerEvent TimerEndEvent;
 
     /// <summary>
     /// Time at which this timer will end.

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -2,7 +2,9 @@ using Content.Shared._ES.Core.Timer.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Collections;
 using Robust.Shared.Map;
+using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._ES.Core.Timer;
 
@@ -14,48 +16,98 @@ public sealed class ESEntityTimerSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MethodTimerEvent>(MethodTimerEventHandler);
+    }
+
+    private void MethodTimerEventHandler(MethodTimerEvent ev)
+    {
+        ev.Method();
+    }
+
     /// <summary>
-    /// Spawns a timer entity that raises a broadcast event after a specified duration.
+    ///     Spawns a timer entity that raises a broadcast event after a specified duration.
     /// </summary>
     /// <param name="duration">Duration of the timer</param>
     /// <param name="endEvent">Event that will be raised when the timer is finished</param>
+    /// <param name="logFailure">Whether to log if SpawnTimer fails to spawn the timer.</param>
     /// <returns>The timer that was created</returns>
     [PublicAPI]
-    public Entity<ESEntityTimerComponent>? SpawnTimer(TimeSpan duration, ESEntityTimerEvent endEvent)
+    [MustUseReturnValue]
+    public Entity<ESEntityTimerComponent>? SpawnTimer(TimeSpan duration, ESEntityTimerEvent endEvent, bool logFailure = true)
     {
         var uid = Spawn(null, MapCoordinates.Nullspace);
         var comp = AddComp<ESEntityTimerComponent>(uid);
 
-        comp.TimerEndEvent = endEvent;
-        comp.TimerEnd = _timing.CurTime + duration;
-        Dirty(uid, comp);
+        SetupTimer((uid, comp), duration, endEvent);
 
         return (uid, comp);
     }
 
     /// <summary>
-    /// Spawns a timer entity that raises a directed event on a target after a specified duration.
+    ///     Spawns a timer entity that raises a directed event on a target after a specified duration.
     /// </summary>
     /// <param name="target">Entity the event will raise on</param>
     /// <param name="duration">Duration of the timer</param>
     /// <param name="endEvent">Event that will be raised when the timer is finished</param>
+    /// <param name="logFailure">Whether to log if SpawnTimer fails to spawn the timer.</param>
     /// <returns>The timer that was created</returns>
     [PublicAPI]
-    public Entity<ESEntityTimerComponent>? SpawnTimer(EntityUid target, TimeSpan duration, ESEntityTimerEvent endEvent)
+    [MustUseReturnValue]
+    public Entity<ESEntityTimerComponent>? SpawnTimer(EntityUid target, TimeSpan duration, ESEntityTimerEvent endEvent, bool logFailure = true)
     {
         if (!TimerTargetIsValid(target))
+        {
+            Log.Error($"Failed to spawn a timer on {target} due to invalidity, event was {endEvent}.");
+
             return null;
+        }
 
         var uid = Spawn();
         var comp = AddComp<ESEntityTimerComponent>(uid);
 
         _transform.SetParent(uid, target);
 
-        comp.TimerEndEvent = endEvent;
-        comp.TimerEnd = _timing.CurTime + duration;
-        Dirty(uid, comp);
+        SetupTimer((uid, comp), duration, endEvent);
 
         return (uid, comp);
+    }
+
+    /// <summary>
+    ///     Spawns a method timer, which is <b>not networked</b> and <b>not serializable</b>, but convenient in some
+    ///     select usecases. Do not use for things that need prediction, do not use for things that need to be saved
+    ///     in maps/etc.
+    /// </summary>
+    /// <param name="duration">Duration of the timer</param>
+    /// <param name="method">The lambda to call when the timer has elapsed.</param>
+    /// <param name="logFailure">Whether to log if SpawnMethodTimer fails to spawn the timer.</param>
+    /// <returns>The timer that was created</returns>
+    [PublicAPI]
+    [MustUseReturnValue]
+    public Entity<ESEntityTimerComponent>? SpawnMethodTimer(TimeSpan duration, Action method, bool logFailure = true)
+    {
+        return SpawnTimer(duration, new MethodTimerEvent(method), logFailure);
+    }
+
+    private void SetupTimer(Entity<ESEntityTimerComponent> timer, TimeSpan duration, ESEntityTimerEvent endEvent)
+    {
+        timer.Comp.TimerEndEvent = endEvent;
+        timer.Comp.TimerEnd = _timing.CurTime + duration;
+
+        // This is essentially only checking that the type is net serializable, nothing more.
+        // If it's not, then we never dirty the component on purpose and disable netsync.
+        var networked = endEvent.GetType().HasCustomAttribute<NetSerializableAttribute>();
+
+        if (networked)
+        {
+            Dirty(timer);
+        }
+        else
+        {
+            // Avoid bricking replays.
+            timer.Comp.NetSyncEnabled = false;
+        }
     }
 
     private bool TimerTargetIsValid(EntityUid uid)
@@ -82,6 +134,11 @@ public sealed class ESEntityTimerSystem : EntitySystem
         {
             var target = xform.ParentUid;
 
+            if (timer.TimerEndEvent is null)
+                continue; // Not our business. Can only happen in replays and other select scenarios
+                          // that cause a server-side timer to be sent to the client.
+                          // We also don't bother with the queuedel.
+
             // broadcast
             if (xform.MapID == MapId.Nullspace)
             {
@@ -96,3 +153,15 @@ public sealed class ESEntityTimerSystem : EntitySystem
         }
     }
 }
+
+[NonNetworkedTimerEvent]
+public sealed partial class MethodTimerEvent(Action method) : ESEntityTimerEvent
+{
+    public readonly Action Method = method;
+}
+
+/// <summary>
+///     Used by integration tests.
+/// </summary>
+[NetSerializable, Serializable]
+public sealed partial class TestTimerEvent : ESEntityTimerEvent;

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -155,9 +155,14 @@ public sealed class ESEntityTimerSystem : EntitySystem
 }
 
 [NonNetworkedTimerEvent]
-public sealed partial class MethodTimerEvent(Action method) : ESEntityTimerEvent
+public sealed partial class MethodTimerEvent : ESEntityTimerEvent
 {
-    public readonly Action Method = method;
+    public readonly Action Method;
+
+    public MethodTimerEvent(Action method)
+    {
+        Method = method;
+    }
 }
 
 /// <summary>

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -94,7 +94,8 @@ public sealed class ESEntityTimerSystem : EntitySystem
 
         // This is essentially only checking that the type is net serializable, nothing more.
         // If it's not, then we never dirty the component on purpose and disable netsync.
-        var networked = endEvent.GetType().HasCustomAttribute<NetSerializableAttribute>();
+        var networked = endEvent.GetType().HasCustomAttribute<NetSerializableAttribute>() &&
+                        !endEvent.GetType().HasCustomAttribute<NonNetworkedTimerEventAttribute>();
 
         comp.NetSyncEnabled = networked;
 

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -57,7 +57,8 @@ public sealed class ESEntityTimerSystem : EntitySystem
     {
         if (!TimerTargetIsValid(target))
         {
-            Log.Error($"Failed to spawn a timer on {target} due to invalidity, event was {endEvent}.");
+            if (logFailure)
+                Log.Error($"Failed to spawn a timer on {target} due to invalidity, event was {endEvent}.");
 
             return null;
         }

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -58,7 +58,12 @@ public sealed class ESEntityTimerSystem : EntitySystem
         if (!TimerTargetIsValid(target))
         {
             if (logFailure)
-                Log.Error($"Failed to spawn a timer on {target} due to invalidity, event was {endEvent}.");
+            {
+                if (TerminatingOrDeleted(target))
+                    Log.Error($"Failed to spawn a timer on {target} due to being in the middle of termianting/being deleted, event was {endEvent}.");
+                else if (LifeStage(target) is not EntityLifeStage.MapInitialized)
+                    Log.Error($"Failed to spawn a timer on {target} due to not being map initialized (was {LifeStage(target)}), event was {endEvent}.");
+            }
 
             return null;
         }
@@ -133,11 +138,6 @@ public sealed class ESEntityTimerSystem : EntitySystem
         foreach (var (uid, timer, xform) in firingTimers)
         {
             var target = xform.ParentUid;
-
-            if (timer.TimerEndEvent is null)
-                continue; // Not our business. Can only happen in replays and other select scenarios
-                          // that cause a server-side timer to be sent to the client.
-                          // We also don't bother with the queuedel.
 
             // broadcast
             if (xform.MapID == MapId.Nullspace)

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -14,6 +14,7 @@ namespace Content.Shared._ES.Core.Timer;
 public sealed class ESEntityTimerSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IComponentFactory _factory = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
@@ -38,11 +39,8 @@ public sealed class ESEntityTimerSystem : EntitySystem
     public Entity<ESEntityTimerComponent>? SpawnTimer(TimeSpan duration, ESEntityTimerEvent endEvent, bool logFailure = true)
     {
         var uid = Spawn(null, MapCoordinates.Nullspace);
-        var comp = AddComp<ESEntityTimerComponent>(uid);
 
-        SetupTimer((uid, comp), duration, endEvent);
-
-        return (uid, comp);
+        return SetupTimer(uid, duration, endEvent);
     }
 
     /// <summary>
@@ -65,13 +63,10 @@ public sealed class ESEntityTimerSystem : EntitySystem
         }
 
         var uid = Spawn();
-        var comp = AddComp<ESEntityTimerComponent>(uid);
 
         _transform.SetParent(uid, target);
 
-        SetupTimer((uid, comp), duration, endEvent);
-
-        return (uid, comp);
+        return SetupTimer(uid, duration, endEvent);
     }
 
     /// <summary>
@@ -90,24 +85,27 @@ public sealed class ESEntityTimerSystem : EntitySystem
         return SpawnTimer(duration, new MethodTimerEvent(method), logFailure);
     }
 
-    private void SetupTimer(Entity<ESEntityTimerComponent> timer, TimeSpan duration, ESEntityTimerEvent endEvent)
+    private Entity<ESEntityTimerComponent> SetupTimer(EntityUid timerEnt, TimeSpan duration, ESEntityTimerEvent endEvent)
     {
-        timer.Comp.TimerEndEvent = endEvent;
-        timer.Comp.TimerEnd = _timing.CurTime + duration;
+        var comp = _factory.GetComponent<ESEntityTimerComponent>();
+
+        comp.TimerEndEvent = endEvent;
+        comp.TimerEnd = _timing.CurTime + duration;
 
         // This is essentially only checking that the type is net serializable, nothing more.
         // If it's not, then we never dirty the component on purpose and disable netsync.
         var networked = endEvent.GetType().HasCustomAttribute<NetSerializableAttribute>();
 
+        comp.NetSyncEnabled = networked;
+
+        AddComp(timerEnt, comp);
+
         if (networked)
         {
-            Dirty(timer);
+            Dirty(timerEnt, comp);
         }
-        else
-        {
-            // Avoid bricking replays.
-            timer.Comp.NetSyncEnabled = false;
-        }
+
+        return (timerEnt, comp);
     }
 
     private bool TimerTargetIsValid(EntityUid uid)

--- a/Content.Shared/_ES/Core/Timer/NonNetworkedTimerEventAttribute.cs
+++ b/Content.Shared/_ES/Core/Timer/NonNetworkedTimerEventAttribute.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._ES.Core.Timer;
+
+/// <summary>
+///     Used to allow a non-networked timer event to exist in shared and pass tests.
+///     Has no functionality besides that.
+/// </summary>
+public sealed class NonNetworkedTimerEventAttribute : Attribute
+{
+}


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Nothing user facing, makes timers support non-networked usecases and adds tests. Also adds method timers (which take an Action) as a "i really don't care let me do convenience" option.

Also makes an opinionated change: Timer spawn results are now must-use, so you have to consider handling the failure state. This only results in a bunch of discards in this PR, but yknow.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
