### PR TITLE
Remove cloth box and variant cube box from chef closet

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -41,7 +41,10 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillClosetChef
+# ES START
+        # tableId: FillClosetChef
+        tableId: ESFillClosetChef
+# ES END
 
 - type: entityTable
   id: FillClosetChef

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -42,7 +42,6 @@
     containers:
       entity_storage: !type:NestedSelector
 # ES START
-        # tableId: FillClosetChef
         tableId: ESFillClosetChef
 # ES END
 

--- a/Resources/Prototypes/_ES/Catalog/Fills/service.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/service.yml
@@ -8,14 +8,12 @@
     - id: ReagentContainerFlour
     - id: DrinkSoyMilkCarton
     - id: FoodCondimentBottleEnzyme
-    - !type:AllSelector
-      rolls: 2
-      children:
+    - rolls: 2
+      all:
       - id: DrinkMilkCarton
       - id: ReagentContainerFlour
       - id: BoxMousetrap
-    - !type:AllSelector
-      rolls: 3
-      children:
+    - rolls: 3
+      all:
       - id: FoodCondimentPacketSalt
       - id: FoodCondimentPacketPepper

--- a/Resources/Prototypes/_ES/Catalog/Fills/service.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/service.yml
@@ -1,0 +1,21 @@
+- type: entityTable
+  id: ESFillClosetChef
+  table: !type:AllSelector
+    children:
+    - id: MonkeyCubeBox
+    - id: SprayBottleWater
+    - id: ReagentContainerSugar
+    - id: ReagentContainerFlour
+    - id: DrinkSoyMilkCarton
+    - id: FoodCondimentBottleEnzyme
+    - !type:AllSelector
+      rolls: 2
+      children:
+      - id: DrinkMilkCarton
+      - id: ReagentContainerFlour
+      - id: BoxMousetrap
+    - !type:AllSelector
+      rolls: 3
+      children:
+      - id: FoodCondimentPacketSalt
+      - id: FoodCondimentPacketPepper

--- a/Resources/Prototypes/_ES/Catalog/Fills/service.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/service.yml
@@ -1,7 +1,7 @@
 - type: entityTable
   id: ESFillClosetChef
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: MonkeyCubeBox
     - id: SprayBottleWater
     - id: ReagentContainerSugar


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Resolves #880 and #847.

Adds new ES locker fill for the chef's closet. Removes the box of cloth and replaces the variant cube box with a monkey cube box.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
N/A
