### PR TITLE
Added a description to a 9mm magazine

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/magazines.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/magazines.yml
@@ -2,7 +2,7 @@
   parent: [ BaseItem, BaseSecurityContraband ]
   id: ESBaseMagazine9mm
   name: 9mm magazine
-  description:
+  description: This ain't for reading; It's for loading a handgun. Holds 9mm rounds.
   suffix: ES
   abstract: true
   components:


### PR DESCRIPTION
## About the PR
Added a description to the 9mm magazine that matches the .357 speed loader.
Fixes issue 9mm magazine has no description #915 

## Media
<img width="401" height="189" alt="image" src="https://github.com/user-attachments/assets/a45a2483-bba9-4de7-b441-df5f97bce159" />