### PR TITLE
Added Armor to security and captain's EVA suit

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
@@ -48,6 +48,13 @@
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
   - type: Clothing
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
+  - type: Armor #Based on armor vest
+    modifiers:
+      coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70
+        Heat: 0.80
   - type: Tag
     tags:
     - SuitEVA
@@ -65,6 +72,13 @@
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/command_space.rsi
   - type: Clothing
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/command_space.rsi
+  - type: Armor #Based on armor vest
+    modifiers:
+      coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70
+        Heat: 0.80
   - type: Tag
     tags:
     - SuitEVA

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
@@ -55,6 +55,8 @@
         Slash: 0.70
         Piercing: 0.70
         Heat: 0.80
+  - type: ExplosionResistance
+    damageCoefficient: 0.90
   - type: Tag
     tags:
     - SuitEVA
@@ -79,6 +81,8 @@
         Slash: 0.70
         Piercing: 0.70
         Heat: 0.80
+  - type: ExplosionResistance
+    damageCoefficient: 0.90
   - type: Tag
     tags:
     - SuitEVA


### PR DESCRIPTION
## About the PR
Added armor to both the captain's EVA suit and the security EVA suit to match the armor vest.
This fixes issue Sec and cap spacesuits have no armor #933 

## Media

<img width="314" height="188" alt="Screenshot 2026-01-16 104300" src="https://github.com/user-attachments/assets/a1a7fe6e-9582-4e63-9b09-4298626fafb3" />
<img width="288" height="173" alt="Screenshot 2026-01-16 105923" src="https://github.com/user-attachments/assets/41e11505-7590-4561-8552-a0113e0771f4" />
<img width="287" height="180" alt="Screenshot 2026-01-16 105929" src="https://github.com/user-attachments/assets/080a1ef1-d0e6-48bd-ab8c-b067684a33a4" />
<img width="578" height="353" alt="Screenshot 2026-01-16 104532" src="https://github.com/user-attachments/assets/4e02dd68-3c5f-495b-b0e5-8b60ce3d28cb" />

## Testing
I shot two Urists just to double check everything was working.
The armored target took more bullets.
I also stopped to get a drink.
