### PR TITLE
Daredevil improvements

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -430,7 +430,9 @@ public sealed class ElectrocutionSystem : SharedElectrocutionSystem
 
         if (shockDamage is { } dmg)
         {
-            if (_damageable.TryChangeDamage(uid, new DamageSpecifier(_prototypeManager.Index(DamageType), dmg), out var damage, origin: sourceUid))
+// ES START
+            if (_damageable.TryChangeDamage(uid, new DamageSpecifier(_prototypeManager.Index(DamageType), dmg), out var damage, source: sourceUid))
+// ES END
             {
                 _adminLogger.Add(LogType.Electrocution,
                     $"{ToPrettyString(uid):entity} received {damage:damage} powered electrocution damage{(sourceUid != null ? " from " + ToPrettyString(sourceUid.Value) : ""):source}");

--- a/Content.Server/Projectiles/ProjectileSystem.cs
+++ b/Content.Server/Projectiles/ProjectileSystem.cs
@@ -57,7 +57,10 @@ public sealed class ProjectileSystem : SharedProjectileSystem
         }
         var deleted = Deleted(target);
 
-        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, origin: component.Shooter) && Exists(component.Shooter))
+// ES START
+        if (_damageableSystem.TryChangeDamage((target, damageableComponent), ev.Damage, out var damage, component.IgnoreResistances, origin: component.Shooter, source: uid, weapon: component.Weapon) &&
+            Exists(component.Shooter))
+// ES END
         {
             if (!deleted)
             {

--- a/Content.Server/_ES/Masks/Objectives/ESTakeDamageFromSourceObjectiveSystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/ESTakeDamageFromSourceObjectiveSystem.cs
@@ -38,9 +38,11 @@ public sealed class ESTakeDamageFromSourceObjectiveSystem : ESBaseObjectiveSyste
         if (!args.DamageIncreased)
             return;
 
-        if (!_tag.HasTag(args.Body, ent.Comp.SelectedSource))
-            return;
-
-        ObjectivesSys.AdjustObjectiveCounter(ent.Owner, args.DamageDone.GetTotal().Float());
+        if (args.Source.HasValue && _tag.HasTag(args.Source.Value, ent.Comp.SelectedSource) ||
+            args.Origin.HasValue && _tag.HasTag(args.Origin.Value, ent.Comp.SelectedSource) ||
+            args.Weapon.HasValue && _tag.HasTag(args.Weapon.Value, ent.Comp.SelectedSource))
+        {
+            ObjectivesSys.AdjustObjectiveCounter(ent.Owner, args.DamageDone.GetTotal().Float());
+        }
     }
 }

--- a/Content.Server/_ES/Masks/Objectives/Relays/ESDamageTakerRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESDamageTakerRelaySystem.cs
@@ -30,7 +30,7 @@ public sealed class ESDamageTakerRelaySystem : ESBaseMindRelay
 
         if (args.DamageDelta != null)
         {
-            var ev = new ESDamageTakenEvent(ent, args.DamageIncreased, args.DamageDelta, args.Origin);
+            var ev = new ESDamageTakenEvent(ent, args.DamageIncreased, args.DamageDelta, args.Origin, args.Source, args.Weapon);
 
             RaiseMindEvent((mindId, mindComp), ref ev);
         }
@@ -45,4 +45,4 @@ public sealed class ESDamageTakerRelaySystem : ESBaseMindRelay
 /// <param name="DamageDone">The amount of damage done</param>
 /// <param name="Origin">The origin of damage</param>
 [ByRefEvent]
-public readonly record struct ESDamageTakenEvent(EntityUid Body, bool DamageIncreased, DamageSpecifier DamageDone, EntityUid? Origin);
+public readonly record struct ESDamageTakenEvent(EntityUid Body, bool DamageIncreased, DamageSpecifier DamageDone, EntityUid? Origin, EntityUid? Source, EntityUid? Weapon);

--- a/Content.Shared/Damage/Systems/DamageableSystem.API.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.API.cs
@@ -71,12 +71,18 @@ public sealed partial class DamageableSystem
         bool ignoreResistances = false,
         bool interruptsDoAfters = true,
         EntityUid? origin = null,
-        bool ignoreGlobalModifiers = false
+// ES START
+        bool ignoreGlobalModifiers = false,
+        EntityUid? source = null,
+        EntityUid? weapon = null
+// ES END
     )
     {
         //! Empty just checks if the DamageSpecifier is _literally_ empty, as in, is internal dictionary of damage types is empty.
         // If you deal 0.0 of some damage type, Empty will be false!
-        return TryChangeDamage(ent, damage, out _, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers);
+// ES START
+        return TryChangeDamage(ent, damage, out _, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers, source: source, weapon: weapon);
+// ES END
     }
 
     /// <summary>
@@ -97,12 +103,18 @@ public sealed partial class DamageableSystem
         bool ignoreResistances = false,
         bool interruptsDoAfters = true,
         EntityUid? origin = null,
-        bool ignoreGlobalModifiers = false
+// ES START
+        bool ignoreGlobalModifiers = false,
+        EntityUid? source = null,
+        EntityUid? weapon = null
+// ES END
     )
     {
         //! Empty just checks if the DamageSpecifier is _literally_ empty, as in, is internal dictionary of damage types is empty.
         // If you deal 0.0 of some damage type, Empty will be false!
-        newDamage = ChangeDamage(ent, damage, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers);
+// ES START
+        newDamage = ChangeDamage(ent, damage, ignoreResistances, interruptsDoAfters, origin, ignoreGlobalModifiers, source: source, weapon: weapon);
+// ES END
         return !damage.Empty;
     }
 
@@ -123,7 +135,11 @@ public sealed partial class DamageableSystem
         bool ignoreResistances = false,
         bool interruptsDoAfters = true,
         EntityUid? origin = null,
-        bool ignoreGlobalModifiers = false
+// ES START
+        bool ignoreGlobalModifiers = false,
+        EntityUid? source = null,
+        EntityUid? weapon = null
+// ES END
     )
     {
         var damageDone = new DamageSpecifier();
@@ -180,8 +196,10 @@ public sealed partial class DamageableSystem
             damageDone.DamageDict[type] = newValue - oldValue;
         }
 
+// ES START
         if (!damageDone.Empty)
-            OnEntityDamageChanged((ent, ent.Comp), damageDone, interruptsDoAfters, origin);
+            OnEntityDamageChanged((ent, ent.Comp), damageDone, interruptsDoAfters, origin, source: source, weapon: weapon);
+// ES END
 
         return damageDone;
     }

--- a/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
@@ -261,16 +261,37 @@ public sealed class DamageChangedEvent : EntityEventArgs
     /// </summary>
     public readonly EntityUid? Origin;
 
+// ES START
+    /// <summary>
+    ///     The physical object which caused the change in damage.
+    ///     Unlike <see cref="Origin"/>, this is not a player but something like a bullet or knife
+    /// </summary>
+    public readonly EntityUid? Source;
+
+    /// <summary>
+    ///     An optional additional object that caused <see cref="Source"/> to function by will of <see cref="Origin"/>
+    ///     So if <see cref="Source"/> is a bullet, <see cref="Origin"/> is a player, then this is the gun.
+    /// </summary>
+    public readonly EntityUid? Weapon;
+// ES END
     public DamageChangedEvent(
         DamageableComponent damageable,
         DamageSpecifier? damageDelta,
         bool interruptsDoAfters,
-        EntityUid? origin
+// ES START
+        EntityUid? origin,
+        EntityUid? source,
+        EntityUid? weapon
+// ES END
     )
     {
         Damageable = damageable;
         DamageDelta = damageDelta;
         Origin = origin;
+// ES START
+        Source = source;
+        Weapon = weapon;
+// ES END
 
         if (DamageDelta is null)
             return;

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -47,7 +47,11 @@ public sealed partial class DamageableSystem : EntitySystem
         Entity<DamageableComponent> ent,
         DamageSpecifier? damageDelta = null,
         bool interruptsDoAfters = true,
-        EntityUid? origin = null
+// ES START
+        EntityUid? origin = null,
+        EntityUid? source = null,
+        EntityUid? weapon = null
+// ES END
     )
     {
         ent.Comp.Damage.GetDamagePerGroup(_prototypeManager, ent.Comp.DamagePerGroup);
@@ -66,7 +70,9 @@ public sealed partial class DamageableSystem : EntitySystem
 
         // TODO DAMAGE
         // byref struct event.
-        RaiseLocalEvent(ent, new DamageChangedEvent(ent.Comp, damageDelta, interruptsDoAfters, origin));
+// ES START
+        RaiseLocalEvent(ent, new DamageChangedEvent(ent.Comp, damageDelta, interruptsDoAfters, origin, source, weapon));
+// ES END
     }
 
     private void DamageableGetState(Entity<DamageableComponent> ent, ref ComponentGetState args)

--- a/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
+++ b/Content.Shared/Weapons/Hitscan/Systems/HitscanBasicDamageSystem.cs
@@ -22,7 +22,9 @@ public sealed class HitscanBasicDamageSystem : EntitySystem
 
         var dmg = ent.Comp.Damage * _damage.UniversalHitscanDamageModifier;
 
-        if(!_damage.TryChangeDamage(args.Data.HitEntity.Value, dmg, out var damageDealt, origin: args.Data.Gun))
+// ES START
+        if(!_damage.TryChangeDamage(args.Data.HitEntity.Value, dmg, out var damageDealt, origin: args.Data.Shooter, source: ent, weapon: args.Data.Gun))
+// ES END
             return;
 
         var damageEvent = new HitscanDamageDealtEvent

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -543,7 +543,9 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEvent.BonusDamage, hitEvent.ModifiersList);
 
-        if (Damageable.TryChangeDamage(target.Value, modifiedDamage, out var damageResult, origin:user, ignoreResistances:resistanceBypass))
+// ES START
+        if (Damageable.TryChangeDamage(target.Value, modifiedDamage, out var damageResult, origin:user, ignoreResistances:resistanceBypass, weapon: meleeUid))
+// ES END
         {
             // If the target has stamina and is taking blunt damage, they should also take stamina damage based on their blunt to stamina factor
             if (damageResult.DamageDict.TryGetValue("Blunt", out var bluntDamage))

--- a/Resources/Locale/en-US/_ES/masks/crew/daredevil.ftl
+++ b/Resources/Locale/en-US/_ES/masks/crew/daredevil.ftl
@@ -2,11 +2,9 @@
 es-daredevil-desc = You need to take some {$damagetype} damage to feel alive!
 
 es-daredevil-source-objective-title-ESGrille = Take {$count} damage from a grille
-es-daredevil-source-objective-title-ESEmitter = Take {$count} damage from an emitter
 es-daredevil-source-objective-title-ESAncestor = Take {$count} damage from a monkey
 
 es-daredevil-source-objective-desc-ESGrille = Feel the thrill of shocking yourself against a grille!
-es-daredevil-source-objective-desc-ESEmitter = Feel the blast of energy from shooting yourself with an emitter!
 es-daredevil-source-objective-desc-ESAncestor = Feel the rage while fighting genetic ancestors!
 
 es-daredevil-total-objective-title = Take {$count} total damage

--- a/Resources/Locale/en-US/_ES/masks/crew/daredevil.ftl
+++ b/Resources/Locale/en-US/_ES/masks/crew/daredevil.ftl
@@ -3,9 +3,15 @@ es-daredevil-desc = You need to take some {$damagetype} damage to feel alive!
 
 es-daredevil-source-objective-title-ESGrille = Take {$count} damage from a grille
 es-daredevil-source-objective-title-ESAncestor = Take {$count} damage from a monkey
+es-daredevil-source-objective-title-ES9mmProjectile = Take {$count} damage from 9mm bullets
+es-daredevil-source-objective-title-ES357Projectile = Take {$count} damage from .357 bullets
+es-daredevil-source-objective-title-ESShotgunPellet = Take {$count} damage from shotgun shell pellets
 
 es-daredevil-source-objective-desc-ESGrille = Feel the thrill of shocking yourself against a grille!
 es-daredevil-source-objective-desc-ESAncestor = Feel the rage while fighting genetic ancestors!
+es-daredevil-source-objective-desc-ES9mmProjectile = Feel the blast of security's peashooters!
+es-daredevil-source-objective-desc-ES357Projectile = Feel the burn of getting ripped apart by a nasty revolver!
+es-daredevil-source-objective-desc-ESShotgunPellet = Feel the sensation of getting peppered by a shotgun's blast!
 
 es-daredevil-total-objective-title = Take {$count} total damage
 es-daredevil-total-objective-desc = Fill your thirst for danger by taking {$count} points of damage!

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -103,8 +103,3 @@
       - On
       - Off
       - Toggle
-  # ES change - adds tags for dardevil
-  - type: Tag
-    tags:
-    - ESEmitter
-  # ES end

--- a/Resources/Prototypes/Entities/Structures/Walls/grille.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/grille.yml
@@ -87,6 +87,10 @@
     - type: AnimationPlayer
 # ES START
     - type: ESDestroyOnUnanchor
+    - type: Tag
+      tags:
+      - Structure
+      - ESGrille
 # ES END
 
 - type: entity
@@ -137,7 +141,6 @@
   - type: Tag
     tags:
     - ForceNoFixRotations
-    - ESGrille # ES change - used for daredevil
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: FlimsyMetallic

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/bullet.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/bullet.yml
@@ -19,6 +19,9 @@
     damage:
       types:
         Piercing: 18
+  - type: Tag
+    tags:
+    - ES9mmProjectile
 
 - type: entity
   parent: ESBaseBullet
@@ -30,6 +33,9 @@
     damage:
       types:
         Piercing: 40
+  - type: Tag
+    tags:
+    - ES357Projectile
 
 # Shotgun bullets
 - type: entity
@@ -45,6 +51,9 @@
     damage:
       types:
         Piercing: 10
+  - type: Tag
+    tags:
+    - ESShotgunPellet
 
 - type: entity
   id: ESPelletShotgunSpread
@@ -55,6 +64,9 @@
     proto: ESPelletShotgun
     count: 6
     spread: 15
+  - type: Tag
+    tags:
+    - ESShotgunPellet
 
 - type: entity
   id: ESPelletShotgunSlug

--- a/Resources/Prototypes/_ES/Objectives/crew.yml
+++ b/Resources/Prototypes/_ES/Objectives/crew.yml
@@ -141,7 +141,6 @@
     - Heat
     - Shock
     - Cold
-    - Caustic
     - Slash
     - Piercing
     - Poison
@@ -164,7 +163,6 @@
   - type: ESTakeDamageFromSourceObjective
     possibleSources:
     - ESGrille
-    - ESEmitter
     - ESAncestor
   - type: ESCounterObjective
     target: 75

--- a/Resources/Prototypes/_ES/Objectives/crew.yml
+++ b/Resources/Prototypes/_ES/Objectives/crew.yml
@@ -164,6 +164,9 @@
     possibleSources:
     - ESGrille
     - ESAncestor
+    - ES9mmProjectile
+    - ES357Projectile
+    - ESShotgunPellet
   - type: ESCounterObjective
     target: 75
     maxTarget: 150

--- a/Resources/Prototypes/_ES/tags.yml
+++ b/Resources/Prototypes/_ES/tags.yml
@@ -17,16 +17,12 @@
 - type: Tag
   id: ESComputerTabletop
 
-- type: Tag
-  id: ESElectronicsKeypad
-
-# Used for daredevil objectives
-- type: Tag
-  id: ESEmitter
-
 # Items that can be stored in the display case
 - type: Tag
   id: ESDisplayCaseItem
+
+- type: Tag
+  id: ESElectronicsKeypad
 
 # Used for daredevil objectives
 - type: Tag
@@ -58,7 +54,7 @@
 
 - type: Tag
   id: ESSuitEVACaptain
-  
+
 - type: Tag
   id: ESSpawnerCargo
 

--- a/Resources/Prototypes/_ES/tags.yml
+++ b/Resources/Prototypes/_ES/tags.yml
@@ -3,10 +3,16 @@
   id: ESAncestor
 
 - type: Tag
+  id: ES357Projectile
+
+- type: Tag
   id: ES357Round
 
 - type: Tag
   id: ES357SpeedLoader
+
+- type: Tag
+  id: ES9mmProjectile
 
 - type: Tag
   id: ES9mmRound
@@ -39,6 +45,9 @@
 
 - type: Tag
   id: ESHelmetEVASec
+
+- type: Tag
+  id: ESShotgunPellet
 
 - type: Tag
   id: ESSilencer


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Fixes #555 
Fixes #672 
Fixes #878 

does some daredevil bugfixing and other shit:
- The 'take damage from source' objective actually works now. It was checking the wrong entity and didnt have a chance in hell of ever getting the right entity so like there we go we did it lads yippee.
- Removed caustic from the 'take damage type' objective because it's insanely hard to get caustic. holy.
- Removed the emitter objective cuz idk man emitters are like only barely in this game anymore and I don't want to really emphasize them atp.
- Added new 'take damage from source' objectives for 9mm, .357, and shotgun pellets. This is just meant to push daredevil to be a little bit more aggressive in pursuing violence. maybe it'll overlap with maso doc but if it's good then we can just keep it idk.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
