### PR TITLE
Allow crew manifest/etc on arrivals.

### DIFF
--- a/Content.Server/_ES/Arrivals/ESArrivalsSystem.cs
+++ b/Content.Server/_ES/Arrivals/ESArrivalsSystem.cs
@@ -186,6 +186,8 @@ public sealed class ESArrivalsSystem : EntitySystem
 
         FlyToStation((shuttle.Value, arrivalsComp));
 
+        _station.AddGridToStation(ent, shuttle.Value);
+
         _map.DeleteMap(mapId);
     }
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
I realized "oh wait the whole arrivals news thing wont work due to not being on station"

ive never reproduced that because i havent bothered, i simply detect its aura