### PR TITLE
Obscure traitor masks in report

### DIFF
--- a/Content.Shared/_ES/Masks/ESTroupePrototype.cs
+++ b/Content.Shared/_ES/Masks/ESTroupePrototype.cs
@@ -54,5 +54,11 @@ public sealed partial class ESTroupePrototype : IPrototype, IInheritingPrototype
     public EntityTableSelector Objectives = new NoneSelector();
 
     [DataField(required: true)]
-    public EntProtoId<ESTroupeRuleComponent> GameRule = default!;
+    public EntProtoId<ESTroupeRuleComponent> GameRule;
+
+    /// <summary>
+    /// String used to refer to the masks of this troupe on the news report for the masquerade.
+    /// </summary>
+    [DataField]
+    public LocId? DisguisedMaskName;
 }

--- a/Resources/Locale/en-US/_ES/news/masks-report.ftl
+++ b/Resources/Locale/en-US/_ES/news/masks-report.ftl
@@ -11,3 +11,5 @@ es-news-masks-entry = - {$count ->
         [one] {$mask}
         *[other] {$mask} ({$count})
     }
+
+es-news-disguise-traitors = Traitor

--- a/Resources/Prototypes/_ES/Masks/troupes.yml
+++ b/Resources/Prototypes/_ES/Masks/troupes.yml
@@ -25,6 +25,7 @@
   - ESWarden
   - ESSecurityOfficer
   - ESDetective
+  disguisedMaskName: es-news-disguise-traitors
   objectives:
     all:
     - pick:

--- a/Resources/Prototypes/_ES/Masquerades/random.yml
+++ b/Resources/Prototypes/_ES/Masquerades/random.yml
@@ -8,7 +8,7 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "#AllCrew" # Everyone besides the traitors gets random crew masks.
     roles:
-      1: [] # Greenshift.
+      1: ["#AllTraitors"] # Greenshift.
       4: ["#AllTraitors"]
       6: ["#AllTraitors"]
       13: ["#AllTraitors"]

--- a/Resources/Prototypes/_ES/Masquerades/random.yml
+++ b/Resources/Prototypes/_ES/Masquerades/random.yml
@@ -8,7 +8,7 @@
   masquerade: !type:MasqueradeRoleSet
     defaultMask: "#AllCrew" # Everyone besides the traitors gets random crew masks.
     roles:
-      1: ["#AllTraitors"] # Greenshift.
+      1: [] # Greenshift.
       4: ["#AllTraitors"]
       6: ["#AllTraitors"]
       13: ["#AllTraitors"]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
I think stating the traitor masks in particular just weakens potential anti-metagaming options like mercs, so i want them all to just be Traitors.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
