### PR TITLE
Make ID computer ignore non ES jobs

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -35,7 +35,9 @@ namespace Content.Client.Access.UI
         private string? _lastJobProto;
 
         // The job that will be picked if the ID doesn't have a job on the station.
-        private static ProtoId<JobPrototype> _defaultJob = "Passenger";
+        //ES START
+        private static ProtoId<JobPrototype> _defaultJob = "ESAssistant";
+        //ES END
 
         public IdCardConsoleWindow(IdCardConsoleBoundUserInterface owner, IPrototypeManager prototypeManager,
             List<ProtoId<AccessLevelPrototype>> accessLevels)
@@ -70,7 +72,9 @@ namespace Content.Client.Access.UI
 
             foreach (var job in jobs)
             {
-                if (!job.OverrideConsoleVisibility.GetValueOrDefault(job.SetPreference))
+                // ES START
+                if (!job.OverrideConsoleVisibility.GetValueOrDefault(job.SetPreference) || !job.ID.StartsWith("ES"))
+                // ES END
                 {
                     continue;
                 }


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
ID Computer now only shows jobs prefixed with ES


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="688" height="513" alt="image" src="https://github.com/user-attachments/assets/3f29b676-55cb-4486-aa81-3e88e632f390" />


