### PR TITLE
Infiltrator mask page + improvements

### DIFF
--- a/Content.Client/_ES/Guidebook/ESGBObjectiveEmbed.cs
+++ b/Content.Client/_ES/Guidebook/ESGBObjectiveEmbed.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Client._ES.Objectives.Ui;
+using Content.Client.Guidebook;
+using Content.Client.Guidebook.Richtext;
+using Content.Shared.Tag;
+using JetBrains.Annotations;
+using Robust.Client.UserInterface;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._ES.Guidebook;
+
+[UsedImplicitly]
+public sealed class ESGBObjectiveEmbed : Control, IDocumentTag
+{
+    [Dependency] private readonly IEntityManager _entMan = default!;
+    [Dependency] private readonly IEntitySystemManager _sysMan = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+
+    private readonly TagSystem _tagSys;
+    private readonly ISawmill _sawmill;
+
+    private readonly ESObjectiveControl _control = new();
+
+    private EntProtoId? _objective;
+    private EntityUid? _managedEnt;
+
+    public ESGBObjectiveEmbed()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _sawmill = _log.GetSawmill("guidebook.objective");
+        _tagSys = _sysMan.GetEntitySystem<TagSystem>();
+
+        AddChild(_control);
+    }
+
+    protected override void EnteredTree()
+    {
+        base.EnteredTree();
+
+        _managedEnt = _entMan.SpawnEntity(_objective, MapCoordinates.Nullspace);
+
+        _tagSys.AddTag(_managedEnt.Value, GuidebookSystem.GuideEmbedTag);
+        _control.SetObjective(_managedEnt.Value);
+    }
+
+    protected override void ExitedTree()
+    {
+        base.ExitedTree();
+
+        if (!_entMan.Deleted(_managedEnt))
+            _entMan.DeleteEntity(_managedEnt);
+    }
+
+    public bool TryParseTag(Dictionary<string, string> args, [NotNullWhen(true)] out Control? control)
+    {
+        if (!args.TryGetValue("Objective", out var proto))
+        {
+            _sawmill.Error("Entity embed tag is missing entity prototype argument");
+            control = null;
+            return false;
+        }
+
+        _objective = proto;
+
+        control = this;
+        return true;
+    }
+}

--- a/Resources/Prototypes/_ES/Guidebook/masks.yml
+++ b/Resources/Prototypes/_ES/Guidebook/masks.yml
@@ -18,4 +18,12 @@
   id: ESTraitors
   hidden: false
   name: guide-entry-traitors
+  children:
+  - ESInfiltrator
   text: "/ServerInfo/_ES/Guidebook/Masks/Traitors.xml"
+
+- type: guideEntry
+  id: ESInfiltrator
+  hidden: false
+  name: Infiltrator
+  text: "/ServerInfo/_ES/Guidebook/Masks/Traitors/Infiltrator.xml"

--- a/Resources/Prototypes/_ES/Objectives/traitor.yml
+++ b/Resources/Prototypes/_ES/Objectives/traitor.yml
@@ -13,7 +13,7 @@
 - type: entity
   parent: ESBaseTraitorObjectiveMinor
   id: ESObjectiveTraitorKillRandom
-  name: Kill...
+  name: Kill a specific member of the crew.
   description: The syndicate needs to make sure they don't interfere with our plans.
   components:
   - type: ESObjective

--- a/Resources/ServerInfo/_ES/Guidebook/Masks/Crew.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/Masks/Crew.xml
@@ -1,9 +1,10 @@
 <Document>
   # Crew
 
-  Crew are crewmembers
+  As a member of the crew, your objective is simple:
+  <ESGBObjectiveEmbed Objective="ESObjectiveResearchTelescience"/>
 
   [color=red]TODO ES write the rest lol[/color]
 
-  [color=red]TODO ES autogenerate mask entries[/color]
+  [color=red]TODO ES write mask entries[/color]
 </Document>

--- a/Resources/ServerInfo/_ES/Guidebook/Masks/Traitors.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/Masks/Traitors.xml
@@ -21,7 +21,14 @@
 
   The nuke can be disarmed--but the detonation timer is significantly shorter than normal, at only 60 seconds. If you fail at that point, it's your own fault.
 
+  The basic objectives, of which you get three, include:
+  <ESGBObjectiveEmbed Objective="ESObjectiveTraitorKillRandom"/>
+  <ESGBObjectiveEmbed Objective="ESObjectiveTraitorSabotageCommunications"/>
+  <ESGBObjectiveEmbed Objective="ESObjectiveTraitorSabotageCrewMonitoring"/>
+  <ESGBObjectiveEmbed Objective="ESObjectiveTraitorSabotageIDComputer"/>
+  <ESGBObjectiveEmbed Objective="ESObjectiveTraitorSabotageCriminalRecords"/>
+  <ESGBObjectiveEmbed Objective="ESObjectiveTraitorSabotageTelecom"/>
   [color=red]TODO ES write the rest lol[/color]
 
-  [color=red]TODO ES autogenerate mask entries[/color]
+  [color=red]TODO ES write mask entries[/color]
 </Document>

--- a/Resources/ServerInfo/_ES/Guidebook/Masks/Traitors/Infiltrator.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/Masks/Traitors/Infiltrator.xml
@@ -1,0 +1,13 @@
+<Document>
+    # Infiltrator
+    As an infiltrator, you're a critical member of the team with a kit meant for breaking and entering.
+    Your cache contains an EMAG, C4, and a bag with a full set of chameleon clothes for quick disguise changes.
+
+    <Box>
+        <GuideEntityEmbed Entity="ESEmag"/>
+        <GuideEntityEmbed Entity="C4"/>
+    </Box>
+
+    Your EMAG can be used to open any airlock or locker, damaging them in the process and bolting open airlocks.
+
+</Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Adds objective embeds as a thing, makes an example page for the Infiltrator.

Not super pretty yet, needs a polish pass, but I don't want to block anyone interested in writing mask pages.

Later when all the mask pages exist I'll make a test to assert no mask goes undocumented.

## Media
<img width="519" height="737" alt="image" src="https://github.com/user-attachments/assets/a56e3281-7079-4d7b-b075-6b608ccf420c" />
<img width="519" height="737" alt="image" src="https://github.com/user-attachments/assets/70ed9693-04ad-4707-a516-0d38149758b0" />

