### PR TITLE
Armor DT + minor doublebarrel nerf

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Crates/crates.yml
@@ -155,7 +155,7 @@
     containers:
       entity_storage:
         all:
-        - id: ClothingOuterArmorBasic
+        - id: ESClothingOuterArmorBasic
           amount: 2
         - id: ClothingHeadHelmetBasic
           amount: 2

--- a/Resources/Prototypes/_ES/Catalog/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Crates/crates.yml
@@ -155,7 +155,7 @@
     containers:
       entity_storage:
         all:
-        - id: ESClothingOuterArmorBasic
+        - id: ESClothingOuterArmorSecurity
           amount: 2
         - id: ClothingHeadHelmetBasic
           amount: 2

--- a/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
@@ -7,7 +7,7 @@
     - id: CigarGoldCase
       prob: 0.25
     - id: ClothingHeadsetAltCommand
-    - id: ClothingOuterArmorCaptainCarapace
+    - id: ESClothingOuterArmorCaptainCarapace
     - id: MedalCase
     - id: NukeDisk
     - id: PinpointerNuclear
@@ -47,7 +47,7 @@
     - id: ClothingBeltSecurityFilled
     - id: ClothingEyesGlassesSecurity
     - id: ClothingHeadsetAltSecurity
-    - id: ClothingOuterCoatHoSTrench
+    - id: ESClothingOuterCoatHoSTrench
     - id: ClothingShoesBootsJack
     - id: FlashlightSeclite
     - id: RubberStampHos
@@ -64,7 +64,7 @@
     - id: ClothingEyesGlassesSecurity
     - id: ClothingHandsGlovesColorBlack
     - id: ClothingShoesBootsJack
-    - id: ClothingOuterCoatWarden
+    - id: ESClothingOuterCoatWarden
     - id: RubberStampWarden
     - id: Binoculars
 
@@ -95,7 +95,7 @@
     - id: ClothingHeadHatDetGadget
       prob: 0.15
     - id: ClothingNeckTieDet
-    - id: ClothingOuterVestDetective
+    - id: ESWeaponHybridTaser
     - id: ESClothingOuterCoatDetective
     - id: FlippoEngravedLighter
     - id: FlashlightSeclite

--- a/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
@@ -76,7 +76,7 @@
       prob: 0.8
     - id: ESWeaponHybridTaser
     - id: ClothingHeadHelmetBasic
-    - id: ClothingOuterArmorBasic
+    - id: ESClothingOuterArmorSecurity
     - id: ClothingBeltSecurityFilled
     - id: Flash
       prob: 0.5

--- a/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
@@ -96,6 +96,7 @@
       prob: 0.15
     - id: ClothingNeckTieDet
     - id: ESWeaponHybridTaser
+    - id: ESClothingOuterArmorDetective
     - id: ESClothingOuterCoatDetective
     - id: FlippoEngravedLighter
     - id: FlashlightSeclite

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/armor.yml
@@ -15,7 +15,6 @@
         Slash: 5
         Piercing: 5
         Heat: 5
-        Caustic: 4
   - type: ExplosionResistance
     damageCoefficient: 0.90
 
@@ -31,7 +30,6 @@
         Slash: 6
         Piercing: 6
         Heat: 6
-        Caustic: 4
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: GroupExamine
@@ -48,6 +46,18 @@
     sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/security.rsi
+
+- type: entity
+  parent: ESClothingOuterArmorBase
+  id: ESClothingOuterArmorDetective
+  name: detective's vest
+  description: A hard-boiled private investigator's armored vest.
+  suffix: ES
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Vests/detvest.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Vests/detvest.rsi
 
 - type: entity
   parent: ESClothingOuterArmorBase

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/armor.yml
@@ -1,0 +1,86 @@
+# Base Prototypes
+- type: entity
+  abstract: true
+  parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing]
+  id: ESClothingOuterArmorBase
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Armor/security.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Armor/security.rsi
+  - type: Armor
+    modifiers:
+      flatReductions:
+        Blunt: 5
+        Slash: 5
+        Piercing: 5
+        Heat: 5
+        Caustic: 4
+  - type: ExplosionResistance
+    damageCoefficient: 0.90
+
+- type: entity
+  abstract: true
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
+  id: ESClothingOuterArmorBaseImproved
+  components:
+  - type: Armor
+    modifiers:
+      flatReductions:
+        Blunt: 6
+        Slash: 6
+        Piercing: 6
+        Heat: 6
+        Caustic: 4
+  - type: ExplosionResistance
+    damageCoefficient: 0.80
+  - type: GroupExamine
+
+# Armor
+- type: entity
+  parent: ESClothingOuterArmorBase
+  id: ESClothingOuterArmorSecurity
+  name: armor vest
+  description: A standard Type I armored vest that provides decent protection against most types of damage.
+  suffix: ES
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Armor/security.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Armor/security.rsi
+
+- type: entity
+  parent: ESClothingOuterArmorBase
+  id: ESClothingOuterCoatWarden
+  name: warden's armored jacket
+  description: A sturdy, utilitarian jacket designed to protect a warden from any brig-bound threats.
+  suffix: ES
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Coats/warden.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Coats/warden.rsi
+
+- type: entity
+  parent: ESClothingOuterArmorBaseImproved
+  id: ESClothingOuterArmorCaptainCarapace
+  name: captain's carapace
+  description: An armored chestpiece that provides protection whilst still offering maximum mobility and flexibility. Issued only to the station's finest.
+  suffix: ES
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Armor/captain_carapace.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Armor/captain_carapace.rsi
+
+- type: entity
+  parent: ESClothingOuterArmorBaseImproved
+  id: ESClothingOuterCoatHoSTrench
+  name: head of security's armored trenchcoat
+  description: A greatcoat enhanced with a special alloy for some extra protection and style for those with a commanding presence.
+  suffix: ES
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
@@ -48,13 +48,13 @@
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
   - type: Clothing
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
-  - type: Armor #Based on armor vest
+  - type: Armor #based on armor vest
     modifiers:
-      coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.80
+      flatReductions:
+        Blunt: 5
+        Slash: 5
+        Piercing: 5
+        Heat: 5
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: Tag

--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Distributed/armory.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Distributed/armory.yml
@@ -15,7 +15,7 @@
     - id: ESWeaponPistol9mm
       amount: 3
     - id: ESWeaponShotgun
-      amount: 3
+      amount: 2
     - id: ESWeaponEnergyRifle
       amount: 3
     - id: ESMagazine9mm
@@ -26,9 +26,9 @@
         - id: ESShotgunShellsBoxSlug
         - id: ESShotgunShellsBoxBeanbag
     - all:
-      - id: ClothingOuterArmorRiot
+      - id: ESClothingOuterArmorSecurity
         amount: 2
-      - id: ClothingHeadHelmetRiot
+      - id: ClothingHeadHelmetBasic
         amount: 2
 
 - type: entity

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
@@ -62,7 +62,7 @@
     capacity: 2
     proto: ESShellShotgunBuckshot
   - type: Gun
-    fireRate: 4
+    fireRate: 1.5
     soundGunshot:
       path: /Audio/_ES/Weapons/Guns/Gunshots/doublebarrel_shot.ogg
     soundEmpty:

--- a/Resources/Prototypes/_ES/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Fills/Crates/caches.yml
@@ -67,7 +67,7 @@
     - id: ESWeaponRevolver357
     - id: ESSpeedLoader357
     - id: KitchenKnife
-    - id: ClothingOuterArmorBasic
+    - id: ESClothingOuterArmorSecurity
     - id: ExGrenade
       amount: 2
 

--- a/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
@@ -162,8 +162,8 @@
 
 - type: entityTable
   id: ESFillWardrobeSecurity
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingUniformJumpsuitSec
     - id: ClothingBackpackSecurity
     - id: ClothingShoesBootsJack
@@ -174,9 +174,9 @@
 - type: entity
   parent: WardrobeSecurity
   id: ESWardrobeSecurityFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeSecurity

--- a/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
@@ -92,6 +92,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingHeadHatFedoraBrown
+    - id: ESClothingOuterCoatDetective
     - id: ClothingBackpackSecurity
     - id: ClothingShoesColorBrown
     - id: ClothingUniformJumpskirtDetective
@@ -158,3 +159,24 @@
     - id: ClothingBackpack
     - id: ClothingShoesColorBrown
     - id: ClothingUniformJumpsuitReporter
+
+- type: entityTable
+  id: ESFillWardrobeSecurity
+  table: !type:AllSelector
+    children:
+    - id: ClothingUniformJumpsuitSec
+    - id: ClothingBackpackSecurity
+    - id: ClothingShoesBootsJack
+    - id: ClothingEyesGlassesSecurity
+    - id: ClothingHeadHelmetBasic
+    - id: ESClothingOuterArmorSecurity
+
+- type: entity
+  parent: WardrobeSecurity
+  id: ESWardrobeSecurityFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobeSecurity

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/captain.yml
@@ -28,7 +28,7 @@
     ears: ClothingHeadsetAltCommand
     head: ClothingHeadHatCaptain
     jumpsuit: ClothingUniformJumpsuitCaptain
-    outerClothing: ClothingOuterArmorCaptainCarapace
+    outerClothing: ESClothingOuterArmorCaptainCarapace
     back: ClothingBackpackCaptain
   storage:
     back:

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
@@ -37,7 +37,7 @@
     head: ClothingHeadHatHoshat
     belt: ClothingBeltSecurityFilled
     jumpsuit: ClothingUniformJumpsuitHoS
-    outerClothing: ClothingOuterCoatHoSTrench
+    outerClothing: ESClothingOuterCoatHoSTrench
     back: ClothingBackpackSecurity
     pocket1: ESWeaponHybridTaser
   storage:

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/detective.yml
@@ -27,7 +27,7 @@
     neck: ClothingNeckTieDet
     belt: ClothingBeltHolster
     jumpsuit: ClothingUniformJumpsuitDetective
-    outerClothing: ClothingOuterCoatDetectiveLoadout
+    outerClothing: ESClothingOuterCoatDetectiveLoadout
     back: ClothingBackpackSecurity
   storage:
     back:

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
@@ -25,7 +25,7 @@
     head: ClothingHeadHelmetBasic
     belt: ClothingBeltSecurityFilled
     jumpsuit: ClothingUniformJumpsuitSec
-    outerClothing: ClothingOuterArmorBasic
+    outerClothing: ESClothingOuterArmorSecurity
     back: ClothingBackpackSecurity
     pocket1: ESWeaponHybridTaser
   storage:

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
@@ -28,7 +28,7 @@
     ears: ClothingHeadsetSecurity
     head: ClothingHeadHatWarden
     jumpsuit: ClothingUniformJumpsuitWarden
-    outerClothing: ClothingOuterCoatWarden
+    outerClothing: ESClothingOuterCoatWarden
     back: ClothingBackpackSecurity
     pocket1: ESWeaponHybridTaser
   storage:

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -255,9 +255,11 @@ ClothingOuterCoatDetectiveGrey: ESClothingOuterCoatDetectiveGrey
 # 2026-1-25
 ClothingOuterArmorBasic: ESClothingOuterArmorSecurity
 ClothingOuterArmorBasicSlim: ESClothingOuterArmorSecurity
+ClothingOuterVestDetective: ESClothingOuterArmorDetective
 ClothingOuterCoatWarden: ESClothingOuterCoatWarden
 ClothingOuterCoatHoSTrench: ESClothingOuterCoatHoSTrench
 ClothingOuterArmorCaptainCarapace: ESClothingOuterArmorCaptainCarapace
+WardrobeSecurityFilled: ESWardrobeSecurityFilled
 
 # ES END
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -252,6 +252,13 @@ ClothingOuterCoatDetective: ESClothingOuterCoatDetective
 ClothingOuterCoatDetectiveLoadout: ESClothingOuterCoatDetectiveLoadout
 ClothingOuterCoatDetectiveGrey: ESClothingOuterCoatDetectiveGrey
 
+# 2026-1-25
+ClothingOuterArmorBasic: ESClothingOuterArmorSecurity
+ClothingOuterArmorBasicSlim: ESClothingOuterArmorSecurity
+ClothingOuterCoatWarden: ESClothingOuterCoatWarden
+ClothingOuterCoatHoSTrench: ESClothingOuterCoatHoSTrench
+ClothingOuterArmorCaptainCarapace: ESClothingOuterArmorCaptainCarapace
+
 # ES END
 
 # 2023-07-03


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Replaces all existing armor with DT variants. these values have not been thoroughly messed with but are probably more then fine enough.
Also removes riot armor from the armory & lowers the amount of shotguns available.

Also makes the DB not have insane firerate because being able to instakill people is probably not good.

## Media
video too big but it is tested. trust
