### PR TITLE
Add Turncoat

### DIFF
--- a/Content.Shared/_ES/Masks/Components/ESTargetMaskBlacklistComponent.cs
+++ b/Content.Shared/_ES/Masks/Components/ESTargetMaskBlacklistComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Masks.Components;
+
+/// <summary>
+///     This is used for blacklisting certain masks from targeted objectives.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESTargetMaskBlacklistComponent : Component
+{
+    /// <summary>
+    /// A blacklist of masks that cannot be targeted.
+    /// </summary>
+    [DataField]
+    public HashSet<ProtoId<ESMaskPrototype>> MaskBlacklist;
+}

--- a/Content.Shared/_ES/Masks/ESTargetMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/ESTargetMaskSystem.cs
@@ -1,0 +1,21 @@
+using Content.Shared._ES.Masks.Components;
+using Content.Shared._ES.Objectives.Target.Components;
+
+namespace Content.Shared._ES.Masks;
+
+public sealed class ESTargetMaskSystem : EntitySystem
+{
+    [Dependency] private readonly ESSharedMaskSystem _mask = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESTargetMaskBlacklistComponent, ESValidateObjectiveTargetCandidates>(Handler);
+    }
+
+    private void Handler(Entity<ESTargetMaskBlacklistComponent> ent, ref ESValidateObjectiveTargetCandidates args)
+    {
+        if (_mask.GetMaskOrNull(args.Candidate) is {} mask && ent.Comp.MaskBlacklist.Contains(mask))
+            args.Invalidate();
+    }
+}

--- a/Content.Shared/_ES/Masks/MaskCycle/ESActionChangeMaskEvent.cs
+++ b/Content.Shared/_ES/Masks/MaskCycle/ESActionChangeMaskEvent.cs
@@ -1,0 +1,13 @@
+using Content.Shared.Actions;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Masks.MaskCycle;
+
+/// <summary>
+///     An action event for changing to another mask.
+/// </summary>
+public sealed partial class ESActionChangeMaskEvent : InstantActionEvent
+{
+    [DataField(required: true)]
+    public ProtoId<ESMaskPrototype> Mask;
+}

--- a/Content.Shared/_ES/Masks/MaskCycle/ESActionChangeMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/MaskCycle/ESActionChangeMaskSystem.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Mind;
+
+namespace Content.Shared._ES.Masks.MaskCycle;
+
+/// <summary>
+/// This handles the mask change action.
+/// </summary>
+public sealed class ESActionChangeMaskSystem : EntitySystem
+{
+    [Dependency] private readonly ESSharedMaskSystem _mask = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESActionChangeMaskEvent>(Handler);
+    }
+
+    private void Handler(ESActionChangeMaskEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!_mind.TryGetMind(args.Performer, out var mind, out var mindComp))
+            return;
+
+        _mask.RemoveMask((mind, mindComp));
+        _mask.ApplyMask((mind, mindComp), args.Mask);
+
+        args.Handled = true;
+    }
+}

--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -75,6 +75,11 @@ es-mask-subverter-desc = As a Subverter, you have received two brain-altering ch
 es-mask-demolitionist-name = Demolitionist
 es-mask-demolitionist-desc = As a Demolitionist, you have been trained by the Syndicate for both controlled and uncontrolled "demolitions"--including in the use of explosive implants, should things turn out that way.
 
+# Oddballs
+
+es-mask-turncoat-name = Turncoat
+es-mask-turncoat-desc = As a Turncoat, you play to both sides, switching teams at will in an effort to win with either the crew or the traitors. Do so carefully, as you can only switch sides so often.
+
 # Meta
 es-objective-issuer-mask = Mask
 

--- a/Resources/Prototypes/_ES/Actions/Masks/turncoat.yml
+++ b/Resources/Prototypes/_ES/Actions/Masks/turncoat.yml
@@ -13,7 +13,7 @@
     iconOn:
       sprite: _ES/Actions/masks/aura.rsi
       state: aura-on
-    useDelay: 10s
+    useDelay: 10m
     startDelay: true
 
 - type: entity

--- a/Resources/Prototypes/_ES/Actions/Masks/turncoat.yml
+++ b/Resources/Prototypes/_ES/Actions/Masks/turncoat.yml
@@ -1,0 +1,35 @@
+- type: entity
+  parent: BaseMentalAction
+  id: ESActionMaskTurncoatSwapTeamsBase
+  name: Turn your coat
+  description: Switch to the enemy's side, and try to win with them instead.
+  abstract: true
+  components:
+  - type: Action
+    checkCanInteract: false
+    icon:
+      sprite: _ES/Actions/masks/aura.rsi
+      state: aura
+    iconOn:
+      sprite: _ES/Actions/masks/aura.rsi
+      state: aura-on
+    useDelay: 10s
+    startDelay: true
+
+- type: entity
+  parent: ESActionMaskTurncoatSwapTeamsBase
+  id: ESActionMaskTurncoatSwapTeamsCrew
+  description: Switch to the crew's side, and try to win with them instead.
+  components:
+  - type: InstantAction
+    event: !type:ESActionChangeMaskEvent
+      mask: ESTurncoatCrew
+
+- type: entity
+  parent: ESActionMaskTurncoatSwapTeamsBase
+  id: ESActionMaskTurncoatSwapTeamsTraitors
+  description: Switch to the traitors' side, and try to win with them instead.
+  components:
+  - type: InstantAction
+    event: !type:ESActionChangeMaskEvent
+      mask: ESTurncoatTraitor

--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -298,3 +298,28 @@
   - type: ESMaskCacheSpawner
     cacheProto:
       id: ESCrateCacheTraitorDemolitionist
+
+# Neutral/oddball masks
+- type: esMask
+  id: ESTurncoatCrew
+  name: es-mask-turncoat-name
+  troupe: ESCrew
+  description: es-mask-turncoat-desc
+  color: gray
+  weight: 0.1
+  components:
+  - type: ActionGrant
+    actions:
+    - ESActionMaskTurncoatSwapTeamsTraitors
+
+- type: esMask
+  parent: ESBaseTraitor
+  id: ESTurncoatTraitor
+  name: es-mask-turncoat-name
+  description: es-mask-turncoat-desc
+  color: gray
+  weight: 0
+  components:
+  - type: ActionGrant
+    actions:
+    - ESActionMaskTurncoatSwapTeamsCrew

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -17,7 +17,7 @@
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["ESEmpath"]
       16: ["ESAvenger"] # 1 generic crew, 3 traitors.
-      17: ["ESTurncoat"]
+      17: ["ESTurncoatCrew"]
       18: ["ESArmsDealer"]
       19: ["ESMarauder"] # 1 generic crew, 4 traitors.
       20: ["ESVIP"]

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -17,7 +17,7 @@
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["ESEmpath"]
       16: ["ESAvenger"] # 1 generic crew, 3 traitors.
-      17: ["#Reaped"]
+      17: ["ESTurncoat"]
       18: ["ESArmsDealer"]
       19: ["ESMarauder"] # 1 generic crew, 4 traitors.
       20: ["ESVIP"]

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -17,7 +17,7 @@
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["ESEmpath"]
       16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
-      17: ["ESTurncoat"]
+      17: ["ESTurncoatCrew"]
       18: ["ESArmsDealer"]
       19: ["ESMarauder"] # 1 generic crew, 4 traitors.
       20: ["#Softsafes"]

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -17,7 +17,7 @@
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["ESEmpath"]
       16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
-      17: ["#Reaped"]
+      17: ["ESTurncoat"]
       18: ["ESArmsDealer"]
       19: ["ESMarauder"] # 1 generic crew, 4 traitors.
       20: ["#Softsafes"]

--- a/Resources/Prototypes/_ES/Objectives/traitor.yml
+++ b/Resources/Prototypes/_ES/Objectives/traitor.yml
@@ -26,6 +26,10 @@
   - type: ESTargetTroupeObjective
     troupe: ESTraitor
     invert: true
+  - type: ESTargetMaskBlacklist
+    maskBlacklist:
+    - ESTurncoatCrew
+    - ESTurncoatTraitor
   - type: ESKillTargetObjective
 
 ### Sabotage objectives


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Turncoat is a mask that can switch sides at will, with the goal to do so strategically and win with either side.

Turncoat starts with the crew in all current masquerades, forcing them to wait til everyone has long left the shuttle to start collecting information on their syndicate counterparts.

Turncoat has not been given a weapon of any kind, may be worth changing this down the line?

Balances them into Traitors and Red Carpet, but not showdown which has less breathing room for the mask and is generally more conflict heavy.

## Media
<img width="669" height="534" alt="image" src="https://github.com/user-attachments/assets/30a93633-782c-4dbf-b4f2-21fb865f599e" />
<img width="669" height="534" alt="Screenshot_20260125_031849" src="https://github.com/user-attachments/assets/6178d1da-7d6a-40e3-b45d-c2c0544c4893" />
