### PR TITLE
Remove empath

### DIFF
--- a/Resources/Prototypes/_ES/Actions/Masks/empath.yml
+++ b/Resources/Prototypes/_ES/Actions/Masks/empath.yml
@@ -46,5 +46,4 @@
   objectiveWhitelist: {}
   priority: 10 # A murderous oracle is still an oracle.
   maskOverrides:
-  - ESEmpath
   - ESInsider

--- a/Resources/Prototypes/_ES/MaskSets/oracles.yml
+++ b/Resources/Prototypes/_ES/MaskSets/oracles.yml
@@ -1,5 +1,4 @@
 - type: esMaskSet
   id: Oracles
   masks:
-    ESEmpath: 1
     ESInsider: 1

--- a/Resources/Prototypes/_ES/Masks/masks.yml
+++ b/Resources/Prototypes/_ES/Masks/masks.yml
@@ -78,17 +78,6 @@
   color: white
 
 - type: esMask
-  id: ESEmpath
-  name: es-mask-empath-name
-  troupe: ESCrew
-  description: es-mask-empath-desc
-  color: plum
-  components:
-  - type: ActionGrant
-    actions:
-    - ESActionMaskDetectAura
-
-- type: esMask
   id: ESGuzzler
   name: es-mask-guzzler-name
   troupe: ESCrew

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -15,7 +15,7 @@
       10: ["ESPhantom"]
       11: ["ESVIP"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
-      14: ["ESEmpath"]
+      14: ["#Oracles"]
       16: ["ESAvenger"] # 1 generic crew, 3 traitors.
       17: ["#Reaped"]
       18: ["ESArmsDealer"]

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -15,7 +15,7 @@
       10: ["ESPhantom"]
       11: ["ESVIP"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
-      14: ["#Oracles"]
+      14: ["ESInsider"]
       16: ["ESAvenger"] # 1 generic crew, 3 traitors.
       17: ["#Reaped"]
       18: ["ESArmsDealer"]

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -14,7 +14,7 @@
       11: ["ESArmsDealer"] # Guarantee another arms dealer, this is definitely balanced around an armed crew.
       12: ["ESAvenger"]
       13: ["ESMartyr"]
-      14: ["ESEmpath"]
+      14: ["#Oracles"]
       15: ["#PowerTraitors"] # 0 generic crew, 4 traitors.
       16: ["#Firmsafes"]
       17: ["#Traitors"] # 0 generic crew, 5 traitors.
@@ -26,5 +26,5 @@
       25: ["#PowerTraitors"] # 1 generic crew, 7 traitors.
       26: ["ESAvenger"]
       27: ["#Softsafes"]
-      28: ["ESEmpath"]
+      28: ["#Oracles"]
       30: ["#Traitors"] # 2 generic crew, 8 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -14,7 +14,7 @@
       11: ["ESArmsDealer"] # Guarantee another arms dealer, this is definitely balanced around an armed crew.
       12: ["ESAvenger"]
       13: ["ESMartyr"]
-      14: ["#Oracles"]
+      14: ["ESInsider"]
       15: ["#PowerTraitors"] # 0 generic crew, 4 traitors.
       16: ["#Firmsafes"]
       17: ["#Traitors"] # 0 generic crew, 5 traitors.
@@ -26,5 +26,5 @@
       25: ["#PowerTraitors"] # 1 generic crew, 7 traitors.
       26: ["ESAvenger"]
       27: ["#Softsafes"]
-      28: ["#Oracles"]
+      28: ["ESInsider"]
       30: ["#Traitors"] # 2 generic crew, 8 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -15,7 +15,7 @@
       10: ["ESPhantom"]
       11: ["ESAvenger"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
-      14: ["ESEmpath"]
+      14: ["#Oracles"]
       16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
       17: ["#Reaped"]
       18: ["ESArmsDealer"]

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -15,7 +15,7 @@
       10: ["ESPhantom"]
       11: ["ESAvenger"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
-      14: ["#Oracles"]
+      14: ["ESInsider"]
       16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
       17: ["#Reaped"]
       18: ["ESArmsDealer"]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
The Empath mask has been removed. All references to it in masquerades have been replaced with an ~~generic Oracle~~ Insider slot. The aura system has been kept for now but is now unused.

## Media
<img width="168" height="218" alt="image" src="https://github.com/user-attachments/assets/a841158f-7177-4121-8abe-f9f932698ed2" />

