### PR TITLE
Antimatter Capsule blows up by C4 now

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Power/antimatter.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Power/antimatter.yml
@@ -161,7 +161,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 60
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/_ES/Entities/Structures/Power/antimatter.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Power/antimatter.yml
@@ -155,13 +155,13 @@
     anchored: false
     noRot: true
   - type: Damageable
-    damageContainer: Inorganic
+    damageContainer: StructuralInorganic
     damageModifierSet: StrongMetallic
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 60
+        damage: 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
C4 does 60 damage, antimatter capsule now takes 60 damage before blowing up solves https://github.com/EphemeralSpace/ephemeral-space/issues/944
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->


https://github.com/user-attachments/assets/9f194cae-d137-4148-b4c1-50f182d819eb

