### PR TITLE
Make survival boxes smaller

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Fills/emergency.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/emergency.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: ESBoxSurvival
   name: survival box
   description: It's a box with basic internals inside.
@@ -16,9 +16,9 @@
     layers:
     - state: internals
     - state: emergencytank
-  
-- type: entity 
-  parent: BoxCardboard
+
+- type: entity
+  parent: BoxCardboardSmall
   id: ESBoxSurvivalMedical
   name: survival box
   description: It's a box with basic internals inside.
@@ -35,9 +35,9 @@
     layers:
     - state: internals
     - state: emergencytank
-    
+
 - type: entity
-  parent: BoxCardboard
+  parent: BoxCardboardSmall
   id: ESBoxHug
   name: box of hugs
   description: A special box for sensitive people.


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Survival boxes are 2x2, because right now its 3x3 for no reason
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
N/A