### PR TITLE
Make insider a bit more fair to deal with

### DIFF
--- a/Resources/Locale/en-US/_ES/masks/crew/insider.ftl
+++ b/Resources/Locale/en-US/_ES/masks/crew/insider.ftl
@@ -1,8 +1,20 @@
 es-troupe-dossier-name = {CAPITALIZE($name)}'s record
 es-troupe-dossier-header = [head=2]Info about "{CAPITALIZE($name)}"[/head]
 es-troupe-dossier-clue-fmt = - {CAPITALIZE($clue)}
-es-troupe-dossier-footer-crew = - Crew
-es-troupe-dossier-footer-not-crew = - Not crew
+es-troupe-dossier-briefing-name = dossier briefing
+es-troupe-dossier-briefing-text = [head=2]NSPT Insider Report[/head]
+
+    The following is known about the {$sum} targets enclosed:
+    {""}- {$crew} of the targets {$crew ->
+    [1] is a member
+    *[Other] are members
+} of the crew
+    {""}- {$noncrew} of the targets {$noncrew ->
+    [1] is not a member
+    *[Other] are not members
+} of the crew
+
+    Use this information to the best of your ability
 
 es-dataset-insider-codename-1 = Amsterdam
 es-dataset-insider-codename-2 = Ankara


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1022

Insider clues no longer state the crew/noncrew affiliation. Instead, the dossier includes an additional document which states how many of the enclosed pages refer to crew and how many refer to noncrew. There's no indication of which is which.

The goal of this is to weaken the insider so that they need to do more investigative work to find the traitor. I like the loop of the insider going around trying to find people, but it's severely hampered by the fact that confirming crew members is like extremely irrelevant and confirming a traitor is fairly easy using 3 clues. I don't want to make finding someone harder tho, since that makes them have a lot of nongameplay (you walk around struggling to identify Anyone)

With this change, you need to seek out all members you have briefs on and keep an eye on them, watching their activities and making sure they aren't up to anything nefarious. It's only after you've caught one of them in the act or deconfirmed the other two (only happens late in the round w/ coroner) that you can really make a definitive action and kill the traitor.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="2133" height="1799" alt="image" src="https://github.com/user-attachments/assets/955bc19f-f1a8-43f0-881b-c3301d48a0b4" />