### PR TITLE
Suit sensor tweaks

### DIFF
--- a/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
+++ b/Content.Server/Medical/CrewMonitoring/CrewMonitoringServerSystem.cs
@@ -6,10 +6,8 @@ using Content.Shared.Medical.SuitSensor;
 using Robust.Shared.Timing;
 using Content.Shared.DeviceNetwork.Components;
 // ES START
-using System.Linq;
 using Content.Shared._ES.Degradation;
 using Content.Shared.Medical.SuitSensors;
-using Robust.Shared.Random;
 // ES END
 
 namespace Content.Server.Medical.CrewMonitoring;
@@ -21,7 +19,6 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
     [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
     [Dependency] private readonly SingletonDeviceNetServerSystem _singletonServerSystem = default!;
 // ES START
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
 // ES END
 
@@ -131,8 +128,6 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
         var sensors = new HashSet<Entity<SuitSensorComponent>>();
         _entityLookup.GetGridEntities(grid, sensors);
 
-        var statuses = Enum.GetValues<SuitSensorMode>().ToList();
-
         foreach (var sensor in sensors)
         {
             // Don't change the sensor of clothing that doesn't support having it changed back
@@ -142,7 +137,7 @@ public sealed class CrewMonitoringServerSystem : EntitySystem
             // Don't enable disabled sensors. First because it'll expose stealthy people and dead bodies, second because it doesnt make sense.
             if (sensor.Comp.Mode == SuitSensorMode.SensorOff)
                 continue;
-            _sensors.SetSensor(sensor.AsNullable(), _random.Pick(statuses));
+            _sensors.SetSensor(sensor.AsNullable(), SuitSensorMode.SensorBinary);
         }
 
         args.Handled = true;

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -89,8 +89,7 @@ public abstract class SharedSuitSensorSystem : EntitySystem
             {
 // ES START
                 SuitSensorMode.SensorBinary,
-                SuitSensorMode.SensorCords,
-                SuitSensorMode.SensorCords,
+                SuitSensorMode.SensorBinary,
                 SuitSensorMode.SensorCords,
 // ES END
             };

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -87,10 +87,12 @@ public abstract class SharedSuitSensorSystem : EntitySystem
             //make the sensor mode favor higher levels, except coords.
             var modesDist = new[]
             {
-                SuitSensorMode.SensorOff,
-                SuitSensorMode.SensorBinary, SuitSensorMode.SensorBinary,
-                SuitSensorMode.SensorVitals, SuitSensorMode.SensorVitals, SuitSensorMode.SensorVitals,
-                SuitSensorMode.SensorCords, SuitSensorMode.SensorCords
+// ES START
+                SuitSensorMode.SensorBinary,
+                SuitSensorMode.SensorCords,
+                SuitSensorMode.SensorCords,
+                SuitSensorMode.SensorCords,
+// ES END
             };
             ent.Comp.Mode = _random.Pick(modesDist);
         }
@@ -201,9 +203,13 @@ public abstract class SharedSuitSensorSystem : EntitySystem
 
         args.Verbs.UnionWith(new[]
         {
-            CreateVerb(ent, args.User, SuitSensorMode.SensorOff),
+// ES START
+            //CreateVerb(ent, args.User, SuitSensorMode.SensorOff),
+// ES END
             CreateVerb(ent, args.User, SuitSensorMode.SensorBinary),
-            CreateVerb(ent, args.User, SuitSensorMode.SensorVitals),
+// ES START
+            //CreateVerb(ent, args.User, SuitSensorMode.SensorVitals),
+// ES END
             CreateVerb(ent, args.User, SuitSensorMode.SensorCords)
         });
     }

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/specific.yml
@@ -32,9 +32,11 @@
         - state: equipped-FEET
           color: "#1d1d1d"
         - state: soles-equipped-FEET
-    - type: SuitSensor
-      randomMode: false
-      mode: SensorOff
+# ES START
+#    - type: SuitSensor
+#      randomMode: false
+#      mode: SensorOff
+# ES END
     - type: ChameleonClothing
       slot: [innerclothing]
       default: ClothingUniformJumpsuitColorBlack


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1048 

changes:
- suit sensors only have binary and coords
- split them 66%/33%
- various fixes to accommodate this insane new paradigm

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
