### PR TITLE
Armor prototype improvements

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/armor.yml
@@ -1,13 +1,9 @@
 # Base Prototypes
 - type: entity
+  id: ESBaseOuterArmor
+  suffix: ES
   abstract: true
-  parent: [ClothingOuterBaseMedium, AllowSuitStorageClothing]
-  id: ESClothingOuterArmorBase
   components:
-  - type: Sprite
-    sprite: Clothing/OuterClothing/Armor/security.rsi
-  - type: Clothing
-    sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Armor
     modifiers:
       flatReductions:
@@ -17,11 +13,12 @@
         Heat: 5
   - type: ExplosionResistance
     damageCoefficient: 0.90
+  - type: GroupExamine
 
 - type: entity
+  parent: ESBaseOuterArmor
+  id: ESBaseOuterArmorImproved
   abstract: true
-  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
-  id: ESClothingOuterArmorBaseImproved
   components:
   - type: Armor
     modifiers:
@@ -32,15 +29,13 @@
         Heat: 6
   - type: ExplosionResistance
     damageCoefficient: 0.80
-  - type: GroupExamine
 
 # Armor
 - type: entity
-  parent: ESClothingOuterArmorBase
+  parent: [ ESBaseOuterArmor, ClothingOuterBaseMedium, AllowSuitStorageClothing ]
   id: ESClothingOuterArmorSecurity
   name: armor vest
   description: A standard Type I armored vest that provides decent protection against most types of damage.
-  suffix: ES
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/security.rsi
@@ -48,7 +43,7 @@
     sprite: Clothing/OuterClothing/Armor/security.rsi
 
 - type: entity
-  parent: ESClothingOuterArmorBase
+  parent: [ ESBaseOuterArmor, ClothingOuterBaseMedium, AllowSuitStorageClothing ]
   id: ESClothingOuterArmorDetective
   name: detective's vest
   description: A hard-boiled private investigator's armored vest.
@@ -60,11 +55,10 @@
     sprite: Clothing/OuterClothing/Vests/detvest.rsi
 
 - type: entity
-  parent: ESClothingOuterArmorBase
+  parent: [ ESBaseOuterArmor, ClothingOuterBaseMedium, AllowSuitStorageClothing ]
   id: ESClothingOuterCoatWarden
   name: warden's armored jacket
   description: A sturdy, utilitarian jacket designed to protect a warden from any brig-bound threats.
-  suffix: ES
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Coats/warden.rsi
@@ -72,11 +66,10 @@
     sprite: Clothing/OuterClothing/Coats/warden.rsi
 
 - type: entity
-  parent: ESClothingOuterArmorBaseImproved
+  parent: [ ESBaseOuterArmorImproved, ClothingOuterBaseMedium, AllowSuitStorageClothing ]
   id: ESClothingOuterArmorCaptainCarapace
   name: captain's carapace
   description: An armored chestpiece that provides protection whilst still offering maximum mobility and flexibility. Issued only to the station's finest.
-  suffix: ES
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Armor/captain_carapace.rsi
@@ -84,11 +77,10 @@
     sprite: Clothing/OuterClothing/Armor/captain_carapace.rsi
 
 - type: entity
-  parent: ESClothingOuterArmorBaseImproved
+  parent: [ ESBaseOuterArmorImproved, ClothingOuterBaseMedium, AllowSuitStorageClothing ]
   id: ESClothingOuterCoatHoSTrench
   name: head of security's armored trenchcoat
   description: A greatcoat enhanced with a special alloy for some extra protection and style for those with a commanding presence.
-  suffix: ES
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Coats/hos_trenchcoat.rsi

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
@@ -38,25 +38,23 @@
     - MonkeyWearable
     - WhitelistChameleon
 
+# ============================== DESIGN NOTE ====================================
+# Spacesuits for sec/command intentionally do not have any form of armor on them.
+# This is to make spaced areas a generally disadvantageous position for all players
+# sec/command already retain the upper hand in terms of access, armor, supplies, etc.
+# in most situations, so stripping armor when in space levels the playing field for
+# players trying to take them down.
+# ===============================================================================
 - type: entity
   parent: ESBaseClothingOuterSpaceSuit
   id: ESClothingOuterSpaceSuitEVASecurity
   name: security EVA suit
-  description: A lightly armored suit that provides protection from the vacuum of space.
+  description: An impressive-looking suit that provides protection from the vacuum of space. Doesn't help with much else thought.
   components:
   - type: Sprite
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
   - type: Clothing
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
-  - type: Armor #based on armor vest
-    modifiers:
-      flatReductions:
-        Blunt: 5
-        Slash: 5
-        Piercing: 5
-        Heat: 5
-  - type: ExplosionResistance
-    damageCoefficient: 0.90
   - type: Tag
     tags:
     - SuitEVA
@@ -68,21 +66,12 @@
   parent: ESBaseClothingOuterSpaceSuit
   id: ESClothingOuterSpaceSuitEVACaptain
   name: captain's EVA suit
-  description: A dignified space suit that protects the captain from space. It is slightly armored, despite its appearance.
+  description: A dignified space suit that protects the captain from space. Or at least, you hope it's the captain.
   components:
   - type: Sprite
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/command_space.rsi
   - type: Clothing
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/command_space.rsi
-  - type: Armor #Based on armor vest
-    modifiers:
-      coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70
-        Heat: 0.80
-  - type: ExplosionResistance
-    damageCoefficient: 0.90
   - type: Tag
     tags:
     - SuitEVA

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/spacesuits.yml
@@ -49,7 +49,7 @@
   parent: ESBaseClothingOuterSpaceSuit
   id: ESClothingOuterSpaceSuitEVASecurity
   name: security EVA suit
-  description: An impressive-looking suit that provides protection from the vacuum of space. Doesn't help with much else thought.
+  description: An impressive-looking suit that provides protection from the vacuum of space. Doesn't help with much else, though.
   components:
   - type: Sprite
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/sec_space.rsi
@@ -66,7 +66,7 @@
   parent: ESBaseClothingOuterSpaceSuit
   id: ESClothingOuterSpaceSuitEVACaptain
   name: captain's EVA suit
-  description: A dignified space suit that protects the captain from space. Or at least, you hope it's the captain.
+  description: A dignified space suit that protects the captain from space. Or at least you hope it's the captain.
   components:
   - type: Sprite
     sprite: _ES/Clothing/OuterClothing/SpaceSuits/command_space.rsi


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

changes:
- made some proper base armor prototypes that are literally just the armor comps and nothing else. This is just for multiple parenting stuff because it's really annoying to channel everything through one parent and use everywhere. I'd rather just inherit from like 5 thing or w/e
- Give the basic armor prototypes proper group examine. I'm not actually sure if this was noticeably missing but im mildly shocked that the component needs to added manually anyways
- Removed armor from sec spacesuit and cap spacesuit. Generally the goal is to make space more of a general equalizer in terms of combat so I want the suits to not bias towards confirmed crew.
- gave sec and cap spacesuits new descriptions since the old ones referenced the armor and we don't have that anymore.
- Added the design reason stuff inside the yaml for suits. Idk this is just something i wanted to try cuz maybe it'll be good for longevity.

i didn't test this yet cuz im out and about but i'll confirm it all works when i get home.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
