### PR TITLE
Make caches reveal when a player dies

### DIFF
--- a/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
+++ b/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
@@ -58,7 +58,7 @@ public sealed class ESMartyrSystem : EntitySystem
             return;
 
         EnsureComp<ESMartyrKillerMarkerComponent>(killerBody);
-        _ = _timer.SpawnTimer(killerBody, ent.Comp.TimeBeforeKillerDeath, new ESMartyrKillerTimeToDieEvent());
+        _timer.SpawnTimer(killerBody, ent.Comp.TimeBeforeKillerDeath, new ESMartyrKillerTimeToDieEvent());
 
         if (!TryComp<ActorComponent>(killerBody, out var actor))
             return;

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -62,6 +62,6 @@ public sealed class ESAutoGhostSystem : EntitySystem
         if (!_mind.TryGetMind(uid, out _, out _))
             return;
 
-        _ = _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
+        _entityTimer.SpawnTimer(uid, AutoGhostDelay, new ESAutoGhostEvent());
     }
 }

--- a/Content.Shared/Mind/SharedMindSystem.Relay.cs
+++ b/Content.Shared/Mind/SharedMindSystem.Relay.cs
@@ -1,5 +1,6 @@
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
 
 namespace Content.Shared.Mind;
 
@@ -15,6 +16,8 @@ public abstract partial class SharedMindSystem : EntitySystem
         SubscribeLocalEvent<MindContainerComponent, RefreshNameModifiersEvent>(RelayRefToMind);
 
 // ES PATCH START
+        SubscribeLocalEvent<MindContainerComponent, MobStateChangedEvent>(RelayToMind);
+
         SubscribeLocalEvent<MindComponent, MindGotAddedEvent>(ESOnMindGotAdded);
     }
 
@@ -34,9 +37,9 @@ public abstract partial class SharedMindSystem : EntitySystem
             RaiseLocalEvent(objective, args);
         }
     }
-// ES PATCH END
 
-    protected void RelayToMind<T>(EntityUid uid, MindContainerComponent component, T args) where T : class
+    protected void RelayToMind<T>(EntityUid uid, MindContainerComponent component, T args) where T : notnull
+// ES PATCH END
     {
         var ev = new MindRelayedEvent<T>(args);
 

--- a/Content.Shared/Mind/SharedMindSystem.Relay.cs
+++ b/Content.Shared/Mind/SharedMindSystem.Relay.cs
@@ -1,6 +1,8 @@
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Mind.Components;
+// ES START
 using Content.Shared.Mobs;
+// ES END
 
 namespace Content.Shared.Mind;
 

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -52,7 +52,6 @@ public sealed class ESEntityTimerSystem : EntitySystem
     /// <param name="logFailure">Whether to log if SpawnTimer fails to spawn the timer.</param>
     /// <returns>The timer that was created</returns>
     [PublicAPI]
-    [MustUseReturnValue]
     public Entity<ESEntityTimerComponent>? SpawnTimer(EntityUid target, TimeSpan duration, ESEntityTimerEvent endEvent, bool logFailure = true)
     {
         if (!TimerTargetIsValid(target))
@@ -85,7 +84,6 @@ public sealed class ESEntityTimerSystem : EntitySystem
     /// <param name="logFailure">Whether to log if SpawnMethodTimer fails to spawn the timer.</param>
     /// <returns>The timer that was created</returns>
     [PublicAPI]
-    [MustUseReturnValue]
     public Entity<ESEntityTimerComponent>? SpawnMethodTimer(TimeSpan duration, Action method, bool logFailure = true)
     {
         return SpawnTimer(duration, new MethodTimerEvent(method), logFailure);

--- a/Content.Shared/_ES/Masks/Traitor/Components/ESCeilingCacheComponent.cs
+++ b/Content.Shared/_ES/Masks/Traitor/Components/ESCeilingCacheComponent.cs
@@ -1,7 +1,9 @@
+using Content.Shared._ES.Core.Timer.Components;
 using Content.Shared.Alert;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared._ES.Masks.Traitor.Components;
 
@@ -31,3 +33,6 @@ public sealed partial class ESCeilingCacheContactingComponent : Component
 }
 
 public sealed partial class ESRevealCacheAlertEvent : BaseAlertEvent;
+
+[Serializable, NetSerializable]
+public sealed partial class ESRevealCacheTimerEvent : ESEntityTimerEvent;


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

Closes #964 

When a mask with caches dies, all of their caches will become visible. The goal with this change is twofold:
1. Ensure that even if a mask with conflict-prone gear doesn't pick up their items, the equipment can still eventually circulate into the round.
2. Enable helpers are able to complete objectives that rely on cache items (arms dealer, fruit vendor) in the event that their partner dies. I want to extend this to more stuff like "directly kill target" objectives but this seemed like a nice first step.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
