### PR TITLE
Purge job related jumpskirts

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Fills/wardrobe_fun.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/wardrobe_fun.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ESWardrobeTheatre
   id: ESWardrobeTheatreFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/_ES/Entities/Structures/Storage/wardrobe.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Storage/wardrobe.yml
@@ -42,3 +42,33 @@
   parent: WardrobeMixed
   id: ESWardrobeTheatre
   name: theatre wardrobe
+
+- type: entity
+  id: ESWardrobeScience
+  parent: WardrobeWhite
+  name: science wardrobe
+
+- type: entity
+  id: ESWardrobeBotanist
+  parent: WardrobeGreen
+  name: botanist wardrobe
+
+- type: entity
+  id: ESWardrobeMedicalDoctor
+  parent: WardrobeWhite
+  name: medical doctor's wardrobe
+
+- type: entity
+  id: ESWardrobeEngineering
+  parent: WardrobeYellow
+  name: engineering wardrobe
+
+- type: entity
+  id: ESWardrobeCargo
+  parent: WardrobePrison
+  name: cargo wardrobe
+
+- type: entity
+  id: ESWardrobePrison
+  parent: WardrobePrison
+  name: prison wardrobe

--- a/Resources/Prototypes/_ES/Entities/Structures/Storage/wardrobe.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Storage/wardrobe.yml
@@ -1,74 +1,89 @@
 - type: entity
   parent: WardrobeBlack
   id: ESWardrobeBartender
+  suffix: ES
   name: bartender's wardrobe
 
 - type: entity
   parent: WardrobeWhite
   id: ESWardrobeChef
+  suffix: ES
   name: chef's wardrobe
 
 - type: entity
   parent: WardrobePink
   id: ESWardrobeClown
+  suffix: ES
   name: clown's wardrobe
 
 - type: entity
   parent: WardrobeBlue
   id: ESWardrobeCoroner
+  suffix: ES
   name: coroner's wardrobe
 
 - type: entity
   parent: WardrobeSecurity
   id: ESWardrobeDetective
+  suffix: ES
   name: detective's wardrobe
 
 - type: entity
   parent: WardrobeMixed
   id: ESWardrobeJanitor
+  suffix: ES
   name: janitor's wardrobe
 
 - type: entity
   parent: WardrobeWhite
   id: ESWardrobeMime
+  suffix: ES
   name: mime's wardrobe
 
 - type: entity
   parent: WardrobeBlack
   id: ESWardrobeReporter
+  suffix: ES
   name: reporter's wardrobe
 
 - type: entity
   parent: WardrobeMixed
   id: ESWardrobeTheatre
+  suffix: ES
   name: theatre wardrobe
 
 - type: entity
   id: ESWardrobeScience
   parent: WardrobeWhite
+  suffix: ES
   name: science wardrobe
 
 - type: entity
   id: ESWardrobeBotanist
   parent: WardrobeGreen
+  suffix: ES
   name: botanist wardrobe
 
 - type: entity
   id: ESWardrobeMedicalDoctor
   parent: WardrobeWhite
+  suffix: ES
   name: medical doctor's wardrobe
 
 - type: entity
   id: ESWardrobeEngineering
   parent: WardrobeYellow
+  suffix: ES
   name: engineering wardrobe
 
 - type: entity
   id: ESWardrobeCargo
   parent: WardrobePrison
+  suffix: ES
   name: cargo wardrobe
 
 - type: entity
   id: ESWardrobePrison
   parent: WardrobePrison
+  suffix: ES
   name: prison wardrobe

--- a/Resources/Prototypes/_ES/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/dressers.yml
@@ -1,0 +1,41 @@
+- type: entity
+  id: ESDresserCaptainFilled
+  parent: Dresser
+  suffix: Filled, Captain
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: ClothingHeadHatCaptain
+        - id: ClothingHandsGlovesCaptain
+        - id: ClothingUniformJumpsuitCaptain
+        - id: ClothingShoesColorBrown
+
+- type: entity
+  id: ESDresserHeadOfPersonnelFilled
+  parent: Dresser
+  suffix: Filled, Head Of Personnel
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: ClothingHeadHatHopcap
+        - id: ClothingEyesHudSecurity
+        - id: ClothingUniformJumpsuitHoP
+        - id: ClothingShoesColorBrown
+
+- type: entity
+  id: ESDresserHeadOfSecurityFilled
+  parent: Dresser
+  suffix: Filled, Head Of Security
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: ClothingHeadHatBeretHoS
+        - id: ClothingHeadHatHoshat
+        - id: ClothingEyesHudSecurity
+        - id: ClothingUniformJumpsuitHoS

--- a/Resources/Prototypes/_ES/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/dressers.yml
@@ -5,8 +5,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      storagebase: !type:AllSelector
-        children:
+      storagebase:
+        all:
         - id: ClothingHeadHatCaptain
         - id: ClothingHandsGlovesCaptain
         - id: ClothingUniformJumpsuitCaptain
@@ -19,8 +19,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      storagebase: !type:AllSelector
-        children:
+      storagebase:
+        all:
         - id: ClothingHeadHatHopcap
         - id: ClothingEyesHudSecurity
         - id: ClothingUniformJumpsuitHoP
@@ -33,8 +33,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      storagebase: !type:AllSelector
-        children:
+      storagebase:
+        all:
         - id: ClothingHeadHatBeretHoS
         - id: ClothingHeadHatHoshat
         - id: ClothingEyesHudSecurity

--- a/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
@@ -14,7 +14,6 @@
     children:
     - id: ClothingBackpack
     - id: ClothingShoesColorBlack
-    - id: ClothingUniformJumpskirtBartender
     - id: ClothingUniformJumpsuitBartender
 
 - type: entity
@@ -34,7 +33,6 @@
     - id: ClothingBackpack
     - id: ClothingOuterApronChef
     - id: ClothingShoesChef
-    - id: ClothingUniformJumpskirtChef
     - id: ClothingUniformJumpsuitChef
 
 - type: entity
@@ -74,7 +72,6 @@
     - id: ClothingBackpackClown
     - id: ClothingMaskClown
     - id: ClothingShoesClown
-    - id: ClothingUniformJumpskirtClown
     - id: ClothingUniformJumpsuitClown
 
 - type: entity
@@ -95,7 +92,6 @@
     - id: ESClothingOuterCoatDetective
     - id: ClothingBackpackSecurity
     - id: ClothingShoesColorBrown
-    - id: ClothingUniformJumpskirtDetective
     - id: ClothingUniformJumpsuitDetective
 
 - type: entity
@@ -116,7 +112,6 @@
     - id: ESClothingHandsGlovesColorOrange
     - id: ClothingHeadHatPurplesoft
     - id: ClothingShoesColorBlack
-    - id: ClothingUniformJumpskirtJanitor
     - id: ClothingUniformJumpsuitJanitor
 
 - type: entity
@@ -139,7 +134,6 @@
     - id: ClothingHeadHatBeretFrench
     - id: ClothingMaskMime
     - id: ClothingShoesColorWhite
-    - id: ClothingUniformJumpskirtMime
     - id: ClothingUniformJumpsuitMime
 
 - type: entity
@@ -180,3 +174,189 @@
     containers:
       entity_storage:
         tableId: ESFillWardrobeSecurity
+
+- type: entity
+  id: ESWardrobeScienceFilled
+  suffix: Filled
+  parent: ESWardrobeScience
+  description: "You've read a couple pop science articles, now it's time for the real deal."
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobeScience
+
+- type: entityTable
+  id: ESFillWardrobeScience
+  table: !type:AllSelector
+    children:
+    - id: ClothingUniformJumpsuitScientist
+    - id: ClothingBackpackScience
+    - id: ClothingShoesChef
+    - id: ClothingOuterCoatLabOpened
+    - id: ClothingEyesGlasses
+      prob: 0.5
+    - id: CrowbarRed #The jojoke - hit video game Half-Life
+      prob: 0.1
+
+- type: entity
+  id: ESWardrobeBotanistFilled
+  suffix: Filled
+  parent: ESWardrobeBotanist
+  description: "Plant yourself among the plant men with these 100% natural plant-derived clothes."
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobeBotanist
+
+- type: entityTable
+  id: ESFillWardrobeBotanist
+  table: !type:AllSelector
+    children:
+    - id: ClothingUniformJumpsuitHydroponics
+    - id: ClothingBackpackHydroponics
+    - id: ClothingShoesColorBrown
+    - id: ClothingOuterApronBotanist
+    - id: ClothingUniformOveralls
+    - id: ClothingHeadHatTrucker #the hat itself is a subtle joke
+      prob: 0.15
+    - id: ClothingHandsGlovesLeather
+      prob: 0.5
+
+- type: entity
+  id: ESWardrobeMedicalDoctorFilled
+  suffix: Filled
+  parent: ESWardrobeMedicalDoctor
+  description: "We've all played doctor before, now practice medicine."
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobeMedicalDoctor
+
+- type: entityTable
+  id: ESFillWardrobeMedicalDoctor
+  table: !type:AllSelector
+    children:
+    - id: ClothingUniformJumpsuitMedicalDoctor
+    - id: ClothingBackpackMedical
+    - id: ClothingShoesColorWhite
+    - id: ClothingOuterCoatLab
+    - id: ClothingHandsGlovesLatex
+      prob: 0.4
+    - id: ClothingEyesGlasses
+      prob: 0.3
+
+- type: entity
+  id: ESWardrobeEngineeringFilled
+  suffix: Filled
+  parent: ESWardrobeEngineering
+  description: "This locker contains a uniform for engineering or social engineering."
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobeEngineering
+
+- type: entityTable
+  id: ESFillWardrobeEngineering
+  table: !type:AllSelector
+    children:
+    - id: ClothingHeadHatHardhatYellow
+    - id: ClothingUniformJumpsuitEngineering
+    - id: ClothingBackpackEngineering
+    - id: ClothingShoesColorOrange
+    - id: ClothingOuterVestHazard
+
+- type: entity
+  id: ESWardrobeCargoFilled
+  suffix: Filled
+  parent: ESWardrobeCargo
+  description: "This locker? Maybe 500 spesos. Brotherhood? Priceless."
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobeCargo
+
+- type: entityTable
+  id: ESFillWardrobeCargo
+  table: !type:AllSelector
+    children:
+    - id: ClothingHeadHatCargosoft
+    - id: ClothingUniformJumpsuitCargo
+    - id: ClothingBackpack
+    - id: ClothingShoesColorBlack
+    - id: ClothingHandsGlovesFingerless
+    - id: AppraisalTool
+
+- type: entity
+  id: ESWardrobePrisonFilled
+  suffix: Filled
+  parent: ESWardrobePrison
+  description: "Contains a selection of nice orange clothes for people enjoying their stay in the brig."
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillWardrobePrison
+
+- type: entityTable
+  id: ESFillWardrobePrison
+  table: !type:AllSelector
+    children:
+    - !type:AllSelector
+      rolls: 2
+      children:
+      - id: ClothingUniformJumpsuitPrisoner
+      - id: ClothingShoesColorBlack
+    - id: ClothingMaskMuzzle
+    - !type:GroupSelector
+      prob: 0.15
+      rolls: 2
+      children:
+      - id: FoodSnackBoritos
+      - id: FoodSnackCheesie
+      - id: FoodSnackChips
+      - id: FoodSnackRaisins
+      - id: FoodSnackMREBrownie
+      - id: FoodSnackChocolate
+      - id: FoodSnackChowMein
+    - !type:GroupSelector
+      prob: 0.25
+      children:
+      - id: BookRandomStory
+      - id: BookRandom
+    - !type:GroupSelector
+      prob: 0.15
+      children:
+      - id: Flare
+      - id: BarberScissors
+      - id: FlippoLighter
+      - id: trayScanner
+      - id: Wristwatch
+      - id: ClothingNeckBling
+      - id: ClothingMultipleHeadphones
+      - id: DiceBag
+      - id: PersonalAI
+      - id: CrayonBox
+      - id: HarmonicaInstrument
+      - id: ToyAmongPequeno
+      - id: WhoopieCushion
+      - id: Brutepack
+      - id: StrangePill
+      - id: Shiv
+    - !type:GroupSelector
+      prob: 0.1
+      children:
+      - id: CigPackBlack
+      - id: Joint
+      - id: Blunt
+      - id: PackPaperRolling
+      - id: Cigarette
+        amount: !type:RangeNumberSelector
+          range: 1, 4
+      - id: GroundCannabis
+        amount: !type:RangeNumberSelector
+          range: 1, 6

--- a/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/wardrobe_job.yml
@@ -1,17 +1,17 @@
 - type: entity
   parent: ESWardrobeBartender
   id: ESWardrobeBartenderFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeBartender
 
 - type: entityTable
   id: ESFillWardrobeBartender
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingBackpack
     - id: ClothingShoesColorBlack
     - id: ClothingUniformJumpsuitBartender
@@ -19,17 +19,17 @@
 - type: entity
   parent: ESWardrobeChef
   id: ESWardrobeChefFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeChef
 
 - type: entityTable
   id: ESFillWardrobeChef
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingBackpack
     - id: ClothingOuterApronChef
     - id: ClothingShoesChef
@@ -58,17 +58,17 @@
 - type: entity
   parent: ESWardrobeClown
   id: ESWardrobeClownFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeClown
 
 - type: entityTable
   id: ESFillWardrobeClown
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingBackpackClown
     - id: ClothingMaskClown
     - id: ClothingShoesClown
@@ -77,17 +77,17 @@
 - type: entity
   parent: ESWardrobeDetective
   id: ESWardrobeDetectiveFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeDetective
 
 - type: entityTable
   id: ESFillWardrobeDetective
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingHeadHatFedoraBrown
     - id: ESClothingOuterCoatDetective
     - id: ClothingBackpackSecurity
@@ -97,17 +97,17 @@
 - type: entity
   parent: ESWardrobeJanitor
   id: ESWardrobeJanitorFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeJanitor
 
 - type: entityTable
   id: ESFillWardrobeJanitor
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingBackpack
     - id: ESClothingHandsGlovesColorOrange
     - id: ClothingHeadHatPurplesoft
@@ -117,7 +117,7 @@
 - type: entity
   parent: ESWardrobeMime
   id: ESWardrobeMimeFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
@@ -139,17 +139,17 @@
 - type: entity
   parent: ESWardrobeReporter
   id: ESWardrobeReporterFilled
-  suffix: Filled
+  suffix: ES, Filled
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeReporter
 
 - type: entityTable
   id: ESFillWardrobeReporter
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingBackpack
     - id: ClothingShoesColorBrown
     - id: ClothingUniformJumpsuitReporter
@@ -177,19 +177,19 @@
 
 - type: entity
   id: ESWardrobeScienceFilled
-  suffix: Filled
+  suffix: ES, Filled
   parent: ESWardrobeScience
   description: "You've read a couple pop science articles, now it's time for the real deal."
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeScience
 
 - type: entityTable
   id: ESFillWardrobeScience
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingUniformJumpsuitScientist
     - id: ClothingBackpackScience
     - id: ClothingShoesChef
@@ -201,19 +201,19 @@
 
 - type: entity
   id: ESWardrobeBotanistFilled
-  suffix: Filled
+  suffix: ES, Filled
   parent: ESWardrobeBotanist
   description: "Plant yourself among the plant men with these 100% natural plant-derived clothes."
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeBotanist
 
 - type: entityTable
   id: ESFillWardrobeBotanist
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingUniformJumpsuitHydroponics
     - id: ClothingBackpackHydroponics
     - id: ClothingShoesColorBrown
@@ -226,19 +226,19 @@
 
 - type: entity
   id: ESWardrobeMedicalDoctorFilled
-  suffix: Filled
+  suffix: ES, Filled
   parent: ESWardrobeMedicalDoctor
   description: "We've all played doctor before, now practice medicine."
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeMedicalDoctor
 
 - type: entityTable
   id: ESFillWardrobeMedicalDoctor
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingUniformJumpsuitMedicalDoctor
     - id: ClothingBackpackMedical
     - id: ClothingShoesColorWhite
@@ -250,19 +250,19 @@
 
 - type: entity
   id: ESWardrobeEngineeringFilled
-  suffix: Filled
+  suffix: ES, Filled
   parent: ESWardrobeEngineering
   description: "This locker contains a uniform for engineering or social engineering."
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeEngineering
 
 - type: entityTable
   id: ESFillWardrobeEngineering
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingHeadHatHardhatYellow
     - id: ClothingUniformJumpsuitEngineering
     - id: ClothingBackpackEngineering
@@ -271,19 +271,19 @@
 
 - type: entity
   id: ESWardrobeCargoFilled
-  suffix: Filled
+  suffix: ES, Filled
   parent: ESWardrobeCargo
   description: "This locker? Maybe 500 spesos. Brotherhood? Priceless."
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobeCargo
 
 - type: entityTable
   id: ESFillWardrobeCargo
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingHeadHatCargosoft
     - id: ClothingUniformJumpsuitCargo
     - id: ClothingBackpack
@@ -293,70 +293,19 @@
 
 - type: entity
   id: ESWardrobePrisonFilled
-  suffix: Filled
+  suffix: ES, Filled
   parent: ESWardrobePrison
   description: "Contains a selection of nice orange clothes for people enjoying their stay in the brig."
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillWardrobePrison
 
 - type: entityTable
   id: ESFillWardrobePrison
-  table: !type:AllSelector
-    children:
-    - !type:AllSelector
-      rolls: 2
-      children:
+  table:
+    all:
       - id: ClothingUniformJumpsuitPrisoner
       - id: ClothingShoesColorBlack
-    - id: ClothingMaskMuzzle
-    - !type:GroupSelector
-      prob: 0.15
-      rolls: 2
-      children:
-      - id: FoodSnackBoritos
-      - id: FoodSnackCheesie
-      - id: FoodSnackChips
-      - id: FoodSnackRaisins
-      - id: FoodSnackMREBrownie
-      - id: FoodSnackChocolate
-      - id: FoodSnackChowMein
-    - !type:GroupSelector
-      prob: 0.25
-      children:
-      - id: BookRandomStory
-      - id: BookRandom
-    - !type:GroupSelector
-      prob: 0.15
-      children:
-      - id: Flare
-      - id: BarberScissors
-      - id: FlippoLighter
-      - id: trayScanner
-      - id: Wristwatch
-      - id: ClothingNeckBling
-      - id: ClothingMultipleHeadphones
-      - id: DiceBag
-      - id: PersonalAI
-      - id: CrayonBox
-      - id: HarmonicaInstrument
-      - id: ToyAmongPequeno
-      - id: WhoopieCushion
-      - id: Brutepack
-      - id: StrangePill
-      - id: Shiv
-    - !type:GroupSelector
-      prob: 0.1
-      children:
-      - id: CigPackBlack
-      - id: Joint
-      - id: Blunt
-      - id: PackPaperRolling
-      - id: Cigarette
-        amount: !type:RangeNumberSelector
-          range: 1, 4
-      - id: GroundCannabis
-        amount: !type:RangeNumberSelector
-          range: 1, 6
+      - id: ClothingMaskMuzzle

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -261,6 +261,16 @@ ClothingOuterCoatHoSTrench: ESClothingOuterCoatHoSTrench
 ClothingOuterArmorCaptainCarapace: ESClothingOuterArmorCaptainCarapace
 WardrobeSecurityFilled: ESWardrobeSecurityFilled
 
+# 2026-2-3
+WardrobeBotanistFilled: ESWardrobeBotanistFilled
+WardrobeMedicalDoctorFilled: ESWardrobeMedicalDoctorFilled
+WardrobeScienceFilled: ESWardrobeScienceFilled
+DresserHeadOfPersonnelFilled: ESDresserHeadOfPersonnelFilled
+DresserHeadOfSecurityFilled: ESDresserHeadOfSecurityFilled
+DresserCaptainFilled: ESDresserCaptainFilled
+WardrobePrisonFilled: ESWardrobePrisonFilled
+WardrobeCargoFilled: ESWardrobeCargoFilled
+WardrobeEngineeringFilled: ESWardrobeEngineeringFilled
 # ES END
 
 # 2023-07-03

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -262,6 +262,9 @@ ClothingOuterArmorCaptainCarapace: ESClothingOuterArmorCaptainCarapace
 WardrobeSecurityFilled: ESWardrobeSecurityFilled
 
 # 2026-2-3
+LockerAtmosphericsFilled: ESLockerAtmosphericsFilled
+
+# 2026-2-4
 WardrobeBotanistFilled: ESWardrobeBotanistFilled
 WardrobeMedicalDoctorFilled: ESWardrobeMedicalDoctorFilled
 WardrobeScienceFilled: ESWardrobeScienceFilled
@@ -271,6 +274,7 @@ DresserCaptainFilled: ESDresserCaptainFilled
 WardrobePrisonFilled: ESWardrobePrisonFilled
 WardrobeCargoFilled: ESWardrobeCargoFilled
 WardrobeEngineeringFilled: ESWardrobeEngineeringFilled
+WardrobeTheaterFilled: ESWardrobeTheatreFilled
 # ES END
 
 # 2023-07-03


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Added Migrations and new Wardrobe/dresser fills for all the of the job related wardrobes and dressers mapped on ES, removing the Jumpskirts. The real question now is do I remove all the colored Jumpskirts? somewhat solves #961 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
