### PR TITLE
Remove Atmos Firesuits

### DIFF
--- a/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ESLockerAtmosphericsFilled
-  suffix: Filled
+  suffix: ESFilled
   parent: LockerAtmospherics
   components:
   - type: EntityTableContainerFill

--- a/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
@@ -1,4 +1,3 @@
-
 - type: entity
   id: ESLockerAtmosphericsFilled
   suffix: Filled
@@ -6,13 +5,13 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:NestedSelector
+      entity_storage:
         tableId: ESFillLockerAtmospherics
 
 - type: entityTable
   id: ESFillLockerAtmospherics
-  table: !type:AllSelector
-    children:
+  table:
+    all:
     - id: ClothingHeadHelmetFire
     - id: ClothingOuterSuitFire
     - id: ClothingMaskGasAtmos

--- a/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
@@ -1,0 +1,24 @@
+
+- type: entity
+  id: ESLockerAtmosphericsFilled
+  suffix: Filled
+  parent: LockerAtmospherics
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: ESFillLockerAtmospherics
+
+- type: entityTable
+  id: ESFillLockerAtmospherics
+  table: !type:AllSelector
+    children:
+    - id: ClothingHeadHelmetFire
+    - id: ClothingOuterSuitFire
+    - id: ClothingMaskGasAtmos
+    - id: GasAnalyzer
+    - id: MedkitOxygenFilled
+    - id: HolofanProjector
+    - id: RCD
+    - id: RCDAmmo
+    - id: AirGrenade

--- a/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/_ES/Fills/Lockers/engineer.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: ESLockerAtmosphericsFilled
-  suffix: ESFilled
+  suffix: ES, Filled
   parent: LockerAtmospherics
   components:
   - type: EntityTableContainerFill

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -261,6 +261,8 @@ ClothingOuterCoatHoSTrench: ESClothingOuterCoatHoSTrench
 ClothingOuterArmorCaptainCarapace: ESClothingOuterArmorCaptainCarapace
 WardrobeSecurityFilled: ESWardrobeSecurityFilled
 
+# 2026-2-3
+LockerAtmosphericsFilled: ESLockerAtmosphericsFilled
 # ES END
 
 # 2023-07-03


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Atmospheric Lockers have had their atmos firesuits replaced with normal firesuits. solves #1057
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
https://www.youtube.com/watch?v=S-Xrlf3taEo&list=RDS-Xrlf3taEo&start_radio=1