### PR TITLE
ES protective suits + sanitation glove fixes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/biohazard.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/biohazard.yml
@@ -6,7 +6,9 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillBiohazardGearGeneric
+# ES Start
+        tableId: ESFillBiohazardSuit
+# ES End
 
 - type: entityTable
   id: FillBiohazardGearGeneric

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -220,7 +220,9 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillRadiationSuit
+# ES Start
+        tableId: ESFillRadiationSuit
+# ES End
 
 - type: entityTable
   id: FillRadiationSuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -138,7 +138,9 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillLockerFireStandard
+# ES Start
+        tableId: ESFillLockerFireStandard
+# ES End
 
 - type: entity
   id: ClosetWallFireFilledRandom

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -262,6 +262,9 @@
 - type: entity
   parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorOrange
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: orange gloves
   description: Regular orange gloves that do not keep you from frying.
   components:

--- a/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/colored.yml
@@ -262,10 +262,8 @@
 - type: entity
   parent: ClothingHandsGlovesSyntheticBase
   id: ClothingHandsGlovesColorOrange
-# ES Start
-  name: sanitation gloves
-  description: Biohazard-resistant orange gloves. Useful for preventing injuries from chemical spills.
-# ES End
+  name: orange gloves
+  description: Regular orange gloves that do not keep you from frying.
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/Color/color.rsi
@@ -288,9 +286,6 @@
         color: "#EF8100"
   - type: Fiber
     fiberColor: fibers-orange
-# ES START
-  - type: ESChameleonClothingWhitelist
-# ES END
 
 # White Gloves
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -268,6 +268,9 @@
 - type: entity
   parent: ClothingHeadLightBase
   id: ClothingHeadHelmetFire
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: fire helmet
   description: An atmos tech's best friend. Provides some heat resistance and looks cool.
   components:
@@ -307,6 +310,9 @@
 - type: entity
   parent: [ClothingHeadLightBase, BaseEngineeringContraband]
   id: ClothingHeadHelmetAtmosFire
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: atmos fire helmet
   description: An atmos fire helmet, able to keep the user cool in any situation.
   components:

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -1,6 +1,9 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatHoodBioGeneral
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio hood
   suffix: Generic
   description: A hood that protects the head and face from biological contaminants.
@@ -25,13 +28,13 @@
       Snout: HEAD
       HeadTop: HEAD
       HeadSide: HEAD
-# ES START
-  - type: ESVoiceObfuscator
-# ES END
 
 - type: entity
   parent: ClothingHeadHatHoodBioGeneral
   id: ClothingHeadHatHoodBioCmo
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio hood
   suffix: CMO
   description: An advanced hood for chief medical officers that protects the head and face from biological contaminants.
@@ -47,6 +50,9 @@
 - type: entity
   parent: ClothingHeadHatHoodBioGeneral
   id: ClothingHeadHatHoodBioJanitor
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio hood
   suffix: Janitor
   description: A hood that protects the head and face from biological contaminants.
@@ -60,6 +66,9 @@
 - type: entity
   parent: ClothingHeadHatHoodBioGeneral
   id: ClothingHeadHatHoodBioScientist
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio hood
   suffix: Science
   description: A hood that protects the head and face from biological contaminants.
@@ -73,6 +82,9 @@
 - type: entity
   parent: ClothingHeadHatHoodBioGeneral
   id: ClothingHeadHatHoodBioSecurity
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio hood
   suffix: Security
   description: A hood that protects the head and face from biological contaminants.
@@ -86,6 +98,9 @@
 - type: entity
   parent: ClothingHeadHatHoodBioGeneral
   id: ClothingHeadHatHoodBioVirology
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio hood
   suffix: Virology
   description: A hood that strongly protects the head and face from biological contaminants.
@@ -155,6 +170,9 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatHoodRad
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: radiation hood
   description: A hood of the hazmat suit, designed for protection from high radioactivity.
   components:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -1,6 +1,9 @@
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothingGasTanks]
   id: ClothingOuterBioGeneral
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio suit
   suffix: Generic
   description: A suit that protects against biological contamination.
@@ -26,6 +29,9 @@
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioCmo
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio suit
   suffix: CMO
   description: An advanced suit that protects against biological contamination, in CMO colors.
@@ -38,6 +44,9 @@
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioJanitor
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio suit
   suffix: Janitor
   description: A suit that protects against biological contamination and caustic spills.
@@ -54,6 +63,9 @@
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioScientist
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio suit
   suffix: Science
   description: A suit that protects against biological contamination, in Scientist colors.
@@ -66,6 +78,9 @@
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSecurityContraband]
   id: ClothingOuterBioSecurity
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio suit
   suffix: Security
   description: A suit that protects against biological contamination, kitted out with additional armor.
@@ -90,6 +105,9 @@
 - type: entity
   parent: ClothingOuterBioGeneral
   id: ClothingOuterBioVirology
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: bio suit
   suffix: Virology
   description: A suit that strongly protects against biological contamination.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -76,9 +76,6 @@
   - type: HideLayerClothing
     slots:
     - Tail
-# ES START
-  - type: ESChameleonClothingWhitelist
-# ES END
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -46,6 +46,9 @@
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterSuitFire
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: fire suit
   description: A suit that helps protect against hazardous temperatures.
   components:
@@ -80,6 +83,9 @@
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
   id: ClothingOuterSuitAtmosFire
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: atmos fire suit
   description: An expensive firesuit that protects against even the most deadly of station fires. Designed to protect even if the wearer is set aflame.
   components:
@@ -119,6 +125,9 @@
 - type: entity
   parent: [ClothingOuterBaseLarge, GeigerCounterClothing, AllowSuitStorageClothing]
   id: ClothingOuterSuitRad
+  # ES Start
+  categories: [ HideSpawnMenu ]
+  # ES End
   name: radiation suit
   description: "A suit that protects against radiation. The label reads, 'Made with lead. Please do not consume insulation.'"
   components:

--- a/Resources/Prototypes/_ES/Catalog/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Crates/crates.yml
@@ -357,11 +357,11 @@
           amount: 2
         - id: FireExtinguisher
           amount: 2
-        - id: ClothingHeadHelmetFire
+        - id: ESClothingHeadHelmetFire
           amount: 2
         - id: ClothingMaskGas
           amount: 2
-        - id: ClothingOuterSuitFire
+        - id: ESClothingOuterSuitFire
           amount: 2
         - id: OxygenTankFilled
           amount: 2

--- a/Resources/Prototypes/_ES/Catalog/Tables/protective_suits.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/protective_suits.yml
@@ -1,0 +1,38 @@
+- type: entityTable
+  id: ESFillLockerFireStandard
+  table: !type:AllSelector
+    children:
+    - id: ESClothingOuterSuitFire
+    - id: ESClothingHeadHelmetFire
+    - id: ClothingMaskGas
+    - !type:GroupSelector
+      children:
+      - id: EmergencyOxygenTankFilled
+      - id: OxygenTankFilled
+    - id: CrowbarRed
+    - !type:GroupSelector
+      children:
+      - id: FireExtinguisher
+        weight: 98
+      - id: SprayBottleWater #It's just budget cut after budget cut man
+        weight: 2
+
+- type: entityTable
+  id: ESFillBiohazardSuit 
+  table: !type:AllSelector
+    children:
+    - id: ESClothingHeadHatHoodBio
+    - id: ESClothingOuterSuitBio
+
+- type: entityTable
+  id: ESFillRadiationSuit
+  table: !type:AllSelector
+    children:
+    - id: ESClothingHeadHatHoodRadiation
+      amount: 2
+    - id: ESClothingOuterSuitRadiation
+      amount: 2
+    - id: GeigerCounter
+      amount: 2
+    - id: PillCanisterPotassiumIodide
+      prob: 0.75

--- a/Resources/Prototypes/_ES/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Hands/gloves.yml
@@ -3,7 +3,8 @@
   parent: ClothingHandsGlovesSyntheticBase
   id: ESClothingHandsGlovesColorOrange
   name: sanitation gloves
-  description: Biohazard-resistant orange gloves. Useful for preventing injuries from chemical spills.
+  description: Biohazard-resistant orange gloves. Useful for preventing contamination.
+  suffix: ES
   components:
   - type: Sprite
     sprite: Clothing/Hands/Gloves/Color/color.rsi

--- a/Resources/Prototypes/_ES/Entities/Clothing/Head/protective_helmets.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Head/protective_helmets.yml
@@ -1,0 +1,87 @@
+- type: entity
+  parent: ClothingHeadLightBase
+  id: ESClothingHeadHelmetFire
+  name: fire helmet
+  suffix: ES
+  description: An atmos tech's best friend. Provides some heat resistance and looks cool.
+  components:
+  - type: Sprite
+    sprite: Clothing/Head/Helmets/firehelmet.rsi
+    layers:
+    - state: icon
+    - state: light-icon
+      shader: unshaded
+      visible: false
+      map: [ "light" ]
+  - type: Clothing
+    sprite: Clothing/Head/Helmets/firehelmet.rsi
+    equippedPrefix: off
+    quickEquip: true
+  - type: IngestionBlocker
+  - type: TemperatureProtection
+    heatingCoefficient: 0.5
+    coolingCoefficient: 0.8
+  - type: FireProtection
+    reduction: 0.15
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+    - FireHelmet
+  - type: HideLayerClothing
+    layers:
+      Hair: HEAD
+      Snout: HEAD
+  - type: ESChameleonClothingWhitelist
+
+- type: entity
+  parent: ClothingHeadBase
+  id: ESClothingHeadHatHoodRadiation
+  name: radiation hood
+  suffix: ES
+  description: A piece of protective gear that helps protect against low levels of radiation. It would be pretty stupid to wear this without a radiation suit.
+  components:
+  - type: Sprite
+    sprite: Clothing/Head/Hoods/rad.rsi
+  - type: Clothing
+    sprite: Clothing/Head/Hoods/rad.rsi
+  - type: BreathMask
+  - type: IngestionBlocker
+  - type: Armor
+    modifiers:
+      flatReductions:
+        Radiation: 1 #4DT total with the full set, split between helmet and suit until we get locational damage
+  - type: IdentityBlocker
+  - type: HideLayerClothing
+    slots:
+    - Hair
+    - Snout
+    - HeadTop
+    - HeadSide
+  - type: ESVoiceObfuscator
+  - type: ESChameleonClothingWhitelist
+
+- type: entity
+  parent: ClothingHeadBase
+  id: ESClothingHeadHatHoodBiological
+  name: bio hood
+  suffix: ES
+  description: A piece of protective gear that protects the head and face from biological contaminants.
+  components:
+  - type: Sprite
+    sprite: Clothing/Head/Hoods/Bio/general.rsi
+  - type: Clothing
+    sprite: Clothing/Head/Hoods/Bio/general.rsi
+  - type: BreathMask
+  - type: IngestionBlocker
+  - type: GroupExamine
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+  - type: HideLayerClothing
+    layers:
+      Hair: HEAD
+      Snout: HEAD
+      HeadTop: HEAD
+      HeadSide: HEAD
+  - type: ESVoiceObfuscator
+  - type: ESChameleonClothingWhitelist

--- a/Resources/Prototypes/_ES/Entities/Clothing/Head/protective_helmets.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Head/protective_helmets.yml
@@ -62,7 +62,7 @@
 
 - type: entity
   parent: ClothingHeadBase
-  id: ESClothingHeadHatHoodBiological
+  id: ESClothingHeadHatHoodBio
   name: bio hood
   suffix: ES
   description: A piece of protective gear that protects the head and face from biological contaminants.

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/protective_suits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/protective_suits.yml
@@ -1,0 +1,76 @@
+- type: entity
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
+  id: ESClothingOuterSuitFire
+  name: fire suit
+  suffix: ES
+  description: A suit that helps protect against hazardous temperatures.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Suits/fire.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Suits/fire.rsi
+  - type: PressureProtection
+    highPressureMultiplier: 0.04
+  - type: TemperatureProtection
+    heatingCoefficient: 0.005
+    coolingCoefficient: 0.05
+  - type: FireProtection
+    reduction: 0.65
+  - type: Armor
+    modifiers:
+      flatReductions:
+        Slash: 1
+        Heat: 4
+        Cold: 4
+  - type: ClothingSpeedModifier
+    walkModifier: 0.7
+    sprintModifier: 0.7
+  - type: HeldSpeedModifier
+  - type: GroupExamine
+  - type: ProtectedFromStepTriggers
+    slots: WITHOUT_POCKET
+  - type: HideLayerClothing
+    slots:
+    - Tail
+  - type: ESChameleonClothingWhitelist
+
+- type: entity
+  parent: [ClothingOuterBaseLarge, GeigerCounterClothing, AllowSuitStorageClothing]
+  id: ESClothingOuterSuitRadiation
+  name: radiation suit
+  suffix: ES
+  description: A suit that helps protect against low levels of radiation.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Suits/rad.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Suits/rad.rsi
+  - type: Armor
+    modifiers:
+      flatReductions:
+        Heat: 1
+        Radiation: 3 #4DT total with the full set, split between helmet and suit until we get locational damage
+  - type: ClothingSpeedModifier
+    walkModifier: 0.90
+    sprintModifier: 0.90
+  - type: GroupExamine
+  - type: ProtectedFromStepTriggers
+    slots: WITHOUT_POCKET
+  - type: HideLayerClothing
+    slots:
+    - Tail
+  - type: ESChameleonClothingWhitelist
+
+  id: ClothingOuterBioGeneral
+  name: bio suit
+  suffix: ES
+  description: A suit that helps protect against dangerous biohazards.
+  components:
+  - type: Sprite
+    sprite: Clothing/OuterClothing/Bio/general.rsi
+  - type: Clothing
+    sprite: Clothing/OuterClothing/Bio/general.rsi
+  - type: HideLayerClothing
+    slots:
+    - Tail
+  - type: GroupExamine

--- a/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/protective_suits.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/OuterClothing/protective_suits.yml
@@ -61,7 +61,9 @@
     - Tail
   - type: ESChameleonClothingWhitelist
 
-  id: ClothingOuterBioGeneral
+- type: entity
+  parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
+  id: ESClothingOuterSuitBio
   name: bio suit
   suffix: ES
   description: A suit that helps protect against dangerous biohazards.

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -263,6 +263,19 @@ WardrobeSecurityFilled: ESWardrobeSecurityFilled
 
 # 2026-2-3
 LockerAtmosphericsFilled: ESLockerAtmosphericsFilled
+
+# 2026-2-5
+# NOTE: There are too many biosuits for me to want to bother reasonably changing, especially considering they will almost always spawn from a locker anyways.
+ClothingHandsGlovesColorOrange: ESClothingHandsGlovesColorOrange
+ClothingHeadHelmetFire: ESClothingHeadHelmetFire
+ClothingHeadHelmetAtmosFire: ESClothingHeadHelmetFire
+ClothingOuterSuitFire: ESClothingOuterSuitFire
+ClothingOuterSuitAtmosFire: ESClothingOuterSuitFire
+ClothingHeadHatHoodRad: ESClothingHeadHatHoodRadiation
+ClothingOuterSuitRad: ESClothingOuterSuitRadiation
+ClothingHeadHatHoodBioGeneral: ESClothingHeadHatHoodBio
+ClothingOuterBioGeneral: ESClothingOuterSuitBio
+
 # ES END
 
 # 2023-07-03

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -265,16 +265,29 @@ WardrobeSecurityFilled: ESWardrobeSecurityFilled
 LockerAtmosphericsFilled: ESLockerAtmosphericsFilled
 
 # 2026-2-5
-# NOTE: There are too many biosuits for me to want to bother reasonably changing, especially considering they will almost always spawn from a locker anyways.
 ClothingHandsGlovesColorOrange: ESClothingHandsGlovesColorOrange
 ClothingHeadHelmetFire: ESClothingHeadHelmetFire
 ClothingHeadHelmetAtmosFire: ESClothingHeadHelmetFire
 ClothingOuterSuitFire: ESClothingOuterSuitFire
 ClothingOuterSuitAtmosFire: ESClothingOuterSuitFire
-ClothingHeadHatHoodRad: ESClothingHeadHatHoodRadiation
 ClothingOuterSuitRad: ESClothingOuterSuitRadiation
 ClothingHeadHatHoodBioGeneral: ESClothingHeadHatHoodBio
 ClothingOuterBioGeneral: ESClothingOuterSuitBio
+# There are so many fucking biosuits
+ClothingHeadHatHoodBioCmo: ESClothingHeadHatHoodBio
+ClothingOuterBioCmo: ESClothingOuterSuitBio
+ClothingHeadHatHoodBioJanitor: ESClothingHeadHatHoodBio
+ClothingOuterBioJanitor: ESClothingOuterSuitBio
+ClothingHeadHatHoodBioScientist: ESClothingHeadHatHoodBio
+ClothingOuterBioScientist: ESClothingOuterSuitBio
+ClothingHeadHatHoodBioSecurity: ESClothingHeadHatHoodBio
+ClothingOuterBioSecurity: ESClothingOuterSuitBio
+ClothingHeadHatHoodBioVirology: ESClothingHeadHatHoodBio
+ClothingOuterBioVirology: ESClothingOuterSuitBio
+ClosetL3VirologyFilled: ClosetL3Filled
+ClosetL3SecurityFilled: ClosetL3Filled
+ClosetL3JanitorFilled: ClosetL3Filled
+ClosetL3ScienceFilled: ClosetL3Filled
 
 # ES END
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Makes protective suit prototypes for the bio/fire/rad suits, and converts their values to DT.
Also removes the duplicate sanitation gloves.

Fixes #987
Fixes #1058
partial work on #1064