### PR TITLE
Toast map update

### DIFF
--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 02/07/2026 08:17:45
+  time: 02/07/2026 17:21:36
   entityCount: 14542
 maps:
 - 3
@@ -1444,7 +1444,8 @@ entities:
           1,-3:
             0: 65327
           1,-2:
-            0: 65535
+            0: 64511
+            1: 1024
           1,-1:
             0: 65295
           1,-5:
@@ -3961,6 +3962,74 @@ entities:
     - type: Transform
       pos: -72.5,1.5
       parent: 2
+- proto: AirlockExternal
+  entities:
+  - uid: 7360
+    components:
+    - type: Transform
+      pos: 11.5,28.5
+      parent: 2
+  - uid: 7443
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -74.5,-24.5
+      parent: 2
+  - uid: 7444
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -72.5,-24.5
+      parent: 2
+  - uid: 7639
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -61.5,-39.5
+      parent: 2
+  - uid: 7640
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -63.5,-41.5
+      parent: 2
+  - uid: 12685
+    components:
+    - type: Transform
+      pos: -66.5,19.5
+      parent: 2
+  - uid: 12686
+    components:
+    - type: Transform
+      pos: -64.5,19.5
+      parent: 2
+  - uid: 12687
+    components:
+    - type: Transform
+      pos: -20.5,21.5
+      parent: 2
+  - uid: 12688
+    components:
+    - type: Transform
+      pos: -20.5,23.5
+      parent: 2
+  - uid: 12707
+    components:
+    - type: Transform
+      pos: 11.5,30.5
+      parent: 2
+  - uid: 14084
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-53.5
+      parent: 2
+  - uid: 14085
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-55.5
+      parent: 2
 - proto: AirlockExternalEngineeringLocked
   entities:
   - uid: 6428
@@ -4042,74 +4111,6 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-59.5
-      parent: 2
-- proto: AirlockExternal
-  entities:
-  - uid: 7360
-    components:
-    - type: Transform
-      pos: 11.5,28.5
-      parent: 2
-  - uid: 7443
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -74.5,-24.5
-      parent: 2
-  - uid: 7444
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -72.5,-24.5
-      parent: 2
-  - uid: 7639
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -61.5,-39.5
-      parent: 2
-  - uid: 7640
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -63.5,-41.5
-      parent: 2
-  - uid: 12685
-    components:
-    - type: Transform
-      pos: -66.5,19.5
-      parent: 2
-  - uid: 12686
-    components:
-    - type: Transform
-      pos: -64.5,19.5
-      parent: 2
-  - uid: 12687
-    components:
-    - type: Transform
-      pos: -20.5,21.5
-      parent: 2
-  - uid: 12688
-    components:
-    - type: Transform
-      pos: -20.5,23.5
-      parent: 2
-  - uid: 12707
-    components:
-    - type: Transform
-      pos: 11.5,30.5
-      parent: 2
-  - uid: 14084
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-53.5
-      parent: 2
-  - uid: 14085
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-55.5
       parent: 2
 - proto: AirlockFreezer
   entities:
@@ -4976,20 +4977,20 @@ entities:
       parent: 2
 - proto: AnomalyLocator
   entities:
-  - uid: 14605
+  - uid: 348
     components:
     - type: Transform
-      pos: 9.1596775,-16.13976
+      pos: 2.8228362,-3.973947
       parent: 2
-  - uid: 14606
+  - uid: 431
     components:
     - type: Transform
-      pos: 9.448313,-16.347767
+      pos: 2.5181487,-4.2786345
       parent: 2
-  - uid: 14607
+  - uid: 436
     components:
     - type: Transform
-      pos: 9.680185,-16.542042
+      pos: 2.2134612,-4.5130095
       parent: 2
 - proto: APCBasic
   entities:
@@ -17252,11 +17253,6 @@ entities:
     - type: Transform
       pos: -19.5,-26.5
       parent: 2
-  - uid: 3636
-    components:
-    - type: Transform
-      pos: -18.5,-26.5
-      parent: 2
   - uid: 3682
     components:
     - type: Transform
@@ -26201,7 +26197,7 @@ entities:
   - uid: 530
     components:
     - type: Transform
-      pos: 19.5,-16.5
+      pos: 19.518803,-12.970959
       parent: 2
 - proto: CableMVStack1
   entities:
@@ -30487,6 +30483,41 @@ entities:
       parent: 2
 - proto: ClosetEmergencyFilledRandom
   entities:
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 13.5,-24.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: -23.5,-34.5
+      parent: 2
+  - uid: 2765
+    components:
+    - type: Transform
+      pos: 5.5,-33.5
+      parent: 2
+  - uid: 3630
+    components:
+    - type: Transform
+      pos: -63.5,-27.5
+      parent: 2
+  - uid: 3636
+    components:
+    - type: Transform
+      pos: -73.5,-10.5
+      parent: 2
+  - uid: 3694
+    components:
+    - type: Transform
+      pos: 14.5,-37.5
+      parent: 2
+  - uid: 5014
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 2
   - uid: 5015
     components:
     - type: Transform
@@ -30522,10 +30553,25 @@ entities:
     - type: Transform
       pos: -19.5,-25.5
       parent: 2
+  - uid: 7630
+    components:
+    - type: Transform
+      pos: 23.5,-3.5
+      parent: 2
   - uid: 7763
     components:
     - type: Transform
       pos: -51.5,-46.5
+      parent: 2
+  - uid: 7764
+    components:
+    - type: Transform
+      pos: -22.5,-52.5
+      parent: 2
+  - uid: 7772
+    components:
+    - type: Transform
+      pos: -63.5,22.5
       parent: 2
   - uid: 7775
     components:
@@ -30541,6 +30587,16 @@ entities:
     components:
     - type: Transform
       pos: -56.5,-35.5
+      parent: 2
+  - uid: 7900
+    components:
+    - type: Transform
+      pos: -22.5,20.5
+      parent: 2
+  - uid: 7908
+    components:
+    - type: Transform
+      pos: 10.5,24.5
       parent: 2
   - uid: 8148
     components:
@@ -30562,6 +30618,16 @@ entities:
     - type: Transform
       pos: -47.5,13.5
       parent: 2
+  - uid: 11524
+    components:
+    - type: Transform
+      pos: 13.5,-50.5
+      parent: 2
+  - uid: 11599
+    components:
+    - type: Transform
+      pos: 31.5,-11.5
+      parent: 2
   - uid: 14063
     components:
     - type: Transform
@@ -30579,10 +30645,45 @@ entities:
     - type: Transform
       pos: 3.5,-11.5
       parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 13.5,-23.5
+      parent: 2
+  - uid: 2832
+    components:
+    - type: Transform
+      pos: 14.5,14.5
+      parent: 2
+  - uid: 3169
+    components:
+    - type: Transform
+      pos: 2.5,-27.5
+      parent: 2
+  - uid: 3632
+    components:
+    - type: Transform
+      pos: -23.5,-33.5
+      parent: 2
   - uid: 4228
     components:
     - type: Transform
       pos: -50.5,-5.5
+      parent: 2
+  - uid: 5011
+    components:
+    - type: Transform
+      pos: 23.5,-4.5
+      parent: 2
+  - uid: 6256
+    components:
+    - type: Transform
+      pos: 14.5,-38.5
+      parent: 2
+  - uid: 6606
+    components:
+    - type: Transform
+      pos: 4.5,13.5
       parent: 2
   - uid: 7555
     components:
@@ -30594,20 +30695,55 @@ entities:
     - type: Transform
       pos: -6.5,-38.5
       parent: 2
+  - uid: 7722
+    components:
+    - type: Transform
+      pos: -27.5,-49.5
+      parent: 2
   - uid: 7762
     components:
     - type: Transform
       pos: -47.5,15.5
+      parent: 2
+  - uid: 7773
+    components:
+    - type: Transform
+      pos: -62.5,22.5
       parent: 2
   - uid: 7777
     components:
     - type: Transform
       pos: -43.5,-44.5
       parent: 2
+  - uid: 7902
+    components:
+    - type: Transform
+      pos: -21.5,20.5
+      parent: 2
+  - uid: 7909
+    components:
+    - type: Transform
+      pos: 9.5,24.5
+      parent: 2
   - uid: 8922
     components:
     - type: Transform
       pos: -15.5,-3.5
+      parent: 2
+  - uid: 11573
+    components:
+    - type: Transform
+      pos: 12.5,-50.5
+      parent: 2
+  - uid: 11575
+    components:
+    - type: Transform
+      pos: -62.5,-33.5
+      parent: 2
+  - uid: 11598
+    components:
+    - type: Transform
+      pos: -41.5,-29.5
       parent: 2
   - uid: 14065
     components:
@@ -30640,10 +30776,20 @@ entities:
       parent: 2
 - proto: ClosetRadiationSuitFilled
   entities:
-  - uid: 581
+  - uid: 7349
     components:
     - type: Transform
-      pos: 3.5,-13.5
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 11608
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 2
+  - uid: 11609
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
       parent: 2
 - proto: ClothingBeltChampion
   entities:
@@ -31161,13 +31307,6 @@ entities:
     components:
     - type: Transform
       pos: 32.5,7.5
-      parent: 2
-- proto: ComputerBroken
-  entities:
-  - uid: 432
-    components:
-    - type: Transform
-      pos: 3.5,-5.5
       parent: 2
 - proto: ComputerComms
   entities:
@@ -36225,6 +36364,23 @@ entities:
     - type: Transform
       pos: -25.5,9.5
       parent: 2
+- proto: ESAnomalyResonator
+  entities:
+  - uid: 11600
+    components:
+    - type: Transform
+      pos: 3.5642586,-3.5
+      parent: 2
+  - uid: 11611
+    components:
+    - type: Transform
+      pos: 2.9670362,-3.5
+      parent: 2
+  - uid: 11715
+    components:
+    - type: Transform
+      pos: 2.4253695,-3.5
+      parent: 2
 - proto: ESAntimatterCapsule
   entities:
   - uid: 6607
@@ -36945,6 +37101,18 @@ entities:
     components:
     - type: Transform
       pos: 32.55152,-6.3524656
+      parent: 2
+- proto: ESComputerAnomaly
+  entities:
+  - uid: 11610
+    components:
+    - type: Transform
+      pos: 19.5,-16.5
+      parent: 2
+  - uid: 11613
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
       parent: 2
 - proto: ESComputerCrewMonitoringTabletop
   entities:
@@ -39752,11 +39920,6 @@ entities:
     - type: Transform
       pos: -19.5,-37.5
       parent: 2
-  - uid: 6606
-    components:
-    - type: Transform
-      pos: -17.5,-39.5
-      parent: 2
   - uid: 6620
     components:
     - type: Transform
@@ -39766,6 +39929,23 @@ entities:
     components:
     - type: Transform
       pos: -17.5,-38.5
+      parent: 2
+- proto: ESSpawnerMarkerDistributedTechStorageMats
+  entities:
+  - uid: 11605
+    components:
+    - type: Transform
+      pos: -19.5,-39.5
+      parent: 2
+  - uid: 11614
+    components:
+    - type: Transform
+      pos: -20.5,-39.5
+      parent: 2
+  - uid: 11615
+    components:
+    - type: Transform
+      pos: -17.5,-39.5
       parent: 2
 - proto: ESSpawnerMarkerDistributedTechStorageSecure
   entities:
@@ -39807,6 +39987,13 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-38.5
+      parent: 2
+- proto: ESSpawnerRandomDistributedTechStorageMats
+  entities:
+  - uid: 11716
+    components:
+    - type: Transform
+      pos: -20.5,-38.5
       parent: 2
 - proto: ESSpawnerRandomDistributedTechStorageSecure
   entities:
@@ -40418,157 +40605,23 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomMaintClosetsEmergency
   entities:
-  - uid: 535
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-24.5
-      parent: 2
-  - uid: 2765
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-23.5
-      parent: 2
-  - uid: 2832
-    components:
-    - type: Transform
-      pos: -23.5,-33.5
-      parent: 2
-  - uid: 3169
-    components:
-    - type: Transform
-      pos: 5.5,-33.5
-      parent: 2
-  - uid: 3630
-    components:
-    - type: Transform
-      pos: 14.5,14.5
-      parent: 2
-  - uid: 3632
-    components:
-    - type: Transform
-      pos: 2.5,-27.5
-      parent: 2
-  - uid: 3694
-    components:
-    - type: Transform
-      pos: -63.5,-27.5
-      parent: 2
   - uid: 3707
     components:
     - type: Transform
       pos: -59.5,5.5
-      parent: 2
-  - uid: 5011
-    components:
-    - type: Transform
-      pos: -23.5,-34.5
-      parent: 2
-  - uid: 6256
-    components:
-    - type: Transform
-      pos: -73.5,-10.5
-      parent: 2
-  - uid: 7630
-    components:
-    - type: Transform
-      pos: 14.5,-38.5
-      parent: 2
-  - uid: 7764
-    components:
-    - type: Transform
-      pos: 23.5,-3.5
-      parent: 2
-  - uid: 7772
-    components:
-    - type: Transform
-      pos: 3.5,13.5
       parent: 2
   - uid: 7780
     components:
     - type: Transform
       pos: -38.5,11.5
       parent: 2
-  - uid: 7900
-    components:
-    - type: Transform
-      pos: 14.5,-37.5
-      parent: 2
-  - uid: 7908
-    components:
-    - type: Transform
-      pos: 4.5,13.5
-      parent: 2
-  - uid: 7909
-    components:
-    - type: Transform
-      pos: 23.5,-4.5
-      parent: 2
-  - uid: 12799
-    components:
-    - type: Transform
-      pos: -27.5,-50.5
-      parent: 2
-  - uid: 12836
-    components:
-    - type: Transform
-      pos: -22.5,-52.5
-      parent: 2
   - uid: 12923
     components:
     - type: Transform
       pos: -46.5,17.5
       parent: 2
-  - uid: 13101
-    components:
-    - type: Transform
-      pos: -63.5,22.5
-      parent: 2
-  - uid: 13102
-    components:
-    - type: Transform
-      pos: -62.5,22.5
-      parent: 2
-  - uid: 13238
-    components:
-    - type: Transform
-      pos: -22.5,20.5
-      parent: 2
-  - uid: 13239
-    components:
-    - type: Transform
-      pos: -21.5,20.5
-      parent: 2
-  - uid: 13302
-    components:
-    - type: Transform
-      pos: 9.5,24.5
-      parent: 2
-  - uid: 13304
-    components:
-    - type: Transform
-      pos: 10.5,24.5
-      parent: 2
-  - uid: 13938
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 12.5,-50.5
-      parent: 2
-  - uid: 14103
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,-50.5
-      parent: 2
 - proto: ESSpawnerRandomMaintClosetsEmergencyOrTertiary
   entities:
-  - uid: 5014
-    components:
-    - type: Transform
-      pos: -20.5,-25.5
-      parent: 2
   - uid: 6370
     components:
     - type: Transform
@@ -40579,37 +40632,32 @@ entities:
     - type: Transform
       pos: -44.5,-38.5
       parent: 2
-  - uid: 7722
-    components:
-    - type: Transform
-      pos: -62.5,-33.5
-      parent: 2
-  - uid: 7773
-    components:
-    - type: Transform
-      pos: 26.5,-8.5
-      parent: 2
-  - uid: 7902
-    components:
-    - type: Transform
-      pos: -40.5,-29.5
-      parent: 2
   - uid: 8235
     components:
     - type: Transform
       pos: -23.5,8.5
       parent: 2
-  - uid: 14206
-    components:
-    - type: Transform
-      pos: 3.5,-55.5
-      parent: 2
 - proto: ESSpawnerRandomMaintClosetsTertiary
   entities:
+  - uid: 430
+    components:
+    - type: Transform
+      pos: -20.5,-25.5
+      parent: 2
   - uid: 8149
     components:
     - type: Transform
       pos: 22.5,2.5
+      parent: 2
+  - uid: 11574
+    components:
+    - type: Transform
+      pos: -40.5,-29.5
+      parent: 2
+  - uid: 11576
+    components:
+    - type: Transform
+      pos: 26.5,-8.5
       parent: 2
   - uid: 13240
     components:
@@ -44305,10 +44353,10 @@ entities:
       fixtures: {}
 - proto: FaxMachineBase
   entities:
-  - uid: 348
+  - uid: 581
     components:
     - type: Transform
-      pos: 2.5,-3.5
+      pos: 9.5,-15.5
       parent: 2
     - type: FaxMachine
       name: Science
@@ -44350,6 +44398,8 @@ entities:
     - type: Transform
       pos: -29.5,-26.5
       parent: 2
+    - type: FaxMachine
+      name: Security
   - uid: 4215
     components:
     - type: Transform
@@ -44369,6 +44419,8 @@ entities:
     - type: Transform
       pos: -23.5,4.5
       parent: 2
+    - type: FaxMachine
+      name: HOS
   - uid: 5120
     components:
     - type: Transform
@@ -44381,6 +44433,8 @@ entities:
     - type: Transform
       pos: -66.5,6.5
       parent: 2
+    - type: FaxMachine
+      name: Library
 - proto: FaxMachineCaptain
   entities:
   - uid: 2438
@@ -44431,11 +44485,6 @@ entities:
     components:
     - type: Transform
       pos: -39.5,-15.5
-      parent: 2
-  - uid: 7349
-    components:
-    - type: Transform
-      pos: 6.5,-3.5
       parent: 2
   - uid: 8796
     components:
@@ -64044,6 +64093,9 @@ entities:
     - type: Transform
       pos: 7.5,-6.5
       parent: 2
+    - type: AccessReader
+      accessListsOriginal:
+      - - Research
 - proto: LockerSecurityFilled
   entities:
   - uid: 1404
@@ -64134,28 +64186,10 @@ entities:
       parent: 2
 - proto: MachineAPE
   entities:
-  - uid: 507
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-15.5
-      parent: 2
   - uid: 7506
     components:
     - type: Transform
       pos: -53.5,10.5
-      parent: 2
-  - uid: 14571
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-16.5
-      parent: 2
-  - uid: 14585
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 11.5,-17.5
       parent: 2
   - uid: 14599
     components:
@@ -64212,16 +64246,6 @@ entities:
       parent: 2
 - proto: MachineFrameDestroyed
   entities:
-  - uid: 430
-    components:
-    - type: Transform
-      pos: 3.5,-7.5
-      parent: 2
-  - uid: 431
-    components:
-    - type: Transform
-      pos: 2.5,-5.5
-      parent: 2
   - uid: 479
     components:
     - type: Transform
@@ -64251,11 +64275,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-58.5
-      parent: 2
-  - uid: 14290
-    components:
-    - type: Transform
-      pos: 2.5,-7.5
       parent: 2
 - proto: MaintenanceFluffSpawner
   entities:
@@ -64725,6 +64744,13 @@ entities:
 
 
         The engine should now be operational. It will likely need refueling partway through the shift. Additional canisters can be found in the secure storage.
+- proto: PaperBin
+  entities:
+  - uid: 11616
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
 - proto: PaperBin10
   entities:
   - uid: 1257
@@ -64828,12 +64854,6 @@ entities:
     components:
     - type: Transform
       pos: -36.5,-34.5
-      parent: 2
-  - uid: 14543
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-4.5
       parent: 2
 - proto: PartRodMetal
   entities:
@@ -65927,11 +65947,6 @@ entities:
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 436
-    components:
-    - type: Transform
-      pos: 3.5,-3.5
-      parent: 2
   - uid: 442
     components:
     - type: Transform
@@ -65963,6 +65978,11 @@ entities:
     components:
     - type: Transform
       pos: -21.5,-37.5
+      parent: 2
+  - uid: 11606
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
       parent: 2
 - proto: PoweredDimSmallLight
   entities:
@@ -66703,6 +66723,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 18.5,-17.5
       parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      pos: -20.5,-39.5
+      parent: 2
   - uid: 521
     components:
     - type: Transform
@@ -67080,6 +67105,11 @@ entities:
     components:
     - type: Transform
       pos: 22.5,1.5
+      parent: 2
+  - uid: 11607
+    components:
+    - type: Transform
+      pos: -19.5,-39.5
       parent: 2
   - uid: 11856
     components:
@@ -69337,6 +69367,8 @@ entities:
     - type: Transform
       pos: 5.5,-2.5
       parent: 2
+    - type: DeviceLinkSink
+      invokeCounter: 1
   - uid: 14449
     components:
     - type: Transform
@@ -69875,6 +69907,8 @@ entities:
     - type: Transform
       pos: 7.5,-2.5
       parent: 2
+    - type: SignalSwitch
+      state: True
     - type: DeviceLinkSource
       linkedPorts:
         7186:
@@ -69892,6 +69926,8 @@ entities:
           - Open
         - - Off
           - Close
+      lastSignals:
+        Status: True
     - type: Fixtures
       fixtures: {}
   - uid: 988
@@ -74013,6 +74049,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 13.5,-20.5
       parent: 2
+  - uid: 11612
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 11717
+    components:
+    - type: Transform
+      pos: 9.5,-15.5
+      parent: 2
   - uid: 11857
     components:
     - type: Transform
@@ -74178,16 +74224,6 @@ entities:
     - type: Transform
       pos: -9.5,-53.5
       parent: 2
-  - uid: 14600
-    components:
-    - type: Transform
-      pos: 9.5,-15.5
-      parent: 2
-  - uid: 14601
-    components:
-    - type: Transform
-      pos: 9.5,-16.5
-      parent: 2
 - proto: TableCarpet
   entities:
   - uid: 2462
@@ -74295,12 +74331,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-13.5
-      parent: 2
-  - uid: 686
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 19.5,-16.5
       parent: 2
   - uid: 688
     components:
@@ -75603,22 +75633,16 @@ entities:
     - type: Transform
       pos: 14.5,8.5
       parent: 2
-    - type: Physics
-      bodyType: Static
   - uid: 9293
     components:
     - type: Transform
       pos: 14.5,7.5
       parent: 2
-    - type: Physics
-      bodyType: Static
   - uid: 11521
     components:
     - type: Transform
       pos: 17.5,8.5
       parent: 2
-    - type: Physics
-      bodyType: Static
 - proto: WallReinforced
   entities:
   - uid: 26
@@ -87223,23 +87247,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,-39.5
-      parent: 2
-- proto: WeaponPistolCHIMP
-  entities:
-  - uid: 14602
-    components:
-    - type: Transform
-      pos: 9.270334,-15.219348
-      parent: 2
-  - uid: 14603
-    components:
-    - type: Transform
-      pos: 9.431589,-15.348376
-      parent: 2
-  - uid: 14604
-    components:
-    - type: Transform
-      pos: 9.588083,-15.569018
       parent: 2
 - proto: Welder
   entities:

--- a/Resources/Prototypes/_ES/Catalog/Tables/protective_suits.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/protective_suits.yml
@@ -18,7 +18,7 @@
         weight: 2
 
 - type: entityTable
-  id: ESFillBiohazardSuit 
+  id: ESFillBiohazardSuit
   table: !type:AllSelector
     children:
     - id: ESClothingHeadHatHoodBio
@@ -29,10 +29,10 @@
   table: !type:AllSelector
     children:
     - id: ESClothingHeadHatHoodRadiation
-      amount: 2
+      amount: 1
     - id: ESClothingOuterSuitRadiation
-      amount: 2
+      amount: 1
     - id: GeigerCounter
-      amount: 2
+      amount: 1
     - id: PillCanisterPotassiumIodide
       prob: 0.75

--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Distributed/tech.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Distributed/tech.yml
@@ -32,6 +32,7 @@
     - id: CrewMonitoringComputerCircuitboard
     # - id: MedicalRecordsComputerCircuitboard
     # Sci
+    - id: ESComputerAnomalyCircuitBoard
     # Sec
     - id: CriminalRecordsComputerCircuitboard
     - id: SurveillanceCameraMonitorCircuitboard


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
moves sci around to add the new anom console and gear. Also adds the tech vault spawners and adds the new sci board to that pool. 
All the random emergency lockers have been moved to static ones, to make map knowledge useful.
Gives the HoS fax a name because It bugged me last playtest.
Reduces radsuit in locker count from 2 -> 1.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="850" height="724" alt="image" src="https://github.com/user-attachments/assets/2565afca-15f2-4ad2-aaf3-4af027c67ace" />
