### PR TITLE
Round-end screen improvements

### DIFF
--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -6,6 +6,9 @@ using Robust.Client.UserInterface.Controls;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Utility;
 using static Robust.Client.UserInterface.Controls.BoxContainer;
+// ES START
+using Content.Client._ES.Core;
+// ES END
 
 namespace Content.Client.RoundEnd
 {
@@ -82,7 +85,9 @@ namespace Content.Client.RoundEnd
             if (!string.IsNullOrEmpty(roundEnd))
             {
                 var roundEndLabel = new RichTextLabel();
-                roundEndLabel.SetMarkup(roundEnd);
+// ES START
+                roundEndLabel.UnsafeSetMarkup(roundEnd);
+// ES END
                 roundEndSummaryContainer.AddChild(roundEndLabel);
             }
 

--- a/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
+++ b/Content.Client/RoundEnd/RoundEndSummaryWindow.cs
@@ -51,7 +51,10 @@ namespace Content.Client.RoundEnd
             var roundEndSummaryContainerScrollbox = new ScrollContainer
             {
                 VerticalExpand = true,
-                Margin = new Thickness(10)
+// ES START
+                Margin = new Thickness(10),
+                HScrollEnabled = false, // did you know that if this isn't set, richtext will never wrap?
+// ES END
             };
             var roundEndSummaryContainer = new BoxContainer
             {

--- a/Content.Shared/_ES/Masks/Components/ESMaskMemoryComponent.cs
+++ b/Content.Shared/_ES/Masks/Components/ESMaskMemoryComponent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Masks.Components;
+
+/// <summary>
+/// Used to store all masks that a given mind has received throughout the round.
+/// </summary>
+[RegisterComponent]
+[Access(typeof(ESSharedMaskSystem))]
+public sealed partial class ESMaskMemoryComponent : Component
+{
+    /// <summary>
+    /// The masks that this mind has had, in order from oldest to newest.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<ESMaskPrototype>> Masks = [];
+}

--- a/Resources/Locale/en-US/_ES/masks/roundend.ftl
+++ b/Resources/Locale/en-US/_ES/masks/roundend.ftl
@@ -3,11 +3,12 @@ es-roundend-mask-troupe-list = [font size=16]The [color={$color}][bold]{$name}[/
 es-roundend-mask-objective-fmt = {"    "}{$text}
 
 es-roundend-mask-player-summary-header = [font size=16]Our actors were playing the following roles:[/font]
-es-roundend-mask-player-summary = {$name} [color=gray]({$username})[/color] played {INDEFINITE($maskName)} [color={$maskColor}][bold]{$maskName}[/bold][/color] {$objCount ->
+es-roundend-mask-player-summary = {$name} [color=gray]({$username})[/color] played {INDEFINITE($maskName)} {$maskName} {$objCount ->
     [0] {""}
     *[Other] with the following objectives:
 }
+es-roundend-mask-fmt = [color={$color}][bold]{$name}[/bold][/color]
+es-roundend-mask-link-fmt = {$mask1}-turned-{$mask2}
 es-roundend-mask-player-group = [font size=14][color={$color}][bold]{$name}[/bold][/color][/font]
 
-es-roundend-masquerade-reveal = [font size=16]Annnd that's a wrap! Today's show was themed "{$masquerade}",
-                                which {$description}.[/font]
+es-roundend-masquerade-reveal = [font size=16]Annnd that's a wrap! Today's show was themed "{$masquerade}", which {$description}.[/font]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

changes:
- game now stores "mask memory" of all masks a given mind gets during a round, which can be reconstructed on the round end menu.
- round-end menu now actually does text wrapping instead of just having giant lines that need to be scrolled.
- font size actually fucking works

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="1200" height="1103" alt="image" src="https://github.com/user-attachments/assets/7c58a31d-3233-464e-9226-a3554ab80a78" />
