### PR TITLE
Remove interactions from cryosleep

### DIFF
--- a/Content.Server/_ES/Arrivals/ESArrivalsSystem.cs
+++ b/Content.Server/_ES/Arrivals/ESArrivalsSystem.cs
@@ -6,12 +6,12 @@ using Content.Server.Screens.Components;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Shuttles.Systems;
+using Content.Server.Spawners.Components;
 using Content.Server.Spawners.EntitySystems;
 using Content.Server.Station.Events;
 using Content.Server.Station.Systems;
 using Content.Shared._ES.CCVar;
 using Content.Shared._ES.Light.Components;
-using Content.Shared.Bed.Cryostorage;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.Gravity;
@@ -138,14 +138,14 @@ public sealed class ESArrivalsSystem : EntitySystem
         if (!TryComp<ESStationArrivalsComponent>(ev.Station, out var arrivals) || arrivals.ShuttleUid is not { } grid)
             return;
 
-        var points = EntityQueryEnumerator<CryostorageComponent, TransformComponent>();
+        var points = EntityQueryEnumerator<ContainerSpawnPointComponent, TransformComponent>();
         var possiblePositions = new List<(EntityUid, BaseContainer)>();
-        while (points.MoveNext(out var uid, out var cryo, out var xform))
+        while (points.MoveNext(out var uid, out var spawnPoint, out var xform))
         {
             if (xform.GridUid != grid)
                 continue;
 
-            if (!_container.TryGetContainer(uid, cryo.ContainerId, out var container) || container.ContainedEntities.Any())
+            if (!_container.TryGetContainer(uid, spawnPoint.ContainerId, out var container) || container.ContainedEntities.Any())
                 continue;
 
             possiblePositions.Add((uid, container));

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -611,7 +611,6 @@
     - Cargo
     - Chemistry
     - Command
-    - Cryogenics
     - Engineering
     - External
     - GenpopEnter

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/tabletop_computer.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/tabletop_computer.yml
@@ -276,7 +276,6 @@
     - Cargo
     - Chemistry
     - Command
-    - Cryogenics
     - Engineering
     - External
     - GenpopEnter

--- a/Resources/Prototypes/_ES/Entities/Structures/hypersleep.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/hypersleep.yml
@@ -1,0 +1,48 @@
+- type: entity
+  parent: BaseStructure
+  id: ESHypersleepPod
+  name: hypersleep pod
+  description: A long-term storage container used for transporting unsuspecting crew to their doom.
+  suffix: ES
+  components:
+  - type: Sprite
+    noRot: true
+    sprite: Structures/cryostorage.rsi
+    layers:
+    - state: sleeper_0
+      map: ["base"]
+  - type: Appearance
+  - type: ESItemMapper
+    mappings:
+      base:
+      - containerId: storage
+        state: sleeper_1
+      - containerId: storage #base empty state
+        state: sleeper_0
+        range:
+          min: 0
+          max: 0
+  - type: ContainerSpawnPoint
+    containerId: storage
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.05"
+        density: 190
+        mask:
+        - TableMask
+  - type: DragInsertContainer
+    containerId: storage
+    entryDelay: 2
+  - type: ExitContainerOnMove
+    containerId: storage
+  - type: PointLight
+    color: Lime
+    radius: 1.5
+    energy: 0.5
+    castShadows: false
+  - type: ContainerContainer
+    containers:
+      storage: !type:ContainerSlot

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_personnel.yml
@@ -19,7 +19,6 @@
   - Chapel
   - Hydroponics
   - External
-  - Cryogenics
   - Chemistry
   - Engineering
   - Research

--- a/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Command/head_of_security.yml
@@ -16,7 +16,6 @@
   - Maintenance
   - External
   - Detective
-  - Cryogenics
   - GenpopEnter
   - GenpopLeave
   special:

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/detective.yml
@@ -12,7 +12,6 @@
   - Brig
   - Maintenance
   - Detective
-  - Cryogenics
   - External
 
 - type: startingGear

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/security_officer.yml
@@ -12,7 +12,6 @@
   - Brig
   - Maintenance
   - External
-  - Cryogenics
 
 - type: startingGear
   id: ESSecurityOfficerGear

--- a/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/Security/warden.yml
@@ -14,7 +14,6 @@
   - Maintenance
   - External
   - Detective
-  - Cryogenics
   - GenpopEnter
   - GenpopLeave
 

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -309,6 +309,10 @@ Tourniquet: TourniquetOffbrand
 ESWardrobeMedicalDoctorFilled: ESWardrobePhysicianFilled
 ESWardrobeMedicalDoctor: ESWardrobePhysician
 
+# 2026-2-8
+CryogenicSleepUnitSpawner: ESHypersleepPod # this one is used for arrivals
+CryogenicSleepUnit: null
+CryogenicSleepUnitSpawnerLateJoin: null
 # ES END
 
 # 2023-07-03


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1109 

changes
- replaces cryosleep pods with new "hypersleep pod." This is basically just a container you spawn in. it doesn't have any unique functionality beyond that.
- removes cryogenics access from game
- migrates out all the pods on-station since they don't matter and aren't used for anything

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
