### PR TITLE
Remove riot shield from sectech

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/_ES/Catalog/VendingMachines/Inventories/sec.yml
@@ -10,7 +10,6 @@
     ClothingEyesGlassesSunglasses: 2
     ClothingEyesGlassesSecurity: 4
     ESWeaponKnife: 3
-    RiotShield: 2
     RadioHandheldSecurity: 5
   # security officers need to follow a diet regimen!
   contrabandInventory:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
title
I was gonna make an ES version with DT, but since we dont have weilding having one hand full doesnt really change anything in combat and the DT would stack to a new total of like 8 or 9 which is ridiculous so I just decided to axe it completely

closes #1115 
