### PR TITLE
Fix terminated objective targets not updating progress

### DIFF
--- a/Content.Shared/_ES/Objectives/Target/ESBaseTargetObjectiveSystem.cs
+++ b/Content.Shared/_ES/Objectives/Target/ESBaseTargetObjectiveSystem.cs
@@ -29,7 +29,7 @@ public abstract class ESBaseTargetObjectiveSystem<TComponent> : ESBaseObjectiveS
     [MustCallBase]
     protected virtual void OnTargetChanged(Entity<TComponent> ent, ref ESObjectiveTargetChangedEvent args)
     {
-        if (args.OldTarget is { } oldTarget)
+        if (args.OldTarget is { } oldTarget && !TerminatingOrDeleted(oldTarget))
         {
             foreach (var relayType in TargetRelayComponents)
             {

--- a/Content.Shared/_ES/Objectives/Target/ESTargetCodenameSystem.cs
+++ b/Content.Shared/_ES/Objectives/Target/ESTargetCodenameSystem.cs
@@ -20,6 +20,9 @@ public sealed class ESTargetCodenameSystem : EntitySystem
 
     private void GetCodename(Entity<ESTargetCodenameComponent> ent, ref ESObjectiveTargetChangedEvent args)
     {
+        if (args.NewTarget == null)
+            return;
+
         var usedCodenames = _objective.GetObjectives<ESTargetCodenameComponent>()
             .Where(o => o.Comp1.Codename.HasValue)
             .Select(o => (string) o.Comp1.Codename!.Value);


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1101 

noticed this last playtest when someone got meatspiked. When an objective target got terminated, it wouldn't actually refresh the objective with the new null target, which caused issues. Now it does that, so everything should work as its supposed to.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
