### PR TITLE
Nerf buckshot

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/boxes.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/boxes.yml
@@ -20,8 +20,9 @@
 
 - type: entity
   id: ESShotgunShellsBoxBuckshot
-  suffix: ES, Buckshot
   parent: ESShotgunShellsBox
+  description: An ammunition box containing buckshot shells for a shotgun.
+  suffix: ES, Buckshot
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/cartridge.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Ammunition/cartridge.yml
@@ -86,7 +86,7 @@
 - type: entity
   id: ESShellShotgunBuckshot
   name: shotgun shell
-  description: A 12-gauge buckshot shell.
+  description: A 12-gauge buckshot shell. It's good at dealing with unarmored targets.
   parent: ESBaseShellShotgun
   components:
   - type: CartridgeAmmo
@@ -96,7 +96,7 @@
   id: ESShellShotgunBeanbag
   name: beanbag slug
   parent: [ ESBaseShellShotgun, BaseSecurityBartenderContraband ]
-  description: A 12-gauge beanbag slug.
+  description: A 12-gauge beanbag slug. Useful for subduing unruly bar assiliants.
   components:
   - type: Tag
     tags:
@@ -115,7 +115,7 @@
 - type: entity
   id: ESShellShotgunSlug
   name: shotgun slug
-  description: A 12-gauge lead slug.
+  description: A 12-gauge lead slug. It can cleave through armor more effectively then the typical buckshot ammunition.
   parent: [ ESBaseShellShotgun, BaseSecurityContraband]
   components:
   - type: Sprite

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/bullet.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/bullet.yml
@@ -50,7 +50,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10
+        Piercing: 7
   - type: Tag
     tags:
     - ESShotgunPellet


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Makes buckshot do less damage per pellet, to make it more specialized-feeling & reign in its power a bit. It's distinctly bad against armor, now.

Also updates the shell descriptions to better reflect their niches.

## Media
[Content.Client_azdh6Pjd7c.webm](https://github.com/user-attachments/assets/c4dbcaf0-51ee-420e-9d98-6b43ef1c46a4)
