### PR TITLE
Maints loot changes part two

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -29,8 +29,6 @@
         weight: 0.1
     - tableId: ESMaintLootRare
       weight: 2
-    - tableId: ESMaintsTraitorLoot
-      weight: 0.5
 
 - type: entityTable
   id: ESMaintLootValuable
@@ -126,7 +124,6 @@
     - id: Igniter
     - id: Mousetrap
     - id: RemoteSignaller
-    - id: TimerTrigger
     - id: ESParcelWrap10
 
     - id: DoorElectronics
@@ -190,14 +187,13 @@
     - id: Bola
     - id: EmergencyRollerBedSpawnFolded
     - id: Spear
+    - id: BaseBallBat
     - id: WelderIndustrial
     - id: Plunger
     - id: Shovel
 
-    - id: ClothingEyesHudDiagnostic
     - id: ClothingEyesHudMedical
     - tableId: FillWelderSupplies # Welding masks
-    - id: ClothingBeltMedical
     - id: ClothingBeltUtility
     - id: ESClothingHeadHelmetSecurity
 
@@ -208,8 +204,6 @@
     - id: PowerCellHigh
       weight: 0.5
     - id: BoxHug
-    - id: ModularReceiver
-    - id: RifleStock
 
     - group:
       - id: Brutepack
@@ -222,7 +216,6 @@
     - id: DrinkFourteenLokoCan
     - id: DrinkSpaceGlue
     - id: DrinkSpaceLube
-    - id: DrinkMopwataBottleRandom
 
     - id: SprayBottle
     - id: SprayBottleSpaceCleaner
@@ -293,8 +286,10 @@
       - id: ClothingOuterCoatJensen
       - id: ClothingEyesGlassesJensen
       weight: 0.5
-    - id: ClothingShoesBootsLaceup
-    - id: ClothingShoesLeather
+    - group:
+      - id: ClothingShoesBootsLaceup
+      - id: ClothingShoesLeather
+      weight: 0.5
 
     - id: SpectralLocator
     - id: d20Dice
@@ -309,17 +304,14 @@
     - id: ESWeaponKnife
       weight: 2
     - id: Handcuffs
-    - id: MakeshiftShield
     - id: WelderIndustrialAdvanced
-    - id: BaseBallBat
     - id: Binoculars
-    - id: MedkitFilled
+    - id: ESMedkitFilled
 
     - id: ClothingEyesHudSecurity
     - id: ClothingEyesGlassesSunglasses
     - id: ClothingHandsGlovesColorYellow
     - id: ClothingHandsGlovesCombat
-    - id: ClothingBeltSecurity
     - id: ClothingShoesBootsJack
 
     - all: # Russian Outfit
@@ -345,5 +337,4 @@
       - id: CigarGold
       - id: WristwatchGold
       - id: RubberStampGreytide
-      - id: GoldenPersonalAI
       - id: ClothingNeckBling


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Resolves #1174
Resolves #1167
Resolves #1157

Removes assorted junk items such as mopwater, diagnostic hud, golden PAI, and sec/medical belts.
Leather and Laceup shoes made less common to match other cosmetics.

Baseball bat moved to be as rare as a spear opposed to twice as rare a a knife, which currently is far superior of a melee weapon.

Improvised gun and modular grenade parts are removed.

Also correct a minor error I made where syndicate items had their own pool when spawning on racks when they already spawned in the rare pool.