### PR TITLE
Add jesters into randomtraitors

### DIFF
--- a/Resources/Prototypes/_ES/MaskSets/alljesters.yml
+++ b/Resources/Prototypes/_ES/MaskSets/alljesters.yml
@@ -1,0 +1,4 @@
+- type: esMaskSet
+  id: AllJesters # Every jester, with their mask's weight.
+  maskProvider: !type:ESTroupeMasksProvider
+    troupe: ESJester

--- a/Resources/Prototypes/_ES/Masquerades/random.yml
+++ b/Resources/Prototypes/_ES/Masquerades/random.yml
@@ -11,8 +11,8 @@
     roles:
       1: [] # Greenshift.
       4: ["#AllTraitors"]
-      6: ["#AllTraitors"]
+      6: ["#AllTraitors", "#AllJesters"]
       13: ["#AllTraitors"]
-      19: ["#AllTraitors"]
-      25: ["#AllTraitors"]
+      19: ["#AllTraitors", "#AllJesters"]
+      25: ["#AllTraitors", "#AllJesters"]
       31: ["#AllTraitors"]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1153 

adds jesters back into randomtraitors after they were removed following being split out from crew troupe

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
