### PR TITLE
Removes shuttle wall rusting

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Walls/indestructible.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Walls/indestructible.yml
@@ -10,7 +10,6 @@
   - type: Icon
     sprite: Structures/Walls/shuttle.rsi
     state: full
-  - type: WallReplacementMarker
   - type: Fixtures
     fixtures:
       fix1:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Removes WallReplacementMarker for shuttle walls - just making them not rust at the roundstart and turn into normal walls.
This looked kind of goofy & shuttle walls are probably too Nice to justify making a custom texture for their rust - I can do that if there's interest, however.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
