### PR TITLE
Remove veggies from fruit vendor cache

### DIFF
--- a/Resources/Prototypes/_ES/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Fills/Crates/caches.yml
@@ -207,25 +207,17 @@
       entity_storage:
         group:
         - id: FoodBanana
-        - id: FoodCarrot
-        - id: FoodCabbage
-        - id: FoodGarlic
         - id: FoodLemon
         - id: FoodLime
         - id: FoodOrange
         - id: FoodPineapple
-        - id: FoodPotato
         - id: FoodTomato
-        - id: FoodEggplant
         - id: FoodApple
-        - id: FoodCorn
-        - id: FoodOnion
-        - id: FoodMushroom
-        - id: FoodChiliPepper
         - id: FoodWatermelon
         - id: FoodGrape
         - id: FoodPumpkin
         - id: FoodCherry
+        - id: FoodBerries
         rolls: 4, 5
 
 # Hitman


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
mirror pointed this out to me in vc today but like half of the fruit vendor items are vegetables and not actually fruits. idk why i never realized this its been like this since day 1.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
