### PR TITLE
Remove hitman, insider, and daredevil

### DIFF
--- a/Resources/Prototypes/_ES/MaskSets/antagonistic.yml
+++ b/Resources/Prototypes/_ES/MaskSets/antagonistic.yml
@@ -3,5 +3,5 @@
   masks:
     ESVandal: 0.3    # While harmless, they're not that interesting to have tons of. Let the others shine.
     ESMercenary: 0.5
-    ESHitman: 1
     ESAvenger: 1
+    ESHater: 0.5

--- a/Resources/Prototypes/_ES/MaskSets/filler.yml
+++ b/Resources/Prototypes/_ES/MaskSets/filler.yml
@@ -4,7 +4,6 @@
   masks:
     # Freaks, funny in moderation.
     ESGlutton: 0.3
-    ESDaredevil: 0.3
     ESGuzzler: 0.3
 
     # Influencers (not that kind)
@@ -12,7 +11,6 @@
     ESAvenger: 1
     ESHater: 1
     ESSecretary: 1
-    ESHitman: 1 # This man has a gun. But I also want them to get a chance to like, show up, so they get a filler spot.
 
     # Freaks^2
     ESFruitVendor: 0.1

--- a/Resources/Prototypes/_ES/MaskSets/gunners.yml
+++ b/Resources/Prototypes/_ES/MaskSets/gunners.yml
@@ -1,7 +1,6 @@
 - type: esMaskSet
   id: Gunners
   masks:
-    ESArmsDealer: 0.5
+    ESArmsDealer: 0.3
     ESMercenary: 1
-    ESHitman: 1
     ESVeteran: 1

--- a/Resources/Prototypes/_ES/MaskSets/oracles.yml
+++ b/Resources/Prototypes/_ES/MaskSets/oracles.yml
@@ -1,4 +1,0 @@
-- type: esMaskSet
-  id: Oracles
-  masks:
-    ESInsider: 1

--- a/Resources/Prototypes/_ES/Masks/crew.yml
+++ b/Resources/Prototypes/_ES/Masks/crew.yml
@@ -32,23 +32,6 @@
   color: white
 
 - type: esMask
-  id: ESDaredevil
-  name: es-mask-daredevil-name
-  troupe: ESCrew
-  description: es-mask-daredevil-desc
-  color: orangered
-  weight: 1
-  objectives:
-    all:
-    - id: ESObjectiveTakeDamage
-    - id: ESObjectiveTakeDamageFromSource
-    - id: ESObjectiveTakeTotalDamage
-  components:
-  - type: ActionGrant
-    actions:
-    - ESActionMaskAdrenalinePump
-
-- type: esMask
   id: ESFruitVendor
   name: es-mask-fruit-vendor-name
   troupe: ESCrew
@@ -99,34 +82,6 @@
   objectives:
     all:
     - id: ESObjectiveHaterHate
-
-- type: esMask
-  id: ESHitman
-  name: es-mask-hitman-name
-  troupe: ESCrew
-  description: es-mask-hitman-desc
-  color: crimson
-  mindComponents:
-  - type: ESSpawnTargetDossier
-  - type: ESMaskCacheSpawner
-    cacheProto:
-      id: ESCrateCacheCrewHitman
-  objectives:
-    all:
-    - id: ESObjectiveHitmanKillTarget
-    - id: ESObjectiveHitmanKillTarget
-      prob: 0.5
-
-- type: esMask
-  id: ESInsider
-  name: es-mask-insider-name
-  troupe: ESCrew
-  description: es-mask-insider-desc
-  color: cornflowerblue
-  mindComponents:
-  - type: ESMaskCacheSpawner
-    cacheProto:
-      id: ESCrateCacheCrewInsider
 
 - type: esMask
   id: ESMercenary

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -9,14 +9,14 @@
     defaultMask: "ESCrewmember/ESVIP"
     superfanTarget: "ESSubverter"
     roles:
-      6: ["ESMarauder", "ESInfiltrator", "ESInsider", "ESVIP", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
+      6: ["ESMarauder", "ESInfiltrator", "#Filler", "ESVIP", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
       7: ["ESMartyr"]
       8: ["ESVIP"]
       9: ["ESVeteran"]
       10: ["ESSyndieSuperfan"]
       11: ["ESVIP"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
-      14: ["ESInsider"]
+      14: ["#Jesters"]
       16: ["ESAvenger"] # 1 generic crew, 3 traitors.
       17: ["#Filler"]
       18: ["ESArmsDealer"]
@@ -26,8 +26,8 @@
       22: ["ESVIP"]
       24: ["#Gunners"] # 2 generic crew, 4 traitors.
       25: ["ESMarauder"] # 2 generic crew, 5 traitors.
-      26: ["ESInsider"]
+      26: ["#Filler"]
       28: ["#Gunners"] # 3 generic crew, 5 traitors.
       29: ["ESVIP"]
       30: ["#Jesters"]
-      31: ["#Traitors", "ESInsider"] # 3 generic crew, 6 traitors.
+      31: ["#Traitors", "#Filler"] # 3 generic crew, 6 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -8,23 +8,23 @@
   masquerade:
     defaultMask: "ESCrewmember"
     roles:
-      8: ["ESMarauder(2)", "ESVandal", "ESMercenary", "ESVIP/ESFruitVendor", "ESArmsDealer", "ESInsider", "#Filler"] # 0 generic crew, 2 traitors
-      9: ["#Gunners"]
+      8: ["ESMarauder(2)", "ESVandal", "ESMercenary", "ESVIP/ESFruitVendor", "ESArmsDealer", "#Filler(2)"] # 0 generic crew, 2 traitors
+      9: ["ESMartyr"]
       10: ["ESInfiltrator"] # 0 generic crew, 3 traitors.
       11: ["ESArmsDealer"] # Guarantee another arms dealer, this is definitely balanced around an armed crew.
       12: ["#Antagonistic"]
-      13: ["ESMartyr"]
-      14: ["ESInsider"]
+      13: ["#Gunners"]
+      14: ["#Jesters"]
       15: ["#PowerTraitors"] # 0 generic crew, 4 traitors.
       16: ["#Firmsafes"]
       17: ["#Traitors"] # 0 generic crew, 5 traitors.
       18: ["#Antagonistic"] # 0 generic crew, 5 traitors.
       20: ["#Traitors"] # 1 generic crew, 6 traitors.
-      21: ["ESInsider"]
+      21: ["#Filler"]
       22: ["#Gunners"] # 1 generic crew, 6 traitors.
       24: ["#Jesters(2)"]
       25: ["#PowerTraitors"] # 1 generic crew, 7 traitors.
       26: ["#Antagonistic"]
       27: ["#Filler"]
-      28: ["ESInsider"]
+      28: ["#Freak"]
       30: ["#Traitors"] # 2 generic crew, 8 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/showdown.yml
+++ b/Resources/Prototypes/_ES/Masquerades/showdown.yml
@@ -26,5 +26,5 @@
       25: ["#PowerTraitors"] # 1 generic crew, 7 traitors.
       26: ["#Antagonistic"]
       27: ["#Filler"]
-      28: ["#Freak"]
+      28: ["#Filler"]
       30: ["#Traitors"] # 2 generic crew, 8 traitors.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -9,14 +9,14 @@
     defaultMask: "ESCrewmember"
     superfanTarget: "ESSubverter"
     roles:
-      6: ["ESMarauder", "ESInfiltrator", "ESInsider", "#Filler", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
+      6: ["ESMarauder", "ESInfiltrator", "#Filler(2)", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
       7: ["ESMartyr"]
       8: ["#Filler"]
       9: ["ESVeteran"]
       10: ["ESSyndieSuperfan"]
       11: ["#Antagonistic"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
-      14: ["ESInsider"]
+      14: ["#Jesters"]
       16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
       17: ["#Filler"]
       18: ["ESArmsDealer"]
@@ -26,8 +26,8 @@
       22: ["#Filler"]
       24: ["#Gunners"] # 2 generic crew, 4 traitors.
       25: ["ESMarauder"] # 2 generic crew, 5 traitors.
-      26: ["ESInsider"]
+      26: ["#Filler"]
       28: ["#Gunners"] # 3 generic crew, 5 traitors.
       29: ["#Filler"]
       30: ["#Jesters"]
-      31: ["#Traitors", "ESInsider"] # 3 generic crew, 6 traitors.
+      31: ["#Traitors", "#Filler"] # 3 generic crew, 6 traitors.


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

closes #1183 
closes #1201 

on masquerades: replaced most insider slots with filler for now, although the midpop insider slot was replaced with a jester generally since we've usually only had one at the pop levels we play at. for showdown opted to swap a gunners slot and martyr slot at early pop so there wouldnt be two jesters in a row

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
