### PR TITLE
Superfan Rebirth (Resurrection)

### DIFF
--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -79,8 +79,8 @@ es-mask-demolitionist-name = Demolitionist
 es-mask-demolitionist-desc = As a Demolitionist, you have been trained by the Syndicate for both controlled and uncontrolled "demolitions"--including in the use of explosive implants, should things turn out that way.
 
 # Oddballs
-es-mask-syndie-superfan-name = Syndie Superfan
-es-mask-syndie-superfan-desc = As the Syndicate's biggest fan, you're a member of crew and win with them, unless the entire traitors team dies, upon which you switch sides and gain a new mask.
+es-mask-sleeper-agent-name = Sleeper Agent
+es-mask-sleeper-agent-desc = As a covert operative, you're a member of crew and win with them, unless the entire traitors team dies, upon which you switch sides and gain a new mask.
 
 # Meta
 es-objective-issuer-mask = Mask

--- a/Resources/Prototypes/_ES/MaskSets/traitoradjacent.yml
+++ b/Resources/Prototypes/_ES/MaskSets/traitoradjacent.yml
@@ -1,0 +1,6 @@
+- type: esMaskSet
+  id: TraitorAdjacent # roles which are not traitors but are adjacent to them in the game.
+  masks:
+    ESSleeperAgent: 0.7
+    ESVandal: 0.1
+    ESMercenary: 0.2

--- a/Resources/Prototypes/_ES/Masks/traitor.yml
+++ b/Resources/Prototypes/_ES/Masks/traitor.yml
@@ -67,10 +67,10 @@
 # Non-traitor masks that are dependent on traitors
 - type: esMask
   parent: ESBaseCommandSecRestricted # same restriction as traitors
-  id: ESSyndieSuperfan
-  name: es-mask-syndie-superfan-name
+  id: ESSleeperAgent
+  name: es-mask-sleeper-agent-name
   troupe: ESCrew
-  description: es-mask-syndie-superfan-desc
-  color: lightpink
+  description: es-mask-sleeper-agent-desc
+  color: darkturquoise
   mindComponents:
   - type: ESSuperfan

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -13,7 +13,7 @@
       7: ["ESMartyr"]
       8: ["ESVIP"]
       9: ["ESVeteran"]
-      10: ["ESSleeperAgent"]
+      10: ["#TraitorAdjacent"]
       11: ["ESVIP"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["#Jesters"]

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -13,7 +13,7 @@
       7: ["ESMartyr"]
       8: ["ESVIP"]
       9: ["ESVeteran"]
-      10: ["ESSyndieSuperfan"]
+      10: ["ESSleeperAgent"]
       11: ["ESVIP"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["#Jesters"]

--- a/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
+++ b/Resources/Prototypes/_ES/Masquerades/redcarpet.yml
@@ -7,7 +7,7 @@
   gameRules: []
   masquerade:
     defaultMask: "ESCrewmember/ESVIP"
-    superfanTarget: "ESSubverter"
+    superfanTarget: "#Traitors"
     roles:
       6: ["ESMarauder", "ESInfiltrator", "#Filler", "ESVIP", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
       7: ["ESMartyr"]

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -13,7 +13,7 @@
       7: ["ESMartyr"]
       8: ["#Filler"]
       9: ["ESVeteran"]
-      10: ["ESSleeperAgent"]
+      10: ["#TraitorAdjacent"]
       11: ["#Antagonistic"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["#Jesters"]

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -13,7 +13,7 @@
       7: ["ESMartyr"]
       8: ["#Filler"]
       9: ["ESVeteran"]
-      10: ["ESSyndieSuperfan"]
+      10: ["ESSleeperAgent"]
       11: ["#Antagonistic"]
       13: ["ESAssassin"]  # 0 generic crew, 3 traitors.
       14: ["#Jesters"]

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -7,7 +7,7 @@
   gameRules: []
   masquerade:
     defaultMask: "ESCrewmember"
-    superfanTarget: "ESSubverter"
+    superfanTarget: "#Traitors"
     roles:
       6: ["ESMarauder", "ESInfiltrator", "#Filler(2)", "ESVandal", "ESMercenary"] # 0 generic crew, 2 traitors
       7: ["ESMartyr"]

--- a/Resources/Prototypes/_ES/Objectives/traitor.yml
+++ b/Resources/Prototypes/_ES/Objectives/traitor.yml
@@ -28,7 +28,7 @@
     invert: true
   - type: ESTargetMaskBlacklist
     maskBlacklist:
-    - ESSyndieSuperfan
+    - ESSleeperAgent
   - type: ESKillTargetObjective
 
 ### Sabotage objectives


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

quick tweaks:
- superfan henceforth redubbed "Sleeper Agent"
  - This name is like objectively the most sensible option and also makes the most sense as to why you would want to stay aligned with crew but also convert at a given arbitrary point.
- Superfan targets have been adjusted for masquerades to now be the three main traitors. It uses the same table so marauder is weighted \~slightly\~ higher. Generally I don't think superfans need a ton of power like a subverter as typically they just need to make some final plays, finish off terminals and cap, and then do nuke. Giving them the more consistent kits will helpfully let them do that instead of just being a subverter and kinda floundering to get some recruits.
- Replaced the guaranteed superfan mask in masquerades with a new "traitor adjacent" set. This currently has superfan at a high chance, then merc, then vandal. I basically just want it to not be a guaranteed roll every round. Idc if it's common but it shouldn't be 100%. eventually angry man can go in here and it'd be coin.

Closes #1248 
Closes #1173 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="1120" height="874" alt="image" src="https://github.com/user-attachments/assets/cf5739dc-b078-497a-b214-5bc14a47c308" />