### PR TITLE
Block jesters from killing people

### DIFF
--- a/Content.Server/_ES/Masks/Jester/Components/ESChangeMaskOnKillObjectiveComponent.cs
+++ b/Content.Server/_ES/Masks/Jester/Components/ESChangeMaskOnKillObjectiveComponent.cs
@@ -10,6 +10,9 @@ namespace Content.Server._ES.Masks.Jester.Components;
 public sealed partial class ESChangeMaskOnKillObjectiveComponent : Component
 {
     [DataField]
+    public LocId Message = "es-fool-conversion-notification";
+
+    [DataField]
     public ProtoId<ESMaskPrototype> Mask;
 
     [DataField]

--- a/Content.Server/_ES/Masks/Jester/Components/ESChangeMaskOnKillObjectiveComponent.cs
+++ b/Content.Server/_ES/Masks/Jester/Components/ESChangeMaskOnKillObjectiveComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class ESChangeMaskOnKillObjectiveComponent : Component
     [DataField]
     public LocId Message = "es-fool-conversion-notification";
 
-    [DataField]
+    [DataField(required: true)]
     public ProtoId<ESMaskPrototype> Mask;
 
     [DataField]

--- a/Content.Server/_ES/Masks/Jester/Components/ESChangeMaskOnKillObjectiveComponent.cs
+++ b/Content.Server/_ES/Masks/Jester/Components/ESChangeMaskOnKillObjectiveComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared._ES.Masks;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._ES.Masks.Jester.Components;
+
+/// <summary>
+/// Used for a mask that becomes another mask when they kill someone.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESChangeMaskOnKillObjectiveComponent : Component
+{
+    [DataField]
+    public ProtoId<ESMaskPrototype> Mask;
+
+    [DataField]
+    public float DefaultProgress = 1f;
+}

--- a/Content.Server/_ES/Masks/Jester/ESChangeMaskOnKillObjectiveSystem.cs
+++ b/Content.Server/_ES/Masks/Jester/ESChangeMaskOnKillObjectiveSystem.cs
@@ -1,13 +1,19 @@
 using Content.Server._ES.Masks.Jester.Components;
 using Content.Server._ES.Masks.Objectives.Relays.Components;
+using Content.Server.Chat.Managers;
 using Content.Shared._ES.KillTracking.Components;
 using Content.Shared._ES.Objectives;
 using Content.Shared._ES.Objectives.Components;
+using Content.Shared.Chat;
+using Robust.Server.Player;
 
 namespace Content.Server._ES.Masks.Jester;
 
 public sealed class ESChangeMaskOnKillObjectiveSystem : ESBaseObjectiveSystem<ESChangeMaskOnKillObjectiveComponent>
 {
+    [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
     public override Type[] RelayComponents => [typeof(ESKilledRelayComponent)];
 
     /// <inheritdoc/>
@@ -29,6 +35,13 @@ public sealed class ESChangeMaskOnKillObjectiveSystem : ESBaseObjectiveSystem<ES
 
         if (!MindSys.TryGetMind(args.Killer, out var mind))
             return;
+
+        if (_player.TryGetSessionByEntity(args.Killer, out var session))
+        {
+            var msg = Loc.GetString(ent.Comp.Message);
+            var wrappedMsg = Loc.GetString("chat-manager-server-wrap-message", ("message", msg));
+            _chat.ChatMessageToOne(ChatChannel.Server, msg, wrappedMsg, default, false, session.Channel, Color.Red);
+        }
 
         MaskSys.ChangeMask(mind.Value, ent.Comp.Mask);
     }

--- a/Content.Server/_ES/Masks/Jester/ESChangeMaskOnKillObjectiveSystem.cs
+++ b/Content.Server/_ES/Masks/Jester/ESChangeMaskOnKillObjectiveSystem.cs
@@ -1,0 +1,40 @@
+using Content.Server._ES.Masks.Jester.Components;
+using Content.Server._ES.Masks.Objectives.Relays.Components;
+using Content.Shared._ES.KillTracking.Components;
+using Content.Shared._ES.Objectives;
+using Content.Shared._ES.Objectives.Components;
+
+namespace Content.Server._ES.Masks.Jester;
+
+public sealed class ESChangeMaskOnKillObjectiveSystem : ESBaseObjectiveSystem<ESChangeMaskOnKillObjectiveComponent>
+{
+    public override Type[] RelayComponents => [typeof(ESKilledRelayComponent)];
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESChangeMaskOnKillObjectiveComponent, ESKilledPlayerEvent>(OnKilledPlayer);
+    }
+
+    private void OnKilledPlayer(Entity<ESChangeMaskOnKillObjectiveComponent> ent, ref ESKilledPlayerEvent args)
+    {
+        if (args.Suicide)
+            return;
+
+        // Only matters if you kill a real player with a mind
+        if (!MindSys.TryGetMind(args.Killed, out _))
+            return;
+
+        if (!MindSys.TryGetMind(args.Killer, out var mind))
+            return;
+
+        MaskSys.ChangeMask(mind.Value, ent.Comp.Mask);
+    }
+
+    protected override void GetObjectiveProgress(Entity<ESChangeMaskOnKillObjectiveComponent> ent, ref ESGetObjectiveProgressEvent args)
+    {
+        args.Progress = ent.Comp.DefaultProgress;
+    }
+}

--- a/Content.Server/_ES/Masks/Objectives/Relays/ESKilledRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESKilledRelaySystem.cs
@@ -1,5 +1,4 @@
 using Content.Server._ES.Masks.Objectives.Relays.Components;
-using Content.Server.KillTracking;
 using Content.Server.Mind;
 using Content.Shared._ES.KillTracking.Components;
 using Content.Shared._ES.Mind;
@@ -14,6 +13,7 @@ public sealed class ESKilledRelaySystem : ESBaseMindRelay
     public override void Initialize()
     {
         SubscribeLocalEvent<ESKilledRelayComponent, ESPlayerKilledEvent>(OnKillReported);
+        SubscribeLocalEvent<ESKilledRelayComponent, ESKilledPlayerEvent>(OnKilledPlayerReported);
     }
 
     private void OnKillReported(Entity<ESKilledRelayComponent> ent, ref ESPlayerKilledEvent args)
@@ -22,5 +22,13 @@ public sealed class ESKilledRelaySystem : ESBaseMindRelay
             return;
 
         RaiseMindEvent((mindId, mindComp), ref args);
+    }
+
+    private void OnKilledPlayerReported(Entity<ESKilledRelayComponent> ent, ref ESKilledPlayerEvent args)
+    {
+        if (!TryGetMind(ent, out var mind))
+            return;
+
+        RaiseMindEvent(mind.Value, ref args);
     }
 }

--- a/Content.Shared/_ES/KillTracking/Components/ESKillTrackerComponent.cs
+++ b/Content.Shared/_ES/KillTracking/Components/ESKillTrackerComponent.cs
@@ -54,3 +54,18 @@ public readonly struct ESPlayerKilledEvent(EntityUid killed, EntityUid? killer)
     [MemberNotNullWhen(false, nameof(Killer))]
     public bool Environment => !Killer.HasValue;
 }
+
+/// <summary>
+/// Event raised on an entity when they kill and entity with <see cref="ESKillTrackerComponent"/>.
+/// </summary>
+[ByRefEvent]
+public readonly struct ESKilledPlayerEvent(EntityUid killed, EntityUid killer)
+{
+    public readonly EntityUid Killed = killed;
+
+    public readonly EntityUid Killer = killer;
+
+    public bool ValidKill => !Suicide;
+
+    public bool Suicide => Killed == Killer;
+}

--- a/Content.Shared/_ES/KillTracking/ESKillTrackingSystem.cs
+++ b/Content.Shared/_ES/KillTracking/ESKillTrackingSystem.cs
@@ -90,15 +90,16 @@ public sealed class ESKillTrackingSystem : EntitySystem
             return;
         ent.Comp.Killed = true;
 
-        var killer = ent.Comp.Sources.Count switch
-        {
-            > 1 => ent.Comp.Sources.Where(s => !s.IsEnvironment).MaxBy(s => s.AccumulatedDamage)?.Entity,
-            1 => ent.Comp.Sources.First().Entity,
-            _ => null,
-        };
+        var killer = GetKiller(ent.AsNullable());
 
         var ev = new ESPlayerKilledEvent(ent, killer);
         RaiseLocalEvent(ent, ref ev, true);
+
+        if (killer.HasValue)
+        {
+            var killerEv = new ESKilledPlayerEvent(ent, killer.Value);
+            RaiseLocalEvent(killer.Value, ref killerEv);
+        }
     }
 
     private void AddDamage(Entity<ESKillTrackerComponent> ent, EntityUid? source, FixedPoint2 damage)
@@ -140,5 +141,35 @@ public sealed class ESKillTrackingSystem : EntitySystem
         {
             ent.Comp.Sources.Remove(source);
         }
+    }
+
+    /// <summary>
+    /// Gets the "killer" of an entity, that being the entity that has
+    /// the most damage sources on a given entity.
+    /// </summary>
+    public EntityUid? GetKiller(Entity<ESKillTrackerComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return null;
+
+        var orderedSources = GetOrderedSources(ent);
+        return orderedSources.FirstOrDefault()?.Entity;
+    }
+
+    /// <summary>
+    /// Returns the damage sources in a sorted order, first by non-environmental, then by damage.
+    /// </summary>
+    public List<ESDamageSource> GetOrderedSources(Entity<ESKillTrackerComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return [];
+
+        if (ent.Comp.Sources.Count == 0)
+            return [];
+
+        return ent.Comp.Sources
+            .OrderBy(s => s.IsEnvironment) // Has non-environment first, then environment.
+            .ThenByDescending(s => s.AccumulatedDamage) // Within those groups, go from most damage to least damage.
+            .ToList();
     }
 }

--- a/Resources/Locale/en-US/_ES/masks/jester/fool.ftl
+++ b/Resources/Locale/en-US/_ES/masks/jester/fool.ftl
@@ -1,0 +1,1 @@
+es-fool-conversion-notification = You've violated the comedic code of the jester's and have been sentenced to become a fool for your crimes.

--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -48,6 +48,9 @@ es-mask-vip-name = VIP
 es-mask-vip-desc = As a VIP, use your fancy VIP card to help confirm your innocence in times of peril.
 
 # Jester masks
+es-mask-the-fool-name = The Fool
+es-mask-the-fool-desc = As the fool, wallow in pity at the failure of your purpose and curse your existence to the very end.
+
 es-mask-martyr-name = Martyr
 es-mask-martyr-desc = As a Martyr, you are a beautiful soul. Be killed by another crewmember in order to ascend to heaven and drag them to hell.
 

--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -48,8 +48,8 @@ es-mask-vip-name = VIP
 es-mask-vip-desc = As a VIP, use your fancy VIP card to help confirm your innocence in times of peril.
 
 # Jester masks
-es-mask-the-fool-name = The Fool
-es-mask-the-fool-desc = As the fool, wallow in pity at the failure of your purpose and curse your existence to the very end.
+es-mask-the-fool-name = Fool
+es-mask-the-fool-desc = As a Fool, wallow in pity at the failure of your purpose and curse your existence to the very end.
 
 es-mask-martyr-name = Martyr
 es-mask-martyr-desc = As a Martyr, you are a beautiful soul. Be killed by another crewmember in order to ascend to heaven and drag them to hell.

--- a/Resources/Prototypes/_ES/Masks/jester.yml
+++ b/Resources/Prototypes/_ES/Masks/jester.yml
@@ -1,5 +1,5 @@
 - type: esMask
-  id: ESTheFool
+  id: ESFool
   name: es-mask-the-fool-name
   troupe: ESJester
   description: es-mask-the-fool-desc

--- a/Resources/Prototypes/_ES/Masks/jester.yml
+++ b/Resources/Prototypes/_ES/Masks/jester.yml
@@ -1,4 +1,15 @@
 - type: esMask
+  id: ESTheFool
+  name: es-mask-the-fool-name
+  troupe: ESJester
+  description: es-mask-the-fool-desc
+  color: olive
+  weight: 0
+  objectives:
+    all:
+    - id: ESObjectiveTheFoolMisery
+
+- type: esMask
   id: ESMartyr
   name: es-mask-martyr-name
   troupe: ESJester

--- a/Resources/Prototypes/_ES/Masks/jester.yml
+++ b/Resources/Prototypes/_ES/Masks/jester.yml
@@ -21,6 +21,7 @@
   objectives:
     all:
     - id: ESObjectiveMartyrBeKilled
+    - id: ESObjectiveJesterDoNoHarm
 
 - type: esMask
   id: ESParasite
@@ -32,7 +33,9 @@
   mindComponents:
   - type: ESParasite
   objectives:
-    id: ESObjectiveParasiteBeKilled
+    all:
+    - id: ESObjectiveParasiteBeKilled
+    - id: ESObjectiveJesterDoNoHarm
 
 - type: esMask
   id: ESPhantom
@@ -47,3 +50,4 @@
     all:
     - id: ESObjectivePhantomDie
     - id: ESObjectivePhantomAvenge
+    - id: ESObjectiveJesterDoNoHarm

--- a/Resources/Prototypes/_ES/Objectives/Jester/the_fool.yml
+++ b/Resources/Prototypes/_ES/Objectives/Jester/the_fool.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: ESBaseMaskObjective
+  id: ESObjectiveTheFoolMisery
+  name: Wallow in misery
+  description: Revel in your failure after violating the comedic sanctity of the jester troupe. Pray for forgiveness you'll never receive.
+  components:
+  - type: ESObjective
+    icon:
+      sprite: Clothing/Mask/clown.rsi
+      state: icon

--- a/Resources/Prototypes/_ES/Objectives/jester.yml
+++ b/Resources/Prototypes/_ES/Objectives/jester.yml
@@ -9,4 +9,4 @@
       sprite: Clothing/Mask/clown.rsi
       state: icon
   - type: ESChangeMaskOnKillObjective
-    mask: ESTheFool
+    mask: ESFool

--- a/Resources/Prototypes/_ES/Objectives/jester.yml
+++ b/Resources/Prototypes/_ES/Objectives/jester.yml
@@ -1,0 +1,12 @@
+- type: entity
+  parent: ESBaseMaskObjective
+  id: ESObjectiveJesterDoNoHarm
+  name: Do no harm
+  description: While your job is to drive others to violence, by the jester's code, you must not take the life of another.
+  components:
+  - type: ESObjective
+    icon:
+      sprite: Clothing/Mask/clown.rsi
+      state: icon
+  - type: ESChangeMaskOnKillObjective
+    mask: ESTheFool


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
adds some new stuff to jesters. Now, when a jester kills someone, they lose their mask and become The Fool. The fool is just an unaligned jester mask that has an uncompletable objective so they always register as losing.

Closes #1250 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="475" height="525" alt="image" src="https://github.com/user-attachments/assets/105ec770-378d-4a74-b84d-a83b755d9fd8" />
<img width="716" height="307" alt="image" src="https://github.com/user-attachments/assets/283a2e02-d8d1-43ef-8cd6-e69efc632b89" />
<img width="1117" height="209" alt="image" src="https://github.com/user-attachments/assets/d12272b4-5a18-4117-8792-da97098ed252" />
