### PR TITLE
minor maint loot adjustments: strange items edition

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -198,7 +198,7 @@
     - id: ESClothingHeadHelmetSecurity
 
     - id: DefaultStationBeaconUnanchored
-    - id: Soap # TODO: soap pool?
+    - tableId: ESSoap
     - id: MaterialWoodPlank
     - id: PowerCellMedium
     - id: PowerCellHigh
@@ -306,12 +306,16 @@
     - id: Handcuffs
     - id: WelderIndustrialAdvanced
     - id: Binoculars
+    - id: PinpointerUniversal
+    - id: PinpointerNuclear
+    - id: CameraBug
+    - id: ChameleonProjector
+    - id: ClothingBackpackSatchelSmugglerUnanchored
     - id: ESMedkitFilled
 
     - id: ClothingEyesHudSecurity
     - id: ClothingEyesGlassesSunglasses
     - id: ClothingHandsGlovesColorYellow
-    - id: ClothingHandsGlovesCombat
     - id: ClothingShoesBootsJack
 
     - all: # Russian Outfit

--- a/Resources/Prototypes/_ES/Catalog/Tables/soap.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/soap.yml
@@ -1,0 +1,16 @@
+- type: entityTable
+  id: ESSoap
+  table:
+    group:
+    - group:
+      - id: Soap
+      - id: SoapNT
+      - id: SoapDeluxe
+      weight: 8
+    - group:
+      - id: SoapHomemade
+      - id: SoapSyndie
+      weight: 1
+    - group:
+      - id: SoapOmega
+      weight: 0.05


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
adjusts the maint loot pool to have some fun & gimmicky upstream-traitor-adjacent items that we can reuse for weird maint stuff. all of them are in the rare pool for now but in the future it could maybe be a seperate loot roll or something since its pretty uncommon to get more then 1 per round.
>   
    - id: PinpointerUniversal
    - id: PinpointerNuclear
    - id: CameraBug
    - id: ChameleonProjector
    - id: ClothingBackpackSatchelSmugglerUnanchored
also adds a soap loot table and adds it to the maint pool, meaning you can now get stuff like syndicate soap.
