### PR TITLE
remove old airlock that references a shuttle for no reason

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Doors/airlocks.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Doors/airlocks.yml
@@ -1,15 +1,3 @@
-
-- type: entity
-  parent: AirlockShuttle
-  id: ESAirlockExternalShuttlePod
-  suffix: External, Pod 7x6, Docking
-  components:
-  - type: GridFill
-    path: /Maps/_ES/Shuttles/space_pod.yml
-  - type: ContainerFill
-    containers:
-      board: [ DoorElectronicsExternal ]
-
 # Department
 
 - type: entity


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
