### PR TITLE
Remove HOP from civilian department

### DIFF
--- a/Resources/Prototypes/_ES/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/_ES/Roles/Jobs/departments.yml
@@ -26,7 +26,6 @@
   weight: -10
   roles:
   - ESClown
-  - ESHeadOfPersonnel
   - ESAssistant
   - ESReporter
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1395 

causes them to show up multiple times on certain UIs plus just doesnt make sense. We dont need to double-mark jobs in departments they can just be command people.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
