### PR TITLE
Fix stagehand notifications leaking info

### DIFF
--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -286,9 +286,9 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         }
         ApplyMask(mind, maskId, troupe);
 
-        if (mind.Comp.OwnedEntity is { } owned)
+        if (mind.Comp.OwnedEntity is not null)
         {
-            var name = _stagehandNotifications.WrapEntityNameWithUsername(owned);
+            var name = mind.Comp.CharacterName ?? string.Empty;
             var mask = Loc.GetString(PrototypeManager.Index(maskId).Name);
             var msg = Loc.GetString("es-stagehand-notification-mask-change", ("player", name), ("mask", mask));
             _stagehandNotifications.SendStagehandNotification(msg, ESStagehandNotificationSeverity.High);

--- a/Content.Server/_ES/Masks/ESMaskSystem.cs
+++ b/Content.Server/_ES/Masks/ESMaskSystem.cs
@@ -286,11 +286,11 @@ public sealed class ESMaskSystem : ESSharedMaskSystem
         }
         ApplyMask(mind, maskId, troupe);
 
-        if (mind.Comp.OwnedEntity is not null)
+        if (mind.Comp.OwnedEntity is { } owned)
         {
-            var name = mind.Comp.CharacterName ?? string.Empty;
-            var mask = Loc.GetString(PrototypeManager.Index(maskId).Name);
-            var msg = Loc.GetString("es-stagehand-notification-mask-change", ("player", name), ("mask", mask));
+            var msg = Loc.GetString("es-stagehand-notification-mask-change",
+                ("player", _stagehandNotifications.WrapEntityName(owned)),
+                ("mask", Loc.GetString(PrototypeManager.Index(maskId).Name)));
             _stagehandNotifications.SendStagehandNotification(msg, ESStagehandNotificationSeverity.High);
         }
     }

--- a/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
+++ b/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
@@ -65,7 +65,7 @@ public sealed class ESMartyrSystem : EntitySystem
 
         var notifMsg = Loc.GetString("es-stagehand-notifications-martyr-got-martyred",
             ("player", _notif.WrapEntityNameWithUsername(args.Killed)),
-            ("attacker", args.Killer.Value));
+            ("attacker", _notif.WrapEntityName(args.Killer.Value)));
 
         _notif.SendStagehandNotification(notifMsg, ESStagehandNotificationSeverity.High);
 

--- a/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
+++ b/Content.Server/_ES/Masks/Martyr/ESMartyrSystem.cs
@@ -63,6 +63,12 @@ public sealed class ESMartyrSystem : EntitySystem
         EnsureComp<ESMartyrKillerMarkerComponent>(args.Killer.Value);
         _timer.SpawnTimer(args.Killer.Value, ent.Comp.TimeBeforeKillerDeath, new ESMartyrKillerTimeToDieEvent());
 
+        var notifMsg = Loc.GetString("es-stagehand-notifications-martyr-got-martyred",
+            ("player", _notif.WrapEntityNameWithUsername(args.Killed)),
+            ("attacker", args.Killer.Value));
+
+        _notif.SendStagehandNotification(notifMsg, ESStagehandNotificationSeverity.High);
+
         if (!TryComp<ActorComponent>(args.Killer.Value, out var actor))
             return;
 
@@ -72,11 +78,5 @@ public sealed class ESMartyrSystem : EntitySystem
         // we are kind of misusing quickdialogs by just using them as a persistent UI popup rather than
         // entering any data, so we just ignore it with an empty action
         _quickDialog.OpenDialog<string>(actor.PlayerSession, title, msg, _ => {});
-
-        var notifMsg = Loc.GetString("es-stagehand-notifications-martyr-got-martyred",
-            ("player", _notif.WrapEntityNameWithUsername(args.Killed)),
-            ("attacker", _notif.WrapEntityNameWithUsername(args.Killer.Value)));
-
-        _notif.SendStagehandNotification(notifMsg, ESStagehandNotificationSeverity.High);
     }
 }

--- a/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -1,14 +1,15 @@
 using Content.Server.Chat.Managers;
 using Content.Server.Mind;
-using Content.Shared._ES.Auditions.Components;
 using Content.Shared._ES.KillTracking.Components;
 using Content.Shared._ES.Objectives;
 using Content.Shared._ES.Objectives.Components;
 using Content.Shared._ES.Stagehand.Components;
 using Content.Shared.Chat;
+using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using JetBrains.Annotations;
 using Robust.Server.Player;
+using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 
@@ -39,22 +40,23 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
 
         string? msg = null;
         var severity = ESStagehandNotificationSeverity.Medium;
-        var wrappedPlayerName = WrapEntityNameWithUsername(ev.Killed);
 
         if (ev.Suicide)
         {
-            msg = Loc.GetString("es-stagehand-notification-kill-suicide", ("player", wrappedPlayerName));
+            msg = Loc.GetString("es-stagehand-notification-kill-suicide",
+                ("player", WrapEntityNameWithUsername(ev.Killed)));
         }
         else if (ev.Environment)
         {
-            msg = Loc.GetString("es-stagehand-notification-kill-environment", ("player", wrappedPlayerName));
+            msg = Loc.GetString("es-stagehand-notification-kill-environment",
+                ("player", WrapEntityNameWithUsername(ev.Killed)));
         }
         else if (ev.Killer is { } killer)
         {
             severity = ESStagehandNotificationSeverity.High;
             msg = Loc.GetString("es-stagehand-notification-kill-player",
-                ("player", wrappedPlayerName),
-                ("attacker", killer));
+                ("player", WrapEntityNameWithUsername(ev.Killed)),
+                ("attacker", WrapEntityName(killer)));
         }
 
         if (msg != null)
@@ -88,11 +90,47 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
             return;
 
         var entityName = Name(holder.Value);
-        if (TryComp<ESCharacterComponent>(holder.Value, out var comp))
-            entityName = comp.Name;
+        if (TryComp<MindComponent>(holder.Value, out var mind) && mind.OwnedEntity is { } owned)
+            entityName = WrapEntityName(owned);
 
         var resolvedMessage = Loc.GetString(msgId, ("entity", entityName), ("objective", ev.Objective.Owner));
         SendStagehandNotification(resolvedMessage);
+    }
+
+    /// <summary>
+    /// Version of <see cref="WrapEntityNameWithUsername"/> that formats relevant IC info into a name without giving a username.
+    /// </summary>
+    /// <remarks>
+    /// Use when displaying an entity name but without the context of the username.
+    /// </remarks>
+    public string WrapEntityName(Entity<MindContainerComponent?> entity)
+    {
+        // Default case: basic entities display their entity name
+        if (!Resolve(entity, ref entity.Comp, false) ||
+            !_mind.TryGetMind(entity, out var mind, entity))
+        {
+            return Name(entity);
+        }
+
+        var entityName = Name(entity);
+        var characterName = mind.Value.Comp.CharacterName ?? string.Empty;
+
+        // If our name matches our body, just display the simple name.
+        if (entityName.Equals(characterName, StringComparison.InvariantCulture))
+        {
+            return entityName;
+        }
+
+        if (TryComp<GrammarComponent>(entity, out var grammar) && grammar.ProperNoun == true)
+        {
+            return Loc.GetString("es-stagehand-notification-wrap-entity-body-player-swap",
+                ("character", characterName),
+                ("body", entityName));
+        }
+
+        return Loc.GetString("es-stagehand-notification-wrap-entity-body-mob-swap",
+            ("character", characterName),
+            ("body", entityName));
     }
 
     /// <summary>
@@ -118,11 +156,11 @@ public sealed class ESStagehandNotificationsSystem : EntitySystem
         }
         else
         {
-            return Name(entity);
+            return WrapEntityName(entity.Owner);
         }
 
         return Loc.GetString("es-stagehand-notification-wrap-entity-username",
-            ("entity", entity.Owner),
+            ("entity", WrapEntityName(entity.Owner)),
             ("username", username));
     }
 

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -13,5 +13,5 @@ es-stagehand-notification-objective-failed = {$entity} failed their objective "{
 
 es-stagehand-notification-mask-change = {$player} donned a new mask, becoming {INDEFINITE($mask)} [bold]{$mask}![/bold]
 
-es-stagehand-notifications-martyr-got-martyred = {$player} has been marked for death after killing {$attacker}, a martyr!
+es-stagehand-notifications-martyr-got-martyred = {$attacker} has been marked for death after killing {$player}, a martyr!
 es-stagehand-notifications-martyr-killed-target = {$player} has met their fated, bloody end after killing a martyr.

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -2,6 +2,8 @@ es-stagehand-notification-wrap-message-low = [font size=10][italic]{$message}[/i
 es-stagehand-notification-wrap-message-medium = [font size=12]{$message}[/font]
 es-stagehand-notification-wrap-message-high = [font size=14][bold]{$message}[/bold][/font]
 
+es-stagehand-notification-wrap-entity-body-player-swap = {$character} in {$body}'s body
+es-stagehand-notification-wrap-entity-body-mob-swap = {$character} in {INDEFINITE($body)} {$body}
 es-stagehand-notification-wrap-entity-username = {$entity} ({$username})
 
 es-stagehand-notification-kill-suicide = {$player} committed suicide!


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1396 
Closes #1393 

should not show a player's name unless they are dying.

also updates usages using a new helper function to display any body swapping shenanigans.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="807" height="530" alt="image" src="https://github.com/user-attachments/assets/e355abee-448c-473e-87dd-237df3e0b04b" />
