### PR TITLE
Fix phantom revenge objective

### DIFF
--- a/Content.Server/_ES/Masks/Phantom/Components/ESAvengeSelfObjectiveComponent.cs
+++ b/Content.Server/_ES/Masks/Phantom/Components/ESAvengeSelfObjectiveComponent.cs
@@ -1,3 +1,6 @@
+using Content.Shared._ES.Objectives.Target.Components;
+using Robust.Shared.Prototypes;
+
 namespace Content.Server._ES.Masks.Phantom.Components;
 
 /// <summary>
@@ -7,6 +10,12 @@ namespace Content.Server._ES.Masks.Phantom.Components;
 [Access(typeof(ESAvengeSelfObjectiveSystem))]
 public sealed partial class ESAvengeSelfObjectiveComponent : Component
 {
+    /// <summary>
+    /// Objective added when killed.
+    /// </summary>
+    [DataField]
+    public EntProtoId<ESTargetObjectiveComponent> AvengeObjective = "ESObjectivePhantomAvenge";
+
     /// <summary>
     /// Objective name used when the player fails to be killed by someone.
     /// </summary>

--- a/Content.Server/_ES/Masks/Phantom/ESAvengeSelfObjectiveSystem.cs
+++ b/Content.Server/_ES/Masks/Phantom/ESAvengeSelfObjectiveSystem.cs
@@ -28,6 +28,12 @@ public sealed class ESAvengeSelfObjectiveSystem : ESBaseObjectiveSystem<ESAvenge
 
     private void OnKillReported(Entity<ESAvengeSelfObjectiveComponent> ent, ref ESPlayerKilledEvent args)
     {
+        if (!ObjectivesSys.TryFindObjectiveHolder(ent.Owner, out var holder))
+            return;
+
+        if (!ObjectivesSys.TryAddObjective(holder.Value.AsNullable(), ent.Comp.AvengeObjective, out var objective))
+            return;
+
         var user = _player.TryGetSessionByEntity(args.Killed, out var session) ? session.Channel : null;
         string msg;
 
@@ -35,13 +41,13 @@ public sealed class ESAvengeSelfObjectiveSystem : ESBaseObjectiveSystem<ESAvenge
             !MindSys.TryGetMind(args.Killer.Value, out _, out var mindComp) ||
             mindComp.OwnedEntity is not { } body)
         {
-            _metaData.SetEntityName(ent, Loc.GetString(ent.Comp.FailName));
+            _metaData.SetEntityName(objective.Value, Loc.GetString(ent.Comp.FailName));
 
             msg = Loc.GetString(ent.Comp.FailMessage);
         }
         else
         {
-            _targetObjective.SetTarget(ent.Owner, body);
+            _targetObjective.SetTarget(objective.Value.Owner, body);
 
             msg = Loc.GetString(ent.Comp.SuccessMessage);
         }

--- a/Resources/Prototypes/_ES/Masks/jester.yml
+++ b/Resources/Prototypes/_ES/Masks/jester.yml
@@ -49,5 +49,4 @@
   objectives:
     all:
     - id: ESObjectivePhantomDie
-    - id: ESObjectivePhantomAvenge
     - id: ESObjectiveJesterDoNoHarm

--- a/Resources/Prototypes/_ES/Objectives/Jester/phantom.yml
+++ b/Resources/Prototypes/_ES/Objectives/Jester/phantom.yml
@@ -11,6 +11,7 @@
   - type: ESTargetObjective
   - type: ESTargetSelfObjective
   - type: ESKillTargetObjective
+  - type: ESAvengeSelfObjective
 
 - type: entity
   parent: ESBaseMaskObjective
@@ -24,6 +25,4 @@
       state: icon
   - type: ESTargetObjective
     title: es-phantom-avenge-objective-title
-  - type: ESAvengeSelfObjective
   - type: ESKillTargetObjective
-    defaultProgress: 0 # if no one kills you, then you LOSE


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1351 

rewrites phantom to now only give the additional objective on kill rather than having it there by default. also fixes the behavior where your kill target getting deleted would cause the objective to fail.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
