### PR TITLE
Explosion fires

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -255,6 +255,17 @@ public sealed partial class ExplosionSystem
                 tileBlocked |= IsBlockingTurf(entity);
             }
         }
+// ES START
+        if (!tileBlocked)
+        {
+            var explosionType = _prototypeManager.Index<ExplosionPrototype>(id);
+            if (_robustRandom.Prob(explosionType.FireChance))
+            {
+                _tileFire.TryDoTileFire(_map.ToCoordinates(grid, tile, grid),
+                    stage: _robustRandom.Next(explosionType.MinFireLevel, explosionType.MaxFireLevel + 1));
+            }
+        }
+// ES END
 
         // Next, we get the intersecting entities AGAIN, but purely for throwing. This way, glass shards spawned from
         // windows will be flung outwards, and not stay where they spawned. This is however somewhat unnecessary, and a

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Numerics;
+using Content.Server._ES.TileFires;
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
@@ -37,6 +38,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
 {
     // ES START
     [Dependency] private readonly ESScreenshakeSystem _shake = default!;
+    [Dependency] private readonly ESTileFireSystem _tileFire = default!;
     // ES END
 
     [Dependency] private readonly IMapManager _mapManager = default!;

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -115,6 +115,16 @@ public sealed partial class ExplosionPrototype : IPrototype
     // steal code from.
     [DataField("fireStates")]
     public int FireStates = 3;
+// ES START
+    [DataField]
+    public float FireChance = 0.15f;
+
+    [DataField]
+    public int MinFireLevel = 1;
+
+    [DataField]
+    public int MaxFireLevel = 1;
+// ES END
 
     /// <summary>
     ///     Basic function for linear interpolation of the _tileBreakChance and _tileBreakIntensity arrays

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -33,7 +33,9 @@
         Heat: 10
   - type: PacifismDangerousAttack
   - type: Explosive
-    explosionType: Default
+# ES START
+    explosionType: ESWelderBomb
+# ES END
     totalIntensity: 60 # Mediocre explosion. Not enough to do any meaningful structural damage to anything other then windows, provided you're only using one tank.
 
 - type: entity

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -134,3 +134,28 @@
   fireStates: 3
   fireStacks: 2
   temperature: 1500
+# ES START
+  fireChance: 0.8
+  minFireLevel: 1
+  maxFireLevel: 3
+# ES END
+
+# ES START
+- type: explosion
+  id: ESWelderBomb # Default but with firebomb firespread
+  damagePerIntensity:
+    types:
+      Heat: 5
+      Blunt: 5
+      Piercing: 5
+  tileBreakChance: [0, 0.5, 1]
+  tileBreakIntensity: [0, 10, 30]
+  tileBreakRerollReduction: 20
+  lightColor: Orange
+  texturePath: /Textures/Effects/fire.rsi
+  fireStates: 3
+  temperature: 800
+  fireChance: 0.8
+  minFireLevel: 1
+  maxFireLevel: 3
+# ES END


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Explosions now have the ability to start fires.

All default explosions have a 15% chance to start a level-1 fire per each tile. This is pretty ineffective, all things considered. Grenades gets maybe 1-3 fire entities per explosion.

Firebombs and welding fuel tanks have increased flammability properties. They spawn fires 80% of the time and the fires can range from level 1 to 3. For firebombs this gives them an interesting niche as a weak firestarter. Welding fuel tanks have a fire roughly comparable to the electrical fire event which makes them more area denial focused and worse at breaching (how are you going to breach through a fire?)

not really super sanely balanced i just wanted to play around with this as functionality.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

grenade:
<img width="1042" height="964" alt="image" src="https://github.com/user-attachments/assets/939ee1ec-b29e-4df5-b8b2-fb246f65cd0d" />

welding tank:
<img width="1009" height="1093" alt="image" src="https://github.com/user-attachments/assets/13a54c91-77a3-4b0f-83fb-1fed72dd0189" />

firebomb:
<img width="540" height="610" alt="image" src="https://github.com/user-attachments/assets/bf12dca8-d5bb-4d2a-a631-24cc17b902a2" />
