### PR TITLE
Can fix bone death with normal suture instead of medicated suture

### DIFF
--- a/Resources/Prototypes/_Offbrand/surgery_graph.yml
+++ b/Resources/Prototypes/_Offbrand/surgery_graph.yml
@@ -201,7 +201,7 @@
       - !type:RemoveStatusEffect
         effect: WoundBoneDeath
       steps:
-      - material: MedicatedSuture
+      - material: Suture
         amount: 3
         doAfter: 5
   - node: OpenRibCageSetting


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Medicated Suture can only be gotten by crafting it with botany plants and it's also the only way to heal bone death which is pretty easy to give a guy by just bashing them with a crowbar after shooting them. We all know that no one is ever really going to craft medicated suture and without it it is not possible to save people with bone death.

This pr makes the normal suture be used for this instead.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="365" height="458" alt="image" src="https://github.com/user-attachments/assets/d51a31c4-2f43-4f8e-b782-663044254307" />
