### PR TITLE
Remove det speedloader

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
@@ -86,8 +86,6 @@
     children:
     - id: ClothingEyesGlassesNoir
     - id: ESWeaponRevolver357 # sure, the other security roles don't get guns, but what is a detective without their revolver?
-    - id: ESSpeedLoader357
-    - id: ClothingBeltHolster # realistically this should just contain the gun, but, i dont want to make a new filled prototype right now. sorry.
     - id: ClothingHeadHatDetGadget
       prob: 0.15
     - id: Stunbaton

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/revolver.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/revolver.yml
@@ -10,6 +10,7 @@
   - type: Clothing
     sprite: _ES/Objects/Weapons/Guns/357.rsi
   - type: Gun
+    fireRate: 0.8
     soundGunshot:
       path: /Audio/_ES/Weapons/Guns/Gunshots/revolver_shot.ogg
     soundEmpty:

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/revolver.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/revolver.yml
@@ -10,7 +10,7 @@
   - type: Clothing
     sprite: _ES/Objects/Weapons/Guns/357.rsi
   - type: Gun
-    fireRate: 0.8
+    fireRate: 1.1
     soundGunshot:
       path: /Audio/_ES/Weapons/Guns/Gunshots/revolver_shot.ogg
     soundEmpty:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1397 

removes the speedloader because det probably doesnt need all of that ammo roundstart.
also kills the holster because poorly implemented slop storage. call me when we have slotinv for belts

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
