### PR TITLE
Overhaul airlock bolt breakage

### DIFF
--- a/Content.Server/_ES/Degradation/Components/ESAirlockFailureEventComponent.cs
+++ b/Content.Server/_ES/Degradation/Components/ESAirlockFailureEventComponent.cs
@@ -1,0 +1,18 @@
+namespace Content.Server._ES.Degradation.Components;
+
+[RegisterComponent]
+[Access(typeof(ESAirlockFailureEventSystem))]
+public sealed partial class ESAirlockFailureEventComponent : Component
+{
+    /// <summary>
+    /// Minimum charges to add (inclusive)
+    /// </summary>
+    [DataField]
+    public int MinCount = 1;
+
+    /// <summary>
+    /// Maximum charges to add (inclusive)
+    /// </summary>
+    [DataField]
+    public int MaxCount = 5;
+}

--- a/Content.Server/_ES/Degradation/ESAirlockFailureEventSystem.cs
+++ b/Content.Server/_ES/Degradation/ESAirlockFailureEventSystem.cs
@@ -1,0 +1,38 @@
+using Content.Server._ES.Degradation.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared._ES.Degradation;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Humanoid;
+using Robust.Shared.Player;
+using Robust.Shared.Random;
+
+namespace Content.Server._ES.Degradation;
+
+public sealed class ESAirlockFailureEventSystem : StationEventSystem<ESAirlockFailureEventComponent>
+{
+    [Dependency] private readonly ESAirlockFailureSystem _airlockFailure = default!;
+
+    protected override void Started(EntityUid uid,
+        ESAirlockFailureEventComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        var validTargets = new List<EntityUid>();
+
+        var players = EntityQueryEnumerator<ActorComponent, HumanoidAppearanceComponent>();
+        while (players.MoveNext(out var player, out _, out _))
+        {
+            validTargets.Add(player);
+        }
+
+        foreach (var player in RobustRandom.GetItems(validTargets, RobustRandom.Next(component.MinCount, component.MaxCount + 1)))
+        {
+            _airlockFailure.AddFailureCharge(player);
+        }
+
+        ForceEndSelf(uid, gameRule);
+        QueueDel(uid);
+    }
+}

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -32,6 +32,10 @@ namespace Content.Shared.Doors.Systems;
 
 public abstract partial class SharedDoorSystem : EntitySystem
 {
+// ES START
+    [Dependency] private readonly ESDegradationSystem _degradation = default!;
+    [Dependency] private readonly ESAirlockFailureSystem _airlockFailure = default!;
+// ES END
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] protected readonly IGameTiming GameTiming = default!;
     [Dependency] private readonly INetManager _net = default!;
@@ -392,6 +396,13 @@ public abstract partial class SharedDoorSystem : EntitySystem
             Audio.PlayPredicted(door.OpenSound, uid, user, AudioParams.Default.WithVolume(-5));
         else if (_net.IsServer)
             Audio.PlayPvs(door.OpenSound, uid, AudioParams.Default.WithVolume(-5));
+
+// ES START
+        if (user.HasValue && _airlockFailure.TryUseFailureCharge(user.Value))
+        {
+            _degradation.Degrade(uid, user);
+        }
+// ES END
 
         if (lastState == DoorState.Emagging && TryComp<DoorBoltComponent>(uid, out var doorBoltComponent))
             SetBoltsDown((uid, doorBoltComponent), true, user, true);

--- a/Content.Shared/_ES/Degradation/Components/ESAirlockFailerComponent.cs
+++ b/Content.Shared/_ES/Degradation/Components/ESAirlockFailerComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Degradation.Components;
+
+/// <summary>
+/// Marker for players which causes them to cause airlock degradation when opening airlocks.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(ESAirlockFailureSystem))]
+public sealed partial class ESAirlockFailerComponent : Component
+{
+    /// <summary>
+    /// Amount of times this will trigger
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int Charges;
+
+    /// <summary>
+    /// Chance per door opening to fail
+    /// </summary>
+    [DataField]
+    public float FailChance = 0.33f;
+}

--- a/Content.Shared/_ES/Degradation/ESAirlockFailureSystem.cs
+++ b/Content.Shared/_ES/Degradation/ESAirlockFailureSystem.cs
@@ -1,0 +1,45 @@
+using Content.Shared._Citadel.Utilities;
+using Content.Shared._ES.Degradation.Components;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._ES.Degradation;
+
+public sealed class ESAirlockFailureSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    /// <summary>
+    /// Adds an airlock failure charge to the target entity.
+    /// </summary>
+    public void AddFailureCharge(EntityUid target)
+    {
+        var comp = EnsureComp<ESAirlockFailerComponent>(target);
+        ++comp.Charges;
+        Dirty(target, comp);
+    }
+
+    /// <summary>
+    /// Consumes an airlock failure charge, decrementing it and cleaning up the component if necessary.
+    /// </summary>
+    public bool TryUseFailureCharge(Entity<ESAirlockFailerComponent?> target)
+    {
+        if (!Resolve(target, ref target.Comp, false))
+            return false;
+
+        var seed = new RngSeed().SeedForStep((int) _timing.CurTick.Value + target.Owner.Id);
+        var random = seed.IntoRandomizer();
+
+        if (!random.Prob(target.Comp.FailChance))
+            return false;
+
+        --target.Comp.Charges;
+        Dirty(target);
+
+        if (target.Comp.Charges == 0)
+        {
+            RemCompDeferred(target, target.Comp);
+        }
+        return true;
+    }
+}

--- a/Content.Shared/_ES/Degradation/ESDegradationSystem.cs
+++ b/Content.Shared/_ES/Degradation/ESDegradationSystem.cs
@@ -2,8 +2,6 @@ using Content.Shared._ES.Degradation.Components;
 using Content.Shared._ES.Sparks;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
-using Content.Shared.Doors;
-using Content.Shared.Doors.Components;
 
 namespace Content.Shared._ES.Degradation;
 
@@ -15,19 +13,6 @@ public sealed class ESDegradationSystem : EntitySystem
 {
     [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     [Dependency] private readonly ESSparksSystem _sparks = default!;
-
-    /// <inheritdoc/>
-    public override void Initialize()
-    {
-        SubscribeLocalEvent<ESQueuedDegradationComponent, DoorStateChangedEvent>(OnDoorStateChanged);
-    }
-
-    private void OnDoorStateChanged(Entity<ESQueuedDegradationComponent> ent, ref DoorStateChangedEvent args)
-    {
-        if (args.State != DoorState.Open)
-            return;
-        Degrade(ent.Owner, null);
-    }
 
     public bool TryDegrade(Entity<ESQueuedDegradationComponent?> ent, EntityUid? user)
     {

--- a/Resources/Prototypes/_ES/GameRules/degradation_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/degradation_events.yml
@@ -4,7 +4,6 @@
   name: Unnamed Degradation Event
   abstract: true
   components:
-  - type: ESDegradationEvent
   - type: StationEvent
     earliestStart: 0
     reoccurrenceDelay: 0
@@ -30,12 +29,7 @@
   name: Airlock Bolt Breakage
   description: Breaks airlocks, making them get stuck when opened.
   components:
-  - type: ESDegradationEvent
-    count: 1, 5
-    component: Airlock
-    blacklist:
-      components:
-      - Docking
+  - type: ESAirlockFailureEvent
   - type: StationEvent
     weight: 50
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Changes the airlock bolt breakage degradation to be user-based rather than airlock-based.

The previous system would just mark the airlocks for degradation, then when they were opened, they'd bolt. This was overwhelming in practice. Primarily, because the airlocks would often be rarely used and thus would never trigger or trigger in obscure low-traffic places.

the new system marks a player, which then causes the next airlock they open (fuzzed a bit) to bolt open. This means that the airlocks affected are more likely to be high traffic zones that have real impact on traversal.

this is also how i originally envisioned the system working anyways. idk why i forgot to implement it like this because the results are like obviously underwhelming.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
