### PR TITLE
Add light overload random event

### DIFF
--- a/Content.Server/_ES/StationEvents/LightOverload/Components/ESApcVoteComponent.cs
+++ b/Content.Server/_ES/StationEvents/LightOverload/Components/ESApcVoteComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._ES.StationEvents.LightOverload.Components;
+
+[RegisterComponent]
+[Access(typeof(ESLightOverloadRule))]
+public sealed partial class ESApcVoteComponent : Component
+{
+    [DataField]
+    public int Count = 4;
+}

--- a/Content.Server/_ES/StationEvents/LightOverload/Components/ESLightOverloadRuleComponent.cs
+++ b/Content.Server/_ES/StationEvents/LightOverload/Components/ESLightOverloadRuleComponent.cs
@@ -5,5 +5,8 @@ namespace Content.Server._ES.StationEvents.LightOverload.Components;
 public sealed partial class ESLightOverloadRuleComponent : Component
 {
     [DataField]
-    public List<EntityUid> Apcs;
+    public List<EntityUid> Apcs = [];
+
+    [DataField]
+    public float Radius = 8f;
 }

--- a/Content.Server/_ES/StationEvents/LightOverload/Components/ESLightOverloadRuleComponent.cs
+++ b/Content.Server/_ES/StationEvents/LightOverload/Components/ESLightOverloadRuleComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._ES.StationEvents.LightOverload.Components;
+
+[RegisterComponent]
+[Access(typeof(ESLightOverloadRule))]
+public sealed partial class ESLightOverloadRuleComponent : Component
+{
+    [DataField]
+    public List<EntityUid> Apcs;
+}

--- a/Content.Server/_ES/StationEvents/LightOverload/ESLightOverloadRule.cs
+++ b/Content.Server/_ES/StationEvents/LightOverload/ESLightOverloadRule.cs
@@ -5,12 +5,14 @@ using Content.Server.StationEvents.Events;
 using Content.Shared._ES.Voting.Components;
 using Content.Shared._ES.Voting.Results;
 using Content.Shared.GameTicking.Components;
+using Content.Shared.Light.Components;
 using Robust.Shared.Random;
 
 namespace Content.Server._ES.StationEvents.LightOverload;
 
 public sealed class ESLightOverloadRule : StationEventSystem<ESLightOverloadRuleComponent>
 {
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly PoweredLightSystem _poweredLight = default!;
 
     /// <inheritdoc/>
@@ -65,13 +67,11 @@ public sealed class ESLightOverloadRule : StationEventSystem<ESLightOverloadRule
             if (TerminatingOrDeleted(apc))
                 return;
 
-            if (!TryComp<ApcPowerProviderComponent>(apc, out var apcPowerComponent))
-                return;
 
-            foreach (var receiverComp in apcPowerComponent.LinkedReceivers)
+            var coords = Transform(apc).Coordinates;
+            foreach (var light in _entityLookup.GetEntitiesInRange<PoweredLightComponent>(coords, component.Radius))
             {
-                var receiver = receiverComp.Owner;
-                _poweredLight.TryDestroyBulb(receiver);
+                _poweredLight.TryDestroyBulb(light);
             }
         }
     }

--- a/Content.Server/_ES/StationEvents/LightOverload/ESLightOverloadRule.cs
+++ b/Content.Server/_ES/StationEvents/LightOverload/ESLightOverloadRule.cs
@@ -1,0 +1,78 @@
+using Content.Server._ES.StationEvents.LightOverload.Components;
+using Content.Server.Light.EntitySystems;
+using Content.Server.Power.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared._ES.Voting.Components;
+using Content.Shared._ES.Voting.Results;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server._ES.StationEvents.LightOverload;
+
+public sealed class ESLightOverloadRule : StationEventSystem<ESLightOverloadRuleComponent>
+{
+    [Dependency] private readonly PoweredLightSystem _poweredLight = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESLightOverloadRuleComponent, ESSynchronizedVotesCompletedEvent>(OnSynchronizedVotesCompleted);
+        SubscribeLocalEvent<ESApcVoteComponent, ESGetVoteOptionsEvent>(OnGetVoteOptions);
+    }
+
+    private void OnSynchronizedVotesCompleted(Entity<ESLightOverloadRuleComponent> ent, ref ESSynchronizedVotesCompletedEvent args)
+    {
+        for (var i = 0; i < args.Results.Count; ++i)
+        {
+            if (args.TryGetResult<ESEntityVoteOption>(i, out var result) &&
+                TryGetEntity(result.Entity, out var apc))
+            {
+                ent.Comp.Apcs.Add(apc.Value);
+            }
+        }
+    }
+
+    private void OnGetVoteOptions(Entity<ESApcVoteComponent> ent, ref ESGetVoteOptionsEvent args)
+    {
+        var apcs = new List<EntityUid>();
+        var query = EntityQueryEnumerator<ApcComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            apcs.Add(uid);
+        }
+
+        foreach (var apc in RobustRandom.GetItems(apcs, Math.Min(apcs.Count, ent.Comp.Count)))
+        {
+            args.Options.Add(new ESEntityVoteOption
+            {
+                DisplayString = Name(apc),
+                Entity = GetNetEntity(apc),
+            });
+        }
+    }
+
+    protected override void Started(EntityUid uid,
+        ESLightOverloadRuleComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        foreach (var apc in component.Apcs)
+        {
+            if (TerminatingOrDeleted(apc))
+                return;
+
+            if (!TryComp<ApcPowerProviderComponent>(apc, out var apcPowerComponent))
+                return;
+
+            foreach (var receiverComp in apcPowerComponent.LinkedReceivers)
+            {
+                var receiver = receiverComp.Owner;
+                _poweredLight.TryDestroyBulb(receiver);
+            }
+        }
+    }
+}

--- a/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
+++ b/Content.Shared/Light/EntitySystems/SharedPoweredLightSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._ES.Sparks;
 using Content.Shared.Audio;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -39,6 +40,7 @@ public abstract class SharedPoweredLightSystem : EntitySystem
     [Dependency] private readonly SharedDeviceLinkSystem _deviceLink = default!;
 // ES START
     [Dependency] private readonly SharedGameTicker _gameTicker = default!;
+    [Dependency] private readonly ESSparksSystem _sparks = default!;
 // ES END
 
     private static readonly TimeSpan ThunkDelay = TimeSpan.FromSeconds(2);
@@ -249,6 +251,9 @@ public abstract class SharedPoweredLightSystem : EntitySystem
             return false;
 
         // break it
+// ES START
+        _sparks.DoSparks(uid, user: user, tileFireChance: 0.05f);
+// ES END
         _bulbSystem.SetState(bulbUid.Value, LightBulbState.Broken, lightBulb);
         _bulbSystem.PlayBreakSound(bulbUid.Value, lightBulb, user);
         UpdateLight(uid, light);

--- a/Resources/Locale/en-US/_ES/station-events/light-overload.ftl
+++ b/Resources/Locale/en-US/_ES/station-events/light-overload.ftl
@@ -1,0 +1,3 @@
+es-station-event-light-overload-start-announcement = An anomalous power surge has been detected in station's powernet. Low-voltage lighting equipment may be affected.
+
+es-voter-query-string-light-overload-location = The APC that will be overloaded is:

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -85,10 +85,6 @@
           collection: GlassBreak
   - type: PlacementReplacement
     key: lights
-# ES START
-  - type: ESSparkOnHit
-    tileFireChance: 0.05
-# ES END
   placement:
     mode: SnapgridCenter
     snap:

--- a/Resources/Prototypes/_ES/GameRules/station_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/station_events.yml
@@ -44,6 +44,7 @@
     - id: ESStationEventPowerGridCheck
     - id: ESStationEventSolarFlare
     - id: ESStationEventVentClog
+    - id: ESStationEventLightOverload
     - id: ESStationEventMeteorSwarm
     - id: ESStationEventElectricalFire
 
@@ -273,3 +274,30 @@
   - type: ESRandomLocationVote
     count: 6
     checkLOS: false
+
+## Light Overload
+- type: entity
+  parent: ESBaseStationEvent
+  id: ESStationEventLightOverload
+  name: Light Overload
+  description: Overload several APCs across the station, breaking all lights attached to them.
+  components:
+  - type: StationEvent
+    startAudio:
+      path: /Audio/_ES/Announcements/attention_medium.ogg
+      params:
+        volume: -4
+    startAnnouncement: es-station-event-light-overload-start-announcement
+  - type: ESLightOverloadRule
+  - type: ESSynchronizedVoteManager
+    votes:
+    - ESVoteLightOverloadAPC
+
+- type: entity
+  id: ESVoteLightOverloadAPC
+  name: Which APC should be overloaded?
+  components:
+  - type: ESVote
+    queryString: es-voter-query-string-light-overload-location
+    duration: 30
+  - type: ESApcVote


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Adds a new random event, the light overload. This picks a random APC (voted by stagehands) and breaks all the lights around it in a decently wide radius. This creates essentially a dark pocket on the station where various nefarious things can go on. It also necessitates some relatively easy low-level repair by a janitor or inspired do-gooder.

im sorry sadie i didnt make audio for it i was lazy

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="2008" height="2021" alt="image" src="https://github.com/user-attachments/assets/9513e1db-da16-43c6-bb15-466588cfa53c" />

overload on the APC underneath my person