### PR TITLE
Make weighted pick not pick 0-vote options

### DIFF
--- a/Content.Shared/_ES/Voting/ESSharedVoteSystem.cs
+++ b/Content.Shared/_ES/Voting/ESSharedVoteSystem.cs
@@ -137,11 +137,18 @@ public abstract partial class ESSharedVoteSystem : EntitySystem
                 result = _random.Pick(winningOptions);
                 break;
             case ResultStrategy.WeightedPick:
-                // Convert each option into a weight based on counts
-                var weights = ent.Comp.Votes
-                    .Select(p => (p.Key, (float) (1 + p.Value.Count))) // + 1 so every option can be chosen
-                    .ToDictionary();
-                result = _random.Pick(weights);
+                if (ent.Comp.Votes.Values.Sum(p => p.Count) == 0)
+                {
+                    result = _random.Pick(ent.Comp.VoteOptions);
+                }
+                else
+                {
+                    // Convert each option into a weight based on counts
+                    var weights = ent.Comp.Votes
+                        .Select(p => (p.Key, (float) p.Value.Count))
+                        .ToDictionary();
+                    result = _random.Pick(weights);
+                }
                 break;
             default:
                 throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1424 

don't ever pick things with 0 votes. The variation is nice when people actually are undecided but man it fucking sucks when people are voting and get ignored in favor of something literally 0 people want.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
