### PR TITLE
Improve avenger objectives

### DIFF
--- a/Content.Server/_ES/Masks/Avenger/Components/ESAvengeOnKillObjectiveComponent.cs
+++ b/Content.Server/_ES/Masks/Avenger/Components/ESAvengeOnKillObjectiveComponent.cs
@@ -19,5 +19,8 @@ public sealed partial class ESAvengeOnKillObjectiveComponent : Component
     public EntProtoId<ESTargetObjectiveComponent> AvengeObjective = "ESObjectiveAvengerKill";
 
     [DataField]
+    public LocId AvengeTitle = "es-objective-condition-avenge-title";
+
+    [DataField]
     public EntProtoId<ActionComponent> ActionPrototype = "ESActionMaskAvengerSense";
 }

--- a/Content.Server/_ES/Masks/Avenger/ESAvengeOnKillObjectiveSystem.cs
+++ b/Content.Server/_ES/Masks/Avenger/ESAvengeOnKillObjectiveSystem.cs
@@ -2,6 +2,7 @@ using Content.Server._ES.Masks.Avenger.Components;
 using Content.Server.Actions;
 using Content.Server.Chat.Managers;
 using Content.Server.Pinpointer;
+using Content.Server.Roles.Jobs;
 using Content.Shared._ES.KillTracking.Components;
 using Content.Shared._ES.Objectives.Target;
 using Content.Shared.Chat;
@@ -16,6 +17,8 @@ public sealed class ESAvengeOnKillObjectiveSystem : ESBaseTargetObjectiveSystem<
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly JobSystem _job = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
 
     public override Type[] TargetRelayComponents { get; } = [typeof(ESAvengeOnKillObjectiveMarkerComponent)];
@@ -70,8 +73,15 @@ public sealed class ESAvengeOnKillObjectiveSystem : ESBaseTargetObjectiveSystem<
         if (!ObjectivesSys.TryAddObjective(holder.Value.AsNullable(), avenge.Comp.AvengeObjective, out var objective))
             return;
         TargetObjective.SetTarget(objective.Value.Owner, args.Killer);
+        _metaData.SetEntityName(objective.Value,
+            Loc.GetString(avenge.Comp.AvengeTitle,
+            ("targetName", Name(args.Killed)),
+            ("job", _job.GetJobName(args.Killed))));
 
         if (mind?.OwnedEntity is { } body)
             _actions.AddAction(body, avenge.Comp.ActionPrototype);
+
+        // Remove the protect objective
+        ObjectivesSys.TryRemoveObjective(avenge.Owner);
     }
 }

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared.Mind;
 using Content.Shared.Players;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Roles.Components;
@@ -14,6 +15,9 @@ namespace Content.Shared.Roles.Jobs;
 /// </summary>
 public abstract class SharedJobSystem : EntitySystem
 {
+// ES START
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+// ES END
     [Dependency] private readonly SharedPlayerSystem _playerSystem = default!;
     [Dependency] private readonly IPrototypeManager _prototypes = default!;
     [Dependency] private readonly SharedRoleSystem _roles = default!;
@@ -206,6 +210,18 @@ public abstract class SharedJobSystem : EntitySystem
         MindTryGetJobName(mindId, out var name);
         return name;
     }
+// ES START
+    public string GetJobName(EntityUid uid)
+    {
+        if (_mind.TryGetMind(uid, out var mindId) &&
+            MindTryGetJobName(mindId, out var jobName))
+        {
+            return jobName;
+        }
+
+        return Loc.GetString("generic-unknown-title");
+    }
+// ES END
 
     public bool CanBeAntag(ICommonSession player)
     {

--- a/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
+++ b/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
@@ -360,12 +360,21 @@ public abstract partial class ESSharedObjectiveSystem : EntitySystem
         return true;
     }
 
+    public bool TryRemoveObjective(Entity<ESObjectiveComponent?> objective)
+    {
+        if (!TryFindObjectiveHolder(objective, out var holder))
+            return false;
+
+        return TryRemoveObjective(holder.Value.AsNullable(), objective);
+    }
+
     public bool TryRemoveObjective(Entity<ESObjectiveHolderComponent?> ent, Entity<ESObjectiveComponent?> objective)
     {
         if (!Resolve(ent, ref ent.Comp) || !Resolve(objective, ref objective.Comp))
             return false;
 
-        ent.Comp.OwnedObjectives.Remove(objective);
+        if (!ent.Comp.OwnedObjectives.Remove(objective))
+            return false;
         RegenerateObjectiveList(ent);
         Del(objective);
         return true;

--- a/Resources/Locale/en-US/_ES/masks/crew/avenger.ftl
+++ b/Resources/Locale/en-US/_ES/masks/crew/avenger.ftl
@@ -1,6 +1,9 @@
-es-avenger-die-message = {$name} has perished {$location}!
-es-avenger-die-message-kill = {$name} has perished {$location}! You must avenge them!
+es-avenger-die-message = {$name} has perished {$location}! You've failed your duty...
+es-avenger-die-message-kill = {$name} has been killed {$location}! You must avenge them!
 es-avenger-revenge-success = With {$name}'s death, you feel at peace...
+
+es-objective-condition-protect-title = Protect {$targetName}, {CAPITALIZE($job)}
+es-objective-condition-avenge-title = Avenge {$targetName}, {CAPITALIZE($job)}
 
 es-avenger-sense-gone = The killer is too far to ever reach!
 es-avenger-sense-far = The killer is far away, {$direction}!

--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -89,7 +89,6 @@ es-mask-sleeper-agent-desc = As a covert operative, you're a member of crew and 
 es-objective-issuer-mask = Mask
 
 es-objective-condition-crewmember-kill-title = Kill {$targetName}, {CAPITALIZE($job)}
-es-objective-condition-protect-title = Protect {$targetName}, {CAPITALIZE($job)}
 
 es-mask-gear-cache-messsage = Your gear can be found in {$cacheLocation}.
 

--- a/Resources/Prototypes/_ES/Objectives/Crew/avenger.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/avenger.yml
@@ -18,7 +18,7 @@
   parent: ESBaseMaskObjective
   id: ESObjectiveAvengerKill
   name: Avenge your protectee
-  description: Someone has slain your target. Use your special sense and hunt them down and kill them yourself. You must be the one to get revenge.
+  description: Someone has slain your protectee. Use your special sense and hunt them down and kill them yourself. You must be the one to get revenge.
   components:
   - type: ESObjective
     icon:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1394 

Smattering of changes:
- Made the messages the avenger receives when their target dies more explicit. I think it was kinda ambiguous whether you were in the win state or lose state.
- The avenge objective now actually states the target's name instead of just saying "protectee"
- The protect objective is now removed when you get the avenge objective. This allows the mask to work properly with secretaries, as before, you would never be able to succeed 100% if the original target died.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
