### PR TITLE
Triple antimatter contact damage

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Power/antimatter.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Power/antimatter.yml
@@ -37,7 +37,7 @@
   - type: DamageContacts
     damage:
       types:
-        Cellular: 5
+        Cellular: 15
   - type: Explosive
     explosionType: Default
     totalIntensity: 60


### PR DESCRIPTION
## About the PR
Closes #1383 

Antimatter with 5 dps kills you far too slowly. 15 dps allows you to have a few moments where you accidentally brush against it and live, but still severely punishes you for walking deep inside of it. It still takes a long time to kill you due to offmed, but the injuries you sustain are permanent and will lead to your death eventually.

## Media

https://github.com/user-attachments/assets/748a027c-af59-4039-9902-78fa34a5a971

