### PR TITLE
Adds damage deflection to structures

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -1,42 +1,25 @@
 - type: damageModifierSet
   id: Metallic
+# ES Start
+# We need to soft-disable all of the modifier prototypes used by structures, since we have damage deflection for that instead.
   coefficients:
-    Blunt: 0.7
-    Slash: 0.5
-    Piercing: 0.7
-    Shock: 1.2
-    Structural: 0.5
-  flatReductions:
-    Blunt: 5
-    Heat: 5
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: StructuralMetallicStrong
+# ES Start
   coefficients:
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.5
-    Shock: 1.2
-    Structural: 0.25
-  flatReductions:
-    Blunt: 10
-    Slash: 10
-    Piercing: 10
-    Heat: 10
-    Structural: 10
+    Structural: 1
+# ES End
+
 
 - type: damageModifierSet
   id: StructuralMetallic
+# ES Start
   coefficients:
-    Shock: 1.2
-    Heat: 1.2
-    Structural: 0.5
-  flatReductions:
-    Blunt: 10
-    Slash: 10
-    Piercing: 10
-    Heat: 10
-    Structural: 10
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Rock
@@ -61,114 +44,76 @@
 # for fragile electronics like consoles or shuttle engines.
 - type: damageModifierSet
   id: Electronic
+# ES Start
   coefficients:
-    Blunt: 0.7
-    Slash: 0.5
-    Piercing: 0.7
-    Shock: 2
-    Heat: 3
-    Structural: 0.5
+    Structural: 1
+# ES End
 
 # Like metallic, but without flat reduction so it can be damaged with fists.
 - type: damageModifierSet
   id: FlimsyMetallic
+# ES Start
   coefficients:
-    Blunt: 0.7
-    Slash: 0.5
-    Piercing: 0.7
-    Shock: 1.2
+    Structural: 1
+# ES End
 
 # Like metallic but very strong to resist most all basic tools and weapons.
 - type: damageModifierSet
   id: StrongMetallic
+# ES Start
   coefficients:
-    Blunt: 0.7
-    Slash: 0.5
-    Piercing: 0.7
-    Shock: 1.2
-  flatReductions:
-    Blunt: 10
-    Slash: 10
-    Piercing: 10
-    Shock: 10
-    Heat: 10
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Inflatable
+# ES Start
   coefficients:
-    Blunt: 0.5
-    Piercing: 2.0
-    Heat: 0.5
-    Shock: 0
-    Structural: 0.25
-  flatReductions:
-    Blunt: 5
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Glass
+# ES Start
   coefficients:
-    Blunt: 1.2
-    Slash: 0.5
-    Piercing: 1.0
-    Heat: 0.8
-    Shock: 0 #glass is an insulator!
-  flatReductions:
-    Slash: 5
-    Piercing: 5
-    Heat: 5
-    Structural: 5
+    Structural: 1
+# ES End
 
 # Glass without the flat reductions
 - type: damageModifierSet
   id: FlimsyGlass
+# ES Start
   coefficients:
-    Blunt: 1.2
-    Slash: 0.5
-    Piercing: 1.0
-    Heat: 0.8
-    Shock: 0 #glass is an insulator!
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: RGlass
+# ES Start
   coefficients:
-    Blunt: 0.5
-    Slash: 0.3
-    Piercing: 0.6
-    Heat: 0.5
-    Shock: 0
-    Structural: 0.5
-  flatReductions:
-    Blunt: 5
-    Slash: 5
-    Piercing: 5
-    Heat: 5
-    Structural: 10
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Wood
+# ES Start
   coefficients:
-    Blunt: 0.5
-    Slash: 2.0
-    Piercing: 1.0
-    Heat: 2.0
-    Structural: 0.5
-  flatReductions:
-    Blunt: 5
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Card
+# ES Start
   coefficients:
-    Slash: 2.0
-    Piercing: 0.1 # Holes easily poked through, but do little to structural integrity
-    Heat: 3.0
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Web # Very flammable, can be easily hacked and slashed, but shooting or hitting it is another story.
+# ES Start
   coefficients:
-    Blunt: 0.7
-    Slash: 1.4
-    Piercing: 0.7
-    Heat: 2.0
+    Structural: 1
+# ES End
 
 - type: damageModifierSet
   id: Slime

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: Airlock
-  parent: BaseStructure
+  parent: [ DeflectionSturdyStructure, BaseStructure ]
   name: airlock
   description: It opens, it closes, and maybe crushes you.
   components:
@@ -149,7 +149,9 @@
   - type: Occluder
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StrongMetallic
+# ES Start
+    damageModifierSet: ESMachine
+# ES End
   - type: RCDDeconstructable
     cost: 6
     delay: 8

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -1,7 +1,7 @@
 - type: entity
   id: BaseFirelock
   abstract: true
-  parent: BaseStructure
+  parent: [ DeflectionSturdyStructure, BaseStructure ]
   name: firelock
   description: Apply crowbar.
   components:
@@ -22,7 +22,7 @@
     - type: InteractionOutline
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: StructuralMetallicStrong
+      damageModifierSet: ESMachine
     - type: RCDDeconstructable
       cost: 4
       delay: 6
@@ -156,6 +156,11 @@
       - Fires
       - Spacing
     - type: SyncSprite
+# ES Start
+    - type: ESSparkOnHit
+      prob: 0.25
+      count: 2
+# ES End
 
 - type: entity
   id: Firelock

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/frame.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: FirelockFrame
-  parent: BaseStructureDynamic
+  parent: [ DeflectionSturdyStructure, BaseStructureDynamic ]
   name: firelock frame
   description: That is a firelock frame.
   components:
@@ -24,7 +24,7 @@
   - type: InteractionOutline
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
+    damageModifierSet: ESMachine
   - type: RCDDeconstructable
     cost: 4
     delay: 6

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: BlastDoor
-  parent: BaseShutter
+  parent: [ DeflectionVerySturdyStructure, BaseShutter ]
   name: blast door
   description: This one says 'BLAST DONGER'.
   components:
@@ -54,6 +54,7 @@
     messagePerceivedByOthers: comp-window-knock
     interactSuccessSound:
       path: /Audio/Effects/glass_knock.ogg
+
 
 - type: entity
   id: BlastDoorOpen

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: BaseShutter
-  parent: BaseStructure
+  parent: [ DeflectionSturdyStructure, BaseStructure ]
   name: shutter
   abstract: true
   description: One shudders to think about what might be behind this shutter.

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -87,7 +87,7 @@
       DoorStatus: false
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: Glass
+    damageModifierSet: ESWindow
   - type: ExaminableDamage
     messages: WindowMessages
   - type: RCDDeconstructable
@@ -225,7 +225,7 @@
       shader: unshaded
       visible: false
   - type: Damageable
-    damageModifierSet: RGlass
+    damageModifierSet: ESReinforcedWindow
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/Tables/base_structuretables.yml
@@ -47,14 +47,7 @@
   name: counter
   abstract: true
   components:
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.45"
-        density: 55
-        mask:
-        - TableMask
-        layer:
-        - TableLayer
+# ES Start
+  - type: ESDamageDeflection
+    threshold: 8 # Need a crowbar or better to break any structure. Fists, wrenches, etc. will not work on their own
+# ES End

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -39,7 +39,7 @@
     offset: "0, -0.5"
   - type: Damageable
     damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageModifierSet: ESMachine
   - type: RCDDeconstructable
     cost: 4
     delay: 2

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -26,7 +26,9 @@
     drawdepth: Objects
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: Electronic
+# ES Start
+    damageModifierSet: ESComputer
+# ES End
   - type: Destructible
     thresholds:
     - trigger:
@@ -51,6 +53,8 @@
     sprite: Structures/Machines/parts.rsi
 # ES START
     noRot: true
+  - type: Damageable
+    damageModifierSet: ESComputer
 # ES END
     layers:
     - state: 0
@@ -81,6 +85,8 @@
     state: broken
 # ES START
     noRot: true
+  - type: Damageable
+    damageModifierSet: ESMachine
 # ES END
   - type: Destructible
     thresholds:

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/frame.yml
@@ -53,8 +53,6 @@
     sprite: Structures/Machines/parts.rsi
 # ES START
     noRot: true
-  - type: Damageable
-    damageModifierSet: ESComputer
 # ES END
     layers:
     - state: 0

--- a/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/base_structuremachines.yml
@@ -24,7 +24,7 @@
         - MachineLayer
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
+    damageModifierSet: ESMachine
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -38,7 +38,7 @@
         machine_parts: !type:Container
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: Metallic
+      damageModifierSet: ESMachine
     - type: Destructible
       thresholds:
       - trigger: # Excess damage, don't spawn entities
@@ -102,7 +102,9 @@
         - machine_parts
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: Metallic
+# ES Start
+      damageModifierSet: ESMachine
+# ES End
     - type: Destructible
       thresholds:
       - trigger: # Excess damage, don't spawn entities
@@ -161,7 +163,9 @@
       node: destroyedMachineFrame
     - type: Damageable
       damageContainer: StructuralInorganic
-      damageModifierSet: Metallic
+# ES Start
+      damageModifierSet: ESMachine
+# ES End
     - type: Destructible
       thresholds:
       - trigger: # Excess damage, don't spawn entities

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -1,6 +1,6 @@
 - type: entity
   abstract: true
-  parent: [ BaseStructureDynamic, BasePaperLabelableVisualized ]
+  parent: [ DeflectionSturdyStructure, BaseStructureDynamic, BasePaperLabelableVisualized ]
   id: GasCanister
   name: gas canister
   description: A canister that can contain any type of gas. It can be attached to connector ports using a wrench.

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -1,10 +1,7 @@
 - type: entity
   id: LockerBase
-  parent: [ DeflectionVerySturdyStructure, ClosetBase ]
+  parent: ClosetBase
   abstract: true
-# ES Start
-  description: A top-of-the-line Nanotrasen storage unit. It's engineered to be as annoying as possible to break in to.
-# ES End
   components:
   - type: AccessReader
   - type: Lock
@@ -69,11 +66,10 @@
     count: 2
 # ES END
 
-# ES TODO: i have no idea what this prototype is even used for??
-# investigate and remove if it is pointless
 - type: entity
   id: LockerBaseSecure
-  parent: LockerBase
+  parent: [ LockerBase, DeflectionVerySturdyStructure ]
+  description: A top-of-the-line Nanotrasen storage unit. It's engineered to be as annoying as possible to break in to.
   abstract: true
   components:
 # ES Start

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -1,7 +1,10 @@
 - type: entity
   id: LockerBase
-  parent: ClosetBase
+  parent: [ DeflectionVerySturdyStructure, ClosetBase ]
   abstract: true
+# ES Start
+  description: A top-of-the-line Nanotrasen storage unit. It's engineered to be as annoying as possible to break in to.
+# ES End
   components:
   - type: AccessReader
   - type: Lock
@@ -29,13 +32,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 100
+        damage: 350
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -57,31 +60,38 @@
   - type: Paintable
     group: Locker
 # ES START
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: ESMachine
   - type: ESGreyTideVirusTarget
   - type: ESSparkOnHit
     prob: 0.25
     count: 2
 # ES END
 
+# ES TODO: i have no idea what this prototype is even used for??
+# investigate and remove if it is pointless
 - type: entity
   id: LockerBaseSecure
   parent: LockerBase
   abstract: true
   components:
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
+# ES Start
+#  - type: Damageable
+#    damageContainer: StructuralInorganic
+#    damageModifierSet: StructuralMetallic
+# ES End
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 350
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 300
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -79,9 +79,11 @@
   - type: Weldable
   - type: ResistLocker
 
+# ES TODO: make these use the same hp values as secure lockers as a shared prototype
 - type: entity
-  parent: CrateBaseWeldable
+  parent: [ DeflectionVerySturdyStructure, CrateBaseWeldable ]
   id: CrateBaseSecure
+  description: A secure container for items. It's engineered to be as annoying as possible to break in to.
   suffix: Secure
   components:
   - type: Lock
@@ -113,7 +115,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 75
+        damage: 350
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: Morgue
+  parent: DeflectionSturdyStructure
   name: morgue
   description: Used to store bodies until someone fetches them. Includes a high-tech alert system for false-positives!
   placement:
@@ -76,6 +77,7 @@
 
 - type: entity
   id: Crematorium
+  parent: DeflectionSturdyStructure
   name: crematorium
   description: A human incinerator. Works well on barbecue nights.
   placement:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/base_wallmount.yml
@@ -45,7 +45,7 @@
   components:
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
+    damageModifierSet: ESMachine
 
 - type: entity
   parent: BaseWallmountMetallic

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -37,7 +37,7 @@
     key: walls
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
+    damageModifierSet: ESWall
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -58,6 +58,8 @@
     resistance: 2
   - type: BlockWeather
   - type: SunShadowCast
+  - type: ESDamageDeflection
+    threshold: 45
 
 - type: entity
   abstract: true
@@ -605,7 +607,7 @@
     node: reinforcedWall
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallicStrong
+    damageModifierSet: ESWall
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/reinforced.yml
@@ -13,7 +13,9 @@
     doAfterDelay: 2
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: RGlass
+# ES Start
+    damageModifierSet: ESReinforcedWindow
+# ES End
   - type: RCDDeconstructable
     cost: 6
     delay: 6
@@ -22,7 +24,9 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150 #excess damage (nuke?). avoid computational cost of spawning entities.
+# ES Start
+        damage: 250 #excess damage (nuke?). avoid computational cost of spawning entities.
+# ES End
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -31,7 +35,9 @@
           collection: WindowShatter
     - trigger:
         !type:DamageTrigger
-        damage: 75
+# ES Start
+        damage: 200
+# ES End
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -51,7 +57,7 @@
   - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
-    damageDivisor: 3
+    damageDivisor: 8
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
@@ -78,12 +84,12 @@
   - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
-    damageDivisor: 1.5
+    damageDivisor: 4
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks_directional.rsi
   - type: Damageable
-    damageModifierSet: RGlass
+    damageModifierSet: ESReinforcedWindow
   - type: RCDDeconstructable
     cost: 4
     delay: 4
@@ -92,7 +98,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 75
+        damage: 150
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -101,7 +107,7 @@
           collection: WindowShatter
     - trigger:
         !type:DamageTrigger
-        damage: 37
+        damage: 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/rplasma.yml
@@ -10,14 +10,14 @@
     sprite: Structures/Windows/reinforced_plasma_window.rsi
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: RGlass
+    damageModifierSet: ESReinforcedWindow
   - type: RadiationBlocker
     resistance: 4
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 350
       behaviors: #excess damage, don't spawn entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -26,7 +26,7 @@
           collection: WindowShatter
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 300
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -49,7 +49,7 @@
   - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
-    damageDivisor: 6
+    damageDivisor: 9
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
@@ -78,25 +78,25 @@
   - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
-    damageDivisor: 3
+    damageDivisor: 4.5
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks_directional.rsi
   - type: Damageable
-    damageModifierSet: RGlass
+    damageModifierSet: ESReinforcedWindow
   - type: RadiationBlocker
     resistance: 2
   - type: Destructible
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 200
       behaviors: #excess damage, don't spawn entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 75
+        damage: 150
       behaviors:
       - !type:PlaySoundBehavior
         sound:

--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -50,7 +50,7 @@
         - GlassLayer
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: Glass
+    damageModifierSet: ESWindow
   - type: ExaminableDamage
     messages: WindowMessages
   - type: Repairable
@@ -71,7 +71,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 100
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -98,7 +98,7 @@
   - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
-    damageDivisor: 2
+    damageDivisor: 4
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
@@ -182,7 +182,7 @@
   - type: Repairable
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: Glass
+    damageModifierSet: ESWindow
   - type: ExaminableDamage
     messages: WindowMessages
   - type: RCDDeconstructable
@@ -193,7 +193,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 50 #excess damage (nuke?). avoid computational cost of spawning entities.
+        damage: 100 #excess damage (nuke?). avoid computational cost of spawning entities.
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -202,7 +202,7 @@
           collection: WindowShatter
     - trigger:
         !type:DamageTrigger
-        damage: 25
+        damage: 50
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -224,6 +224,7 @@
   - type: Appearance
   - type: DamageVisuals
     thresholds: [5, 10, 20]
+    damageDivisor: 2
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks_directional.rsi

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -26,6 +26,10 @@
   - type: Tag
     tags:
       - Structure
+# ES Start
+  - type: ESDamageDeflection
+    threshold: 6 # Need something better then your fists to break any structure.
+# ES End
 
 - type: entity
   # This means that it's not anchored on spawn.

--- a/Resources/Prototypes/_ES/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_ES/Damage/modifier_sets.yml
@@ -1,0 +1,40 @@
+# IMPORTANT: always prefer using damage deflection over making these, as it is less work and more intuitive.
+# avoid making bespoke resistance values unless your're trying to fill a niche that your object seriously needs / there's some kind of new property you want to add
+
+- type: damageModifierSet
+  id: ESWall # regular weapons should never work on walls, you need some insane firepower or explosives to do anything to them
+  flatReductions:
+    Blunt: 10
+    Slash: 30
+    Piercing: 30
+    Structural: 20 # fireaxe is not effective without this
+
+- type: damageModifierSet
+  id: ESWindow # gets instantly broken by 9mm, also you can't really cut windows very well
+  coefficients:
+    Piercing: 6
+    Structural: 4
+  flatReductions:
+    Slash: 8
+
+- type: damageModifierSet
+  id: ESReinforcedWindow # bulletproof glass. for consistency & gamefeel, piercing weapons are still effective, but it does not get instakilled by 9mm rounds like normal windows does.
+  coefficients:
+    Piercing: 2
+    Structural: 4
+  flatReductions:
+    Slash: 16
+
+- type: damageModifierSet
+  id: ESComputer # like glass except it can be cut & doesn't get owned by bullets as hard. fireaxe also insta-breaks them with these values.
+  coefficients:
+    Piercing: 3
+    Structural: 2
+  flatReductions:
+    Slash: 8
+
+- type: damageModifierSet
+  id: ESMachine # we don't usually want people easily breaking machines. so they have a bit of resistance against the most common weapon types
+  flatReductions:
+    Blunt: 2
+    Slash: 6

--- a/Resources/Prototypes/_ES/Entities/Structures/base_structureresistances.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/base_structureresistances.yml
@@ -1,0 +1,16 @@
+# this is for damage deflection thresholds that get reused multiple times across stuff that's not inherited (i.e walls don't count.)
+# you need to add these as the first inherited prototype to ensure they do not get overriden.
+
+- type: entity
+  id: DeflectionSturdyStructure # for airlocks and airlock-adjacent things like shutters
+  abstract: true
+  components:
+  - type: ESDamageDeflection
+    threshold: 18
+
+- type: entity
+  id: DeflectionVerySturdyStructure # for very strong structures that are meant to keep people out, like secure containers
+  abstract: true
+  components:
+  - type: ESDamageDeflection
+    threshold: 24


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
adds DD (damage deflection) to basically every structure, which blocks all damage unless it is above the given threshold. a summary of the micro-changes:
- every structure inherited from BaseStructure has 6 DD. you cannot break anything with your fists anymore
- if you do any damage, things will break much faster (at most a minute and a half instead of how it was before where you could do 0.2 damage to a wall for 5 minutes or whatever)
- the days of insane damage resistances for random stuff are gone (no more effectively immortal firelocks and windoors)
- airlocks and everything derivative of them are a lot stronger now and can only really be broken by bullets and the fireaxe
- walls cannot be broken by any weapon in the game. you need to deconstruct them or blow them up
- slash damage is generally now ineffective against most structures (especially windows)
- gunshots deal massively increased damage to windows and computers
- secure containers and blast doors cannot be broken in to easily. even most gunshots will not work, extremely strong weapons are required to break in (like a bunch of .357 rounds or the fireaxe)

this will definitely cause a lot of problems because some stuff randomly doesnt parent basestructure, the relation to damage values and stuff is completely different, etc.
please report any fist-breakable structures you find ingame

## Media
N/A