### PR TITLE
remove botany from toast

### DIFF
--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 275.0.0
   forkId: ""
   forkVersion: ""
-  time: 03/28/2026 21:51:44
-  entityCount: 14577
+  time: 03/30/2026 23:08:39
+  entityCount: 14517
 maps:
 - 3
 grids:
@@ -85,7 +85,7 @@ entities:
           version: 7
         -1,-2:
           ind: -1,-2
-          tiles: WQAAAAACAFkAAAAAAABZAAAAAAMAWQAAAAABAFkAAAAAAQBZAAAAAAAAWQAAAAADAFkAAAAAAwBZAAAAAAIAWQAAAAAAAFkAAAAAAQBZAAAAAAMAWQAAAAAAAFkAAAAAAQBZAAAAAAEAWQAAAAADAFkAAAAAAwBZAAAAAAEAWQAAAAACAFkAAAAAAABZAAAAAAEAWQAAAAADAFkAAAAAAwBZAAAAAAMAWQAAAAACAFkAAAAAAgBZAAAAAAAAWQAAAAABAFkAAAAAAQBZAAAAAAMAWQAAAAABAFkAAAAAAgBZAAAAAAMAWQAAAAADAFkAAAAAAgBZAAAAAAMAWQAAAAADAFkAAAAAAABZAAAAAAEAWQAAAAAAAFkAAAAAAwBZAAAAAAIAWQAAAAACAFkAAAAAAwBZAAAAAAEAWQAAAAACAFkAAAAAAABZAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAIAWQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAWQAAAAABAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAAAAFkAAAAAAgBZAAAAAAIAAQAAAAAAAAkAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAAAWQAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAABwAAAAADAAcAAAAAAgAHAAAAAAIABwAAAAAAAAcAAAAAAAAHAAAAAAMABwAAAAACAAcAAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAAcAAAAAAgBZAAAAAAAAWQAAAAACAFkAAAAAAwBZAAAAAAIAWQAAAAACAFkAAAAAAABZAAAAAAIAAQAAAAAAAFkAAAAAAwBZAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAAAHAAAAAAIAWQAAAAACAFkAAAAAAwBZAAAAAAEAWQAAAAAAAFkAAAAAAABZAAAAAAAAWQAAAAAAAFkAAAAAAQBZAAAAAAMAWQAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAABwAAAAAAAFkAAAAAAABZAAAAAAEAWQAAAAABAFkAAAAAAgBZAAAAAAMAWQAAAAAAAFkAAAAAAQBZAAAAAAEAWQAAAAAAAFkAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAgBZAAAAAAAAWQAAAAABAFkAAAAAAwBZAAAAAAEAWQAAAAADAFkAAAAAAwBZAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAAAAQAAAAAAAFkAAAAAAABZAAAAAAAAWQAAAAACAAcAAAAAAAAHAAAAAAMAWQAAAAABAFkAAAAAAQBZAAAAAAMAWQAAAAAAAFkAAAAAAABZAAAAAAIAWQAAAAACAAEAAAAAAABZAAAAAAAAWQAAAAABAAEAAAAAAABZAAAAAAAAWQAAAAADAFkAAAAAAAABAAAAAAAABwAAAAACAAcAAAAAAwAHAAAAAAEABwAAAAAAAAcAAAAAAAAHAAAAAAEAWQAAAAABAFkAAAAAAgBZAAAAAAAAWQAAAAADAFkAAAAAAAABAAAAAAAAWQAAAAABAFkAAAAAAQBZAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAACAFkAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAQBZAAAAAAMACQAAAAAAAFkAAAAAAABZAAAAAAAAWQAAAAAAAFkAAAAAAAADAAAAAAIAAwAAAAACAAMAAAAAAwADAAAAAAIAAwAAAAADAAMAAAAAAAADAAAAAAMAAwAAAAACAFkAAAAAAQBZAAAAAAIAWQAAAAACAA==
+          tiles: WQAAAAACAFkAAAAAAABZAAAAAAMAWQAAAAABAFkAAAAAAQBZAAAAAAAAWQAAAAADAFkAAAAAAwBZAAAAAAIAWQAAAAAAAFkAAAAAAQBZAAAAAAMAWQAAAAAAAFkAAAAAAQBZAAAAAAEAWQAAAAADAFkAAAAAAwBZAAAAAAEAWQAAAAACAFkAAAAAAABZAAAAAAEAWQAAAAADAFkAAAAAAwBZAAAAAAMAWQAAAAACAFkAAAAAAgBZAAAAAAAAWQAAAAABAFkAAAAAAQBZAAAAAAMAWQAAAAABAFkAAAAAAgBZAAAAAAMAWQAAAAADAFkAAAAAAgBZAAAAAAMAWQAAAAADAFkAAAAAAABZAAAAAAEAWQAAAAAAAFkAAAAAAwBZAAAAAAIAWQAAAAACAFkAAAAAAwBZAAAAAAEAWQAAAAACAFkAAAAAAABZAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAIAWQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAWQAAAAABAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAAAAFkAAAAAAgBZAAAAAAIAAQAAAAAAAAkAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAAAWQAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABsAAAAAAAAbAAAAAAAAGwAAAAAAABsAAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAbAAAAAAAAAQAAAAAAABsAAAAAAAAbAAAAAAAAAQAAAAAAAFkAAAAAAwBZAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAGwAAAAAAABsAAAAAAAAbAAAAAAAAGwAAAAAAAAEAAAAAAABZAAAAAAMAWQAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAABsAAAAAAAAbAAAAAAAAGwAAAAAAABsAAAAAAAABAAAAAAAAWQAAAAAAAFkAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAAAAQAAAAAAAFkAAAAAAABZAAAAAAAAWQAAAAAAAAcAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAEAAAAAAABZAAAAAAAAWQAAAAABAAEAAAAAAABZAAAAAAAAWQAAAAADAFkAAAAAAAABAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAAABAAAAAAAAWQAAAAABAFkAAAAAAQBZAAAAAAEAAQAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAADAAAAAAAAAQAAAAAAAFkAAAAAAQBZAAAAAAMACQAAAAAAAFkAAAAAAABZAAAAAAAAWQAAAAAAAFkAAAAAAAADAAAAAAIAAwAAAAACAAMAAAAAAwADAAAAAAIAAwAAAAADAAMAAAAAAAADAAAAAAMAAwAAAAACAFkAAAAAAQBZAAAAAAIAWQAAAAACAA==
           version: 7
         0,-2:
           ind: 0,-2
@@ -97,7 +97,7 @@ entities:
           version: 7
         -1,-3:
           ind: -1,-3
-          tiles: AQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAIADwAAAAAAAA8AAAAAAABZAAAAAAEAWQAAAAAAAAEAAAAAAABZAAAAAAIAWQAAAAACAFkAAAAAAABZAAAAAAMAWQAAAAABAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAABZAAAAAAMAWQAAAAAAAA8AAAAAAAAPAAAAAAAAWQAAAAADAFkAAAAAAQABAAAAAAAAWQAAAAAAAFkAAAAAAwBZAAAAAAEAWQAAAAAAAFkAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAwAPAAAAAAAADwAAAAAAAFkAAAAAAwBZAAAAAAIAAQAAAAAAAFkAAAAAAgAHAAAAAAEABwAAAAADAFkAAAAAAQBZAAAAAAMAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAEAWQAAAAACAFkAAAAAAQBZAAAAAAIAWQAAAAAAAFkAAAAAAwBZAAAAAAIABwAAAAABAAcAAAAAAgBZAAAAAAIAWQAAAAACAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAABZAAAAAAIAWQAAAAADAFkAAAAAAgBZAAAAAAEAWQAAAAABAFkAAAAAAABZAAAAAAAAWQAAAAABAAcAAAAAAwAHAAAAAAAAWQAAAAACAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAQAHAAAAAAAABwAAAAADAFkAAAAAAwBZAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAkAAAAAAABZAAAAAAEAWQAAAAABAFkAAAAAAwBZAAAAAAIAWQAAAAABAAEAAAAAAAAXAAAAAAIABQAAAAADAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAwAXAAAAAAAABQAAAAABAAUAAAAAAwAXAAAAAAQABQAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAIAWQAAAAADAFkAAAAAAABZAAAAAAIABQAAAAAAAAUAAAAAAwAXAAAAAAAABQAAAAABAAUAAAAAAQAXAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAEAWQAAAAABAFkAAAAAAgBZAAAAAAMAWQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAWQAAAAAAAFkAAAAAAQBZAAAAAAEAWQAAAAABAFkAAAAAAAAbAAAAAAIAGwAAAAABABsAAAAAAwAbAAAAAAMAGwAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAFkAAAAAAABZAAAAAAMAWQAAAAACAFkAAAAAAwBZAAAAAAAAGwAAAAADABsAAAAAAAABAAAAAAAAGwAAAAAAABsAAAAAAgABAAAAAAAADwAAAAAAAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAwBZAAAAAAMAWQAAAAABABsAAAAAAQAbAAAAAAEAGwAAAAAAABsAAAAAAQAbAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAABZAAAAAAMAWQAAAAADAFkAAAAAAwAbAAAAAAEAGwAAAAADABsAAAAAAAAbAAAAAAMAGwAAAAACAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAEAWQAAAAAAAFkAAAAAAQBZAAAAAAIAAQAAAAAAAAEAAAAAAABZAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAWQAAAAACAFkAAAAAAgBZAAAAAAIAAQAAAAAAAAEAAAAAAABZAAAAAAMAWQAAAAACAFkAAAAAAQBZAAAAAAIAWQAAAAABAA==
+          tiles: AQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAIADwAAAAAAAA8AAAAAAABZAAAAAAEAWQAAAAAAAAEAAAAAAABZAAAAAAIAWQAAAAACAFkAAAAAAABZAAAAAAMAWQAAAAABAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAABZAAAAAAMAWQAAAAAAAA8AAAAAAAAPAAAAAAAAWQAAAAADAFkAAAAAAQABAAAAAAAAWQAAAAAAAFkAAAAAAwBZAAAAAAEAWQAAAAAAAFkAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAwAPAAAAAAAADwAAAAAAAFkAAAAAAwBZAAAAAAIAAQAAAAAAAFkAAAAAAgAHAAAAAAEABwAAAAADAFkAAAAAAQBZAAAAAAMAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAEAWQAAAAACAFkAAAAAAQBZAAAAAAIAWQAAAAAAAFkAAAAAAwBZAAAAAAIABwAAAAABAAcAAAAAAgBZAAAAAAIAWQAAAAACAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAABZAAAAAAIAWQAAAAADAFkAAAAAAgBZAAAAAAEAWQAAAAABAFkAAAAAAABZAAAAAAAAWQAAAAABAAcAAAAAAwAHAAAAAAAAWQAAAAACAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAQAHAAAAAAAABwAAAAADAFkAAAAAAwBZAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAkAAAAAAABZAAAAAAEAWQAAAAABAFkAAAAAAwBZAAAAAAIAWQAAAAABAAEAAAAAAAAXAAAAAAIABQAAAAADAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAwAXAAAAAAAABQAAAAABAAUAAAAAAwAXAAAAAAQABQAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAIAWQAAAAADAFkAAAAAAABZAAAAAAIABQAAAAAAAAUAAAAAAwAXAAAAAAAABQAAAAABAAUAAAAAAQAXAAAAAAEAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAABZAAAAAAEAWQAAAAABAFkAAAAAAgBZAAAAAAMAWQAAAAAAAAEAAAAAAAABAAAAAAAACQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAJAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAWQAAAAAAAFkAAAAAAQBZAAAAAAEAWQAAAAABAFkAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAAEAAAAAAAAPAAAAAAAAAQAAAAAAAFkAAAAAAABZAAAAAAMAWQAAAAACAFkAAAAAAwBZAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAAABAAAAAAAADwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAwBZAAAAAAMAWQAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA8AAAAAAAABAAAAAAAAWQAAAAADAFkAAAAAAABZAAAAAAMAWQAAAAADAFkAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAFkAAAAAAgBZAAAAAAEAWQAAAAAAAFkAAAAAAQBZAAAAAAIAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAWQAAAAACAFkAAAAAAgBZAAAAAAIAAQAAAAAAAAEAAAAAAABZAAAAAAMAWQAAAAACAFkAAAAAAQBZAAAAAAIAWQAAAAABAA==
           version: 7
         0,-3:
           ind: 0,-3
@@ -326,13 +326,13 @@ entities:
             742: -19,-43
             743: -18,-43
             744: -18,-36
-            745: -16,-35
-            746: -16,-34
             776: 6,-16
             977: -27,-24
             1021: -24,5
             1022: -24,6
             1029: -21,-24
+            1125: -4,-22
+            1126: -4,-24
         - node:
             color: '#FF00FFFF'
             id: BotGreyscale
@@ -347,7 +347,6 @@ entities:
             color: '#FFFFFFFF'
             id: BotLeftGreyscale
           decals:
-            3: -9,-19
             234: 22,-29
             398: -45,-5
             399: -47,-7
@@ -367,21 +366,20 @@ entities:
             color: '#9FED587D'
             id: CheckerNESW
           decals:
-            806: -9,-21
-            807: -9,-22
-            808: -9,-23
-            809: -7,-23
-            810: -8,-23
-            811: -8,-22
-            812: -8,-21
-            813: -7,-21
-            814: -7,-22
-            815: -6,-21
-            816: -6,-22
-            817: -6,-23
-            818: -5,-23
-            819: -5,-22
-            820: -5,-21
+            1128: -9,-18
+            1129: -8,-18
+            1130: -7,-18
+            1132: -6,-19
+            1133: -7,-19
+            1134: -8,-19
+            1135: -9,-19
+            1136: -6,-18
+            1137: -4,-18
+            1138: -4,-19
+            1139: -4,-20
+            1147: -11,-18
+            1148: -11,-19
+            1149: -11,-20
         - node:
             color: '#52B4E97D'
             id: CheckerNWSE
@@ -417,8 +415,6 @@ entities:
             color: '#FFFFFFFF'
             id: Delivery
           decals:
-            1: -6,-19
-            2: -9,-18
             31: 1,-23
             32: 1,-22
             111: -6,4
@@ -840,16 +836,6 @@ entities:
             890: 3,-35
             891: 3,-34
             892: 3,-33
-        - node:
-            color: '#D37DC97D'
-            id: QuarterTileOverlayGreyscale180
-          decals:
-            828: -16,-32
-            829: -15,-32
-            830: -14,-32
-            831: -13,-32
-            832: -12,-32
-            902: -17,-32
         - node:
             color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale180
@@ -1294,7 +1280,7 @@ entities:
           -3,-1:
             0: 65295
           -3,-5:
-            0: 63727
+            0: 65262
           -3,0:
             0: 65327
           -2,-4:
@@ -1306,7 +1292,7 @@ entities:
           -2,-1:
             0: 65295
           -2,-5:
-            0: 61695
+            0: 65535
           -2,0:
             0: 24015
           -1,-4:
@@ -1318,7 +1304,7 @@ entities:
           -1,-1:
             0: 65485
           -1,-5:
-            0: 64765
+            0: 64989
           -1,0:
             0: 36863
           0,-4:
@@ -1485,7 +1471,7 @@ entities:
           -7,-1:
             0: 65295
           -7,0:
-            0: 63359
+            0: 61567
           -7,-5:
             0: 53247
           -6,-4:
@@ -1584,20 +1570,18 @@ entities:
             0: 58111
           -4,-6:
             0: 3822
-          -4,-9:
-            0: 20479
           -3,-8:
             0: 4095
           -3,-7:
             0: 58623
           -3,-6:
-            0: 61166
+            0: 3822
           -2,-8:
             0: 4095
           -2,-7:
-            0: 61695
+            0: 58623
           -2,-6:
-            0: 65535
+            0: 3822
           -2,-9:
             0: 35763
           -1,-8:
@@ -1605,7 +1589,7 @@ entities:
           -1,-7:
             0: 56573
           -1,-6:
-            0: 56797
+            0: 52733
           -1,-9:
             0: 65520
           0,-8:
@@ -1688,6 +1672,8 @@ entities:
             0: 65335
           -4,-10:
             0: 62719
+          -4,-9:
+            0: 4095
           -4,-13:
             0: 16106
           -3,-12:
@@ -2746,6 +2732,18 @@ entities:
       container: 14198
 - proto: AirAlarm
   entities:
+  - uid: 812
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-20.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 10464
+      - 10350
+    - type: Fixtures
+      fixtures: {}
   - uid: 1016
     components:
     - type: Transform
@@ -2896,6 +2894,18 @@ entities:
       - 9307
     - type: Fixtures
       fixtures: {}
+  - uid: 5902
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-22.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 5796
+      - 862
+    - type: Fixtures
+      fixtures: {}
   - uid: 7067
     components:
     - type: Transform
@@ -2959,18 +2969,6 @@ entities:
       - 5185
       - 10341
       - 5172
-    - type: Fixtures
-      fixtures: {}
-  - uid: 10884
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-17.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 10534
-      - 10464
     - type: Fixtures
       fixtures: {}
   - uid: 11921
@@ -3295,18 +3293,6 @@ entities:
       - 10506
     - type: Fixtures
       fixtures: {}
-  - uid: 11955
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,-25.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 10571
-      - 10543
-    - type: Fixtures
-      fixtures: {}
   - uid: 11956
     components:
     - type: Transform
@@ -3315,20 +3301,8 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 10529
-      - 10480
-    - type: Fixtures
-      fixtures: {}
-  - uid: 11957
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,-35.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 10794
-      - 10770
+      - 10466
+      - 5317
     - type: Fixtures
       fixtures: {}
   - uid: 11958
@@ -3689,25 +3663,21 @@ entities:
   - uid: 6830
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,12.5
       parent: 2
   - uid: 6838
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -45.5,12.5
       parent: 2
   - uid: 6839
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,7.5
       parent: 2
   - uid: 6840
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -50.5,4.5
       parent: 2
 - proto: AirlockAtmosphericsGlassLocked
@@ -3739,7 +3709,6 @@ entities:
   - uid: 142
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,-7.5
       parent: 2
 - proto: AirlockBrigGlassLocked
@@ -3841,7 +3810,6 @@ entities:
   - uid: 5074
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-35.5
       parent: 2
 - proto: AirlockEngineeringGlassLocked
@@ -3866,7 +3834,6 @@ entities:
   - uid: 31
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -36.5,-21.5
       parent: 2
   - uid: 374
@@ -3877,7 +3844,6 @@ entities:
   - uid: 898
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,-21.5
       parent: 2
   - uid: 1574
@@ -3888,13 +3854,11 @@ entities:
   - uid: 3840
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,-15.5
       parent: 2
   - uid: 3841
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -46.5,-15.5
       parent: 2
   - uid: 4255
@@ -3910,7 +3874,6 @@ entities:
   - uid: 9535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -46.5,-21.5
       parent: 2
   - uid: 13378
@@ -3935,7 +3898,6 @@ entities:
   - uid: 7443
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -74.5,-24.5
       parent: 2
     - type: DeviceLinkSink
@@ -3948,7 +3910,6 @@ entities:
   - uid: 7444
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -72.5,-24.5
       parent: 2
     - type: DeviceLinkSink
@@ -3961,7 +3922,6 @@ entities:
   - uid: 7639
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -61.5,-39.5
       parent: 2
     - type: DeviceLinkSink
@@ -3974,7 +3934,6 @@ entities:
   - uid: 7640
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -63.5,-41.5
       parent: 2
     - type: DeviceLinkSink
@@ -4047,7 +4006,6 @@ entities:
   - uid: 14084
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-53.5
       parent: 2
     - type: DeviceLinkSink
@@ -4060,7 +4018,6 @@ entities:
   - uid: 14085
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-55.5
       parent: 2
     - type: DeviceLinkSink
@@ -4297,7 +4254,6 @@ entities:
   - uid: 1664
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-28.5
       parent: 2
   - uid: 1992
@@ -4363,7 +4319,6 @@ entities:
   - uid: 6521
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,1.5
       parent: 2
 - proto: AirlockHeadOfPersonnelLocked
@@ -4376,35 +4331,20 @@ entities:
   - uid: 5264
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,8.5
-      parent: 2
-- proto: AirlockHydroponicsLocked
-  entities:
-  - uid: 319
-    components:
-    - type: Transform
-      pos: -2.5,-18.5
-      parent: 2
-  - uid: 3688
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,-19.5
       parent: 2
 - proto: AirlockJanitorLocked
   entities:
-  - uid: 5268
+  - uid: 176
     components:
     - type: Transform
-      pos: -13.5,-32.5
+      pos: -2.5,-22.5
       parent: 2
 - proto: AirlockKitchenLocked
   entities:
   - uid: 167
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,-16.5
       parent: 2
   - uid: 406
@@ -4436,7 +4376,6 @@ entities:
   - uid: 520
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-47.5
       parent: 2
   - uid: 2710
@@ -4466,7 +4405,6 @@ entities:
   - uid: 5337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-36.5
       parent: 2
 - proto: AirlockMaintEngiLocked
@@ -4474,13 +4412,11 @@ entities:
   - uid: 3815
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-28.5
       parent: 2
   - uid: 4335
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -50.5,-0.5
       parent: 2
 - proto: AirlockMaintHOPLocked
@@ -4490,19 +4426,12 @@ entities:
     - type: Transform
       pos: -2.5,10.5
       parent: 2
-- proto: AirlockMaintHydroLocked
-  entities:
-  - uid: 6640
-    components:
-    - type: Transform
-      pos: -9.5,-25.5
-      parent: 2
 - proto: AirlockMaintJanitorLocked
   entities:
-  - uid: 5267
+  - uid: 7280
     components:
     - type: Transform
-      pos: -13.5,-37.5
+      pos: -5.5,-25.5
       parent: 2
 - proto: AirlockMaintKitchenLocked
   entities:
@@ -4516,13 +4445,11 @@ entities:
   - uid: 1401
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,4.5
       parent: 2
   - uid: 1402
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,8.5
       parent: 2
   - uid: 3139
@@ -4558,7 +4485,6 @@ entities:
   - uid: 6517
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,6.5
       parent: 2
   - uid: 6638
@@ -4569,7 +4495,6 @@ entities:
   - uid: 6853
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -55.5,-36.5
       parent: 2
   - uid: 7492
@@ -4585,25 +4510,21 @@ entities:
   - uid: 7553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-32.5
       parent: 2
   - uid: 7556
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-32.5
       parent: 2
   - uid: 7557
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -51.5,-29.5
       parent: 2
   - uid: 7558
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -61.5,-32.5
       parent: 2
   - uid: 7560
@@ -4614,13 +4535,11 @@ entities:
   - uid: 7562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -68.5,-24.5
       parent: 2
   - uid: 7569
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,2.5
       parent: 2
   - uid: 7922
@@ -4646,13 +4565,11 @@ entities:
   - uid: 8908
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,13.5
       parent: 2
   - uid: 8910
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,12.5
       parent: 2
   - uid: 12463
@@ -4663,7 +4580,6 @@ entities:
   - uid: 12467
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -52.5,19.5
       parent: 2
   - uid: 12475
@@ -4704,19 +4620,16 @@ entities:
   - uid: 13947
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,-51.5
       parent: 2
   - uid: 14056
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-41.5
       parent: 2
   - uid: 14062
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-52.5
       parent: 2
 - proto: AirlockMaintMedLocked
@@ -4724,7 +4637,6 @@ entities:
   - uid: 1400
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,6.5
       parent: 2
   - uid: 3074
@@ -4740,7 +4652,6 @@ entities:
   - uid: 8534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-1.5
       parent: 2
   - uid: 8535
@@ -4751,13 +4662,11 @@ entities:
   - uid: 11171
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-7.5
       parent: 2
   - uid: 11547
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-7.5
       parent: 2
 - proto: AirlockMaintRnDLocked
@@ -4792,7 +4701,6 @@ entities:
   - uid: 6704
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-36.5
       parent: 2
 - proto: AirlockMaintServiceLocked
@@ -4800,7 +4708,6 @@ entities:
   - uid: 2919
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,-16.5
       parent: 2
   - uid: 5042
@@ -4833,13 +4740,11 @@ entities:
   - uid: 207
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,4.5
       parent: 2
   - uid: 224
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-0.5
       parent: 2
 - proto: AirlockMedicalMorgueMaintLocked
@@ -4883,7 +4788,6 @@ entities:
   - uid: 2771
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-14.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
@@ -4919,7 +4823,6 @@ entities:
   - uid: 6700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-37.5
       parent: 2
 - proto: AirlockServiceGlassLocked
@@ -5002,15 +4905,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,-22.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 299
-    components:
-    - type: MetaData
-      name: Hydroponics APC
-    - type: Transform
-      pos: -3.5,-17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -5437,13 +5331,12 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 5326
+  - uid: 5327
     components:
     - type: MetaData
-      name: Jani APC
+      name: Janitor Closet APC
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,-37.5
+      pos: -5.5,-20.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -6116,13 +6009,6 @@ entities:
     - type: Transform
       pos: 10.5,-37.5
       parent: 2
-- proto: Biogenerator
-  entities:
-  - uid: 324
-    components:
-    - type: Transform
-      pos: -6.5,-20.5
-      parent: 2
 - proto: BlastDoor
   entities:
   - uid: 3966
@@ -6354,6 +6240,14 @@ entities:
     - type: Transform
       pos: -52.5,-25.5
       parent: 2
+- proto: BoxFolderBaseThreePapers
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.515399,-35.123524
+      parent: 2
 - proto: BoxFolderBlue
   entities:
   - uid: 2446
@@ -6429,25 +6323,25 @@ entities:
       parent: 2
 - proto: Bucket
   entities:
-  - uid: 343
+  - uid: 858
     components:
     - type: Transform
-      pos: -4.5,-18.5
+      pos: -6.629437,-23.330805
+      parent: 2
+  - uid: 872
+    components:
+    - type: Transform
+      pos: -6.2622495,-23.53393
       parent: 2
   - uid: 3101
     components:
     - type: Transform
       pos: -25.5,-9.5
       parent: 2
-  - uid: 5315
+  - uid: 5446
     components:
     - type: Transform
-      pos: -15.502963,-35.44067
-      parent: 2
-  - uid: 14589
-    components:
-    - type: Transform
-      pos: -15.299164,-35.545246
+      pos: -10.531975,-18.365225
       parent: 2
 - proto: ButtonFrameCaution
   entities:
@@ -6506,11 +6400,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-20.5
       parent: 2
-  - uid: 14316
-    components:
-    - type: Transform
-      pos: -4.5,-17.5
-      parent: 2
 - proto: C4
   entities:
   - uid: 3878
@@ -6540,30 +6429,30 @@ entities:
     - type: Transform
       pos: -16.5,-23.5
       parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 2
   - uid: 257
     components:
     - type: Transform
       pos: -13.5,-17.5
-      parent: 2
-  - uid: 263
-    components:
-    - type: Transform
-      pos: -3.5,-19.5
       parent: 2
   - uid: 293
     components:
     - type: Transform
       pos: -13.5,-16.5
       parent: 2
-  - uid: 295
-    components:
-    - type: Transform
-      pos: -3.5,-18.5
-      parent: 2
   - uid: 296
     components:
     - type: Transform
       pos: -13.5,-18.5
+      parent: 2
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -4.5,-22.5
       parent: 2
   - uid: 307
     components:
@@ -6580,10 +6469,35 @@ entities:
     - type: Transform
       pos: -14.5,-23.5
       parent: 2
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -4.5,-23.5
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -5.5,-21.5
+      parent: 2
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -5.5,-20.5
+      parent: 2
   - uid: 320
     components:
     - type: Transform
       pos: -13.5,-19.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -5.5,-22.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
       parent: 2
   - uid: 350
     components:
@@ -6674,6 +6588,11 @@ entities:
     components:
     - type: Transform
       pos: 17.5,-16.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
       parent: 2
   - uid: 608
     components:
@@ -6920,6 +6839,21 @@ entities:
     - type: Transform
       pos: 16.5,-16.5
       parent: 2
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 2
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -4.5,-19.5
+      parent: 2
+  - uid: 802
+    components:
+    - type: Transform
+      pos: -5.5,-19.5
+      parent: 2
   - uid: 816
     components:
     - type: Transform
@@ -7115,85 +7049,10 @@ entities:
     - type: Transform
       pos: -4.5,-15.5
       parent: 2
-  - uid: 858
-    components:
-    - type: Transform
-      pos: -8.5,-21.5
-      parent: 2
-  - uid: 859
-    components:
-    - type: Transform
-      pos: -8.5,-20.5
-      parent: 2
-  - uid: 860
-    components:
-    - type: Transform
-      pos: -8.5,-19.5
-      parent: 2
-  - uid: 861
-    components:
-    - type: Transform
-      pos: -7.5,-19.5
-      parent: 2
-  - uid: 862
-    components:
-    - type: Transform
-      pos: -6.5,-19.5
-      parent: 2
-  - uid: 863
-    components:
-    - type: Transform
-      pos: -5.5,-19.5
-      parent: 2
-  - uid: 864
-    components:
-    - type: Transform
-      pos: -4.5,-19.5
-      parent: 2
-  - uid: 865
-    components:
-    - type: Transform
-      pos: -4.5,-20.5
-      parent: 2
-  - uid: 866
-    components:
-    - type: Transform
-      pos: -4.5,-21.5
-      parent: 2
   - uid: 867
     components:
     - type: Transform
-      pos: -4.5,-22.5
-      parent: 2
-  - uid: 868
-    components:
-    - type: Transform
-      pos: -4.5,-23.5
-      parent: 2
-  - uid: 869
-    components:
-    - type: Transform
-      pos: -5.5,-23.5
-      parent: 2
-  - uid: 870
-    components:
-    - type: Transform
-      pos: -6.5,-23.5
-      parent: 2
-  - uid: 871
-    components:
-    - type: Transform
-      pos: -7.5,-23.5
-      parent: 2
-  - uid: 872
-    components:
-    - type: Transform
-      pos: -8.5,-23.5
-      parent: 2
-  - uid: 873
-    components:
-    - type: Transform
-      pos: -8.5,-22.5
+      pos: -7.5,-19.5
       parent: 2
   - uid: 886
     components:
@@ -8415,11 +8274,6 @@ entities:
     - type: Transform
       pos: -16.5,-19.5
       parent: 2
-  - uid: 3229
-    components:
-    - type: Transform
-      pos: -3.5,-17.5
-      parent: 2
   - uid: 3277
     components:
     - type: Transform
@@ -8739,6 +8593,11 @@ entities:
     components:
     - type: Transform
       pos: -43.5,-31.5
+      parent: 2
+  - uid: 3748
+    components:
+    - type: Transform
+      pos: -8.5,-19.5
       parent: 2
   - uid: 3755
     components:
@@ -9838,32 +9697,12 @@ entities:
   - uid: 5319
     components:
     - type: Transform
-      pos: -13.5,-36.5
+      pos: -6.5,-19.5
       parent: 2
-  - uid: 5327
+  - uid: 5331
     components:
     - type: Transform
-      pos: -12.5,-37.5
-      parent: 2
-  - uid: 5328
-    components:
-    - type: Transform
-      pos: -12.5,-36.5
-      parent: 2
-  - uid: 5329
-    components:
-    - type: Transform
-      pos: -12.5,-35.5
-      parent: 2
-  - uid: 5330
-    components:
-    - type: Transform
-      pos: -12.5,-34.5
-      parent: 2
-  - uid: 5332
-    components:
-    - type: Transform
-      pos: -14.5,-35.5
+      pos: -9.5,-19.5
       parent: 2
   - uid: 5408
     components:
@@ -9945,10 +9784,10 @@ entities:
     - type: Transform
       pos: -16.5,-25.5
       parent: 2
-  - uid: 5796
+  - uid: 5759
     components:
     - type: Transform
-      pos: -14.5,-36.5
+      pos: -9.5,-17.5
       parent: 2
   - uid: 5898
     components:
@@ -9959,6 +9798,11 @@ entities:
     components:
     - type: Transform
       pos: -8.5,-28.5
+      parent: 2
+  - uid: 5918
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
       parent: 2
   - uid: 5962
     components:
@@ -20448,6 +20292,11 @@ entities:
       parent: 2
 - proto: CableMV
   entities:
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 2
   - uid: 206
     components:
     - type: Transform
@@ -20463,11 +20312,6 @@ entities:
     - type: Transform
       pos: -16.5,-20.5
       parent: 2
-  - uid: 298
-    components:
-    - type: Transform
-      pos: -6.5,-19.5
-      parent: 2
   - uid: 312
     components:
     - type: Transform
@@ -20477,6 +20321,11 @@ entities:
     components:
     - type: Transform
       pos: -16.5,-23.5
+      parent: 2
+  - uid: 319
+    components:
+    - type: Transform
+      pos: -8.5,-19.5
       parent: 2
   - uid: 328
     components:
@@ -20632,6 +20481,26 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-12.5
+      parent: 2
+  - uid: 797
+    components:
+    - type: Transform
+      pos: -5.5,-20.5
+      parent: 2
+  - uid: 803
+    components:
+    - type: Transform
+      pos: -5.5,-19.5
+      parent: 2
+  - uid: 809
+    components:
+    - type: Transform
+      pos: -7.5,-19.5
+      parent: 2
+  - uid: 863
+    components:
+    - type: Transform
+      pos: -6.5,-19.5
       parent: 2
   - uid: 876
     components:
@@ -22278,11 +22147,6 @@ entities:
     - type: Transform
       pos: -36.5,-25.5
       parent: 2
-  - uid: 3265
-    components:
-    - type: Transform
-      pos: -3.5,-18.5
-      parent: 2
   - uid: 3308
     components:
     - type: Transform
@@ -22888,11 +22752,6 @@ entities:
     - type: Transform
       pos: -13.5,-20.5
       parent: 2
-  - uid: 3689
-    components:
-    - type: Transform
-      pos: -3.5,-19.5
-      parent: 2
   - uid: 4002
     components:
     - type: Transform
@@ -23496,27 +23355,7 @@ entities:
   - uid: 5445
     components:
     - type: Transform
-      pos: -13.5,-40.5
-      parent: 2
-  - uid: 5446
-    components:
-    - type: Transform
-      pos: -13.5,-38.5
-      parent: 2
-  - uid: 5447
-    components:
-    - type: Transform
-      pos: -13.5,-39.5
-      parent: 2
-  - uid: 5448
-    components:
-    - type: Transform
-      pos: -12.5,-38.5
-      parent: 2
-  - uid: 5449
-    components:
-    - type: Transform
-      pos: -12.5,-37.5
+      pos: -9.5,-19.5
       parent: 2
   - uid: 5450
     components:
@@ -23748,55 +23587,20 @@ entities:
     - type: Transform
       pos: -45.5,1.5
       parent: 2
-  - uid: 5753
-    components:
-    - type: Transform
-      pos: -4.5,-19.5
-      parent: 2
-  - uid: 5756
-    components:
-    - type: Transform
-      pos: -5.5,-19.5
-      parent: 2
-  - uid: 5758
-    components:
-    - type: Transform
-      pos: -7.5,-19.5
-      parent: 2
-  - uid: 5759
-    components:
-    - type: Transform
-      pos: -10.5,-19.5
-      parent: 2
-  - uid: 5760
-    components:
-    - type: Transform
-      pos: -3.5,-17.5
-      parent: 2
-  - uid: 5761
-    components:
-    - type: Transform
-      pos: -11.5,-19.5
-      parent: 2
-  - uid: 5762
-    components:
-    - type: Transform
-      pos: -12.5,-19.5
-      parent: 2
   - uid: 5763
     components:
     - type: Transform
-      pos: -9.5,-19.5
-      parent: 2
-  - uid: 5765
-    components:
-    - type: Transform
-      pos: -8.5,-19.5
+      pos: -9.5,-17.5
       parent: 2
   - uid: 5906
     components:
     - type: Transform
       pos: -7.5,-33.5
+      parent: 2
+  - uid: 5917
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
       parent: 2
   - uid: 6155
     components:
@@ -26123,7 +25927,6 @@ entities:
   - uid: 3699
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -53.5,3.5
       parent: 2
   - uid: 7372
@@ -26321,37 +26124,31 @@ entities:
   - uid: 8854
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,19.5
       parent: 2
   - uid: 8855
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,17.5
       parent: 2
   - uid: 8856
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,19.5
       parent: 2
   - uid: 8857
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,18.5
       parent: 2
   - uid: 8858
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 24.5,17.5
       parent: 2
   - uid: 8859
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 23.5,18.5
       parent: 2
 - proto: Catwalk
@@ -29635,6 +29432,12 @@ entities:
       parent: 2
 - proto: ChairOfficeDark
   entities:
+  - uid: 338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.52843,-35.15426
+      parent: 2
   - uid: 523
     components:
     - type: Transform
@@ -29691,6 +29494,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -28.504223,-27.441425
+      parent: 2
+  - uid: 2897
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.493602,-34.24801
       parent: 2
   - uid: 3116
     components:
@@ -30485,15 +30294,15 @@ entities:
       parent: 2
 - proto: ClosetL3Filled
   entities:
+  - uid: 5448
+    components:
+    - type: Transform
+      pos: -4.5,-24.5
+      parent: 2
   - uid: 8794
     components:
     - type: Transform
       pos: -3.5,17.5
-      parent: 2
-  - uid: 14218
-    components:
-    - type: Transform
-      pos: -11.5,-34.5
       parent: 2
 - proto: ClosetLegalFilled
   entities:
@@ -30556,6 +30365,13 @@ entities:
     components:
     - type: Transform
       pos: -21.5,-39.5
+      parent: 2
+- proto: ClothingHeadBandBotany
+  entities:
+  - uid: 5756
+    components:
+    - type: Transform
+      pos: -9.44404,-21.475182
       parent: 2
 - proto: ClothingHeadHatCone
   entities:
@@ -31473,6 +31289,11 @@ entities:
       parent: 2
 - proto: CrateHydroponicsTools
   entities:
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -8.5,-24.5
+      parent: 2
   - uid: 14215
     components:
     - type: Transform
@@ -31532,10 +31353,10 @@ entities:
       parent: 2
 - proto: CrateTrashCartJani
   entities:
-  - uid: 5313
+  - uid: 9554
     components:
     - type: Transform
-      pos: -14.5,-36.5
+      pos: -4.5,-21.5
       parent: 2
 - proto: CrayonBox
   entities:
@@ -31704,13 +31525,6 @@ entities:
     - type: Transform
       pos: -8.5,-6.5
       parent: 2
-- proto: DefaultStationBeaconBotany
-  entities:
-  - uid: 4810
-    components:
-    - type: Transform
-      pos: -8.5,-21.5
-      parent: 2
 - proto: DefaultStationBeaconBridge
   entities:
   - uid: 4825
@@ -31794,13 +31608,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,7.5
-      parent: 2
-- proto: DefaultStationBeaconJanitorsCloset
-  entities:
-  - uid: 5331
-    components:
-    - type: Transform
-      pos: -13.5,-34.5
       parent: 2
 - proto: DefaultStationBeaconKitchen
   entities:
@@ -32019,24 +31826,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -7.5,-6.5
       parent: 2
-  - uid: 810
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-23.5
-      parent: 2
-  - uid: 811
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-23.5
-      parent: 2
-  - uid: 812
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,-18.5
-      parent: 2
   - uid: 1197
     components:
     - type: Transform
@@ -32234,12 +32023,6 @@ entities:
     - type: Transform
       pos: -29.5,-35.5
       parent: 2
-  - uid: 5916
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-34.5
-      parent: 2
   - uid: 5922
     components:
     - type: Transform
@@ -32344,6 +32127,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -32.5,-46.5
       parent: 2
+  - uid: 9508
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-22.5
+      parent: 2
   - uid: 12363
     components:
     - type: Transform
@@ -32369,6 +32158,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-12.5
+      parent: 2
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -0.5,-22.5
       parent: 2
   - uid: 1782
     components:
@@ -32434,11 +32228,6 @@ entities:
     - type: Transform
       pos: -0.5,-16.5
       parent: 2
-  - uid: 5843
-    components:
-    - type: Transform
-      pos: -0.5,-18.5
-      parent: 2
   - uid: 5853
     components:
     - type: Transform
@@ -32496,12 +32285,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 1.5,-30.5
       parent: 2
-  - uid: 5902
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-30.5
-      parent: 2
   - uid: 5903
     components:
     - type: Transform
@@ -32538,6 +32321,17 @@ entities:
       parent: 2
 - proto: DisposalPipe
   entities:
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-30.5
+      parent: 2
   - uid: 506
     components:
     - type: Transform
@@ -32746,78 +32540,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-6.5
-      parent: 2
-  - uid: 797
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-18.5
-      parent: 2
-  - uid: 798
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-18.5
-      parent: 2
-  - uid: 799
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-18.5
-      parent: 2
-  - uid: 800
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-23.5
-      parent: 2
-  - uid: 801
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-23.5
-      parent: 2
-  - uid: 802
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-23.5
-      parent: 2
-  - uid: 803
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-23.5
-      parent: 2
-  - uid: 804
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-23.5
-      parent: 2
-  - uid: 805
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-22.5
-      parent: 2
-  - uid: 806
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-21.5
-      parent: 2
-  - uid: 807
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-20.5
-      parent: 2
-  - uid: 808
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-19.5
       parent: 2
   - uid: 1188
     components:
@@ -33538,6 +33260,12 @@ entities:
     - type: Transform
       pos: -0.5,-11.5
       parent: 2
+  - uid: 5843
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-22.5
+      parent: 2
   - uid: 5844
     components:
     - type: Transform
@@ -33865,30 +33593,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -32.5,-34.5
       parent: 2
-  - uid: 5917
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-34.5
-      parent: 2
-  - uid: 5918
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-31.5
-      parent: 2
-  - uid: 5919
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-33.5
-      parent: 2
-  - uid: 5920
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-32.5
-      parent: 2
   - uid: 5923
     components:
     - type: Transform
@@ -33983,6 +33687,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-30.5
+      parent: 2
+  - uid: 6820
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-22.5
       parent: 2
   - uid: 6952
     components:
@@ -34604,12 +34314,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -19.5,-31.5
       parent: 2
-  - uid: 11380
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-22.5
-      parent: 2
   - uid: 11571
     components:
     - type: Transform
@@ -34796,12 +34500,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -13.5,-8.5
       parent: 2
-  - uid: 809
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-24.5
-      parent: 2
   - uid: 1765
     components:
     - type: Transform
@@ -34882,11 +34580,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: -29.5,-37.5
       parent: 2
-  - uid: 5915
+  - uid: 5329
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-34.5
+      rot: 3.141592653589793 rad
+      pos: -3.5,-23.5
       parent: 2
   - uid: 5921
     components:
@@ -34991,11 +34689,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-8.5
-      parent: 2
-  - uid: 347
-    components:
-    - type: Transform
-      pos: -10.5,-24.5
       parent: 2
   - uid: 437
     components:
@@ -35122,11 +34815,6 @@ entities:
     - type: Transform
       pos: -17.5,-35.5
       parent: 2
-  - uid: 5914
-    components:
-    - type: Transform
-      pos: -15.5,-34.5
-      parent: 2
   - uid: 6661
     components:
     - type: Transform
@@ -35136,6 +34824,11 @@ entities:
     components:
     - type: Transform
       pos: -34.5,-42.5
+      parent: 2
+  - uid: 9564
+    components:
+    - type: Transform
+      pos: -3.5,-23.5
       parent: 2
   - uid: 11669
     components:
@@ -35985,37 +35678,31 @@ entities:
   - uid: 8174
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -63.5,5.5
       parent: 2
   - uid: 8175
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,5.5
       parent: 2
   - uid: 8176
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,4.5
       parent: 2
   - uid: 8177
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -63.5,4.5
       parent: 2
   - uid: 8178
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,6.5
       parent: 2
   - uid: 8179
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -63.5,6.5
       parent: 2
   - uid: 12797
@@ -36318,6 +36005,11 @@ entities:
       parent: 2
 - proto: ESCrateTrashBin
   entities:
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -14.5,-36.5
+      parent: 2
   - uid: 4429
     components:
     - type: Transform
@@ -36519,6 +36211,11 @@ entities:
     components:
     - type: Transform
       pos: -45.5,-2.5
+      parent: 2
+  - uid: 6817
+    components:
+    - type: Transform
+      pos: -4.5,-23.5
       parent: 2
   - uid: 11686
     components:
@@ -36845,11 +36542,6 @@ entities:
     - type: Transform
       pos: -16.5,-30.5
       parent: 2
-  - uid: 13809
-    components:
-    - type: Transform
-      pos: -13.5,-35.5
-      parent: 2
   - uid: 13810
     components:
     - type: Transform
@@ -36989,16 +36681,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-18.5
-      parent: 2
-  - uid: 13851
-    components:
-    - type: Transform
-      pos: -5.5,-22.5
-      parent: 2
-  - uid: 13852
-    components:
-    - type: Transform
-      pos: -8.5,-21.5
       parent: 2
   - uid: 13856
     components:
@@ -38882,6 +38564,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,-6.5
       parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-23.5
+      parent: 2
   - uid: 490
     components:
     - type: Transform
@@ -39051,17 +38739,6 @@ entities:
     components:
     - type: Transform
       pos: -50.5,-14.5
-      parent: 2
-  - uid: 2897
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-22.5
-      parent: 2
-  - uid: 2912
-    components:
-    - type: Transform
-      pos: -4.5,-18.5
       parent: 2
   - uid: 2914
     components:
@@ -39279,6 +38956,18 @@ entities:
     - type: Transform
       pos: -8.5,9.5
       parent: 2
+  - uid: 5761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-19.5
+      parent: 2
+  - uid: 5762
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-19.5
+      parent: 2
   - uid: 6795
     components:
     - type: Transform
@@ -39340,11 +39029,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-9.5
-      parent: 2
-  - uid: 7351
-    components:
-    - type: Transform
-      pos: -14.5,-33.5
       parent: 2
   - uid: 7828
     components:
@@ -39620,19 +39304,16 @@ entities:
   - uid: 23
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -54.5,12.5
       parent: 2
   - uid: 8911
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,15.5
       parent: 2
   - uid: 12286
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-46.5
       parent: 2
   - uid: 12287
@@ -39643,7 +39324,6 @@ entities:
   - uid: 12288
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-32.5
       parent: 2
   - uid: 12289
@@ -39654,13 +39334,11 @@ entities:
   - uid: 12290
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-27.5
       parent: 2
   - uid: 12291
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -54.5,9.5
       parent: 2
   - uid: 12292
@@ -39681,19 +39359,16 @@ entities:
   - uid: 12295
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -47.5,-3.5
       parent: 2
   - uid: 14305
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -0.5,16.5
       parent: 2
   - uid: 14311
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-28.5
       parent: 2
 - proto: ESRandomPosterContraband
@@ -39701,7 +39376,6 @@ entities:
   - uid: 1897
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,-6.5
       parent: 2
   - uid: 8678
@@ -39712,7 +39386,6 @@ entities:
   - uid: 12296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -53.5,-27.5
       parent: 2
   - uid: 12297
@@ -39723,7 +39396,6 @@ entities:
   - uid: 12298
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,13.5
       parent: 2
   - uid: 12299
@@ -39734,19 +39406,16 @@ entities:
   - uid: 12300
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,-3.5
       parent: 2
   - uid: 12301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,-5.5
       parent: 2
   - uid: 14306
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -43.5,19.5
       parent: 2
   - uid: 14307
@@ -39757,7 +39426,6 @@ entities:
   - uid: 14308
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -65.5,8.5
       parent: 2
 - proto: ESRandomPosterLegit
@@ -39765,13 +39433,11 @@ entities:
   - uid: 681
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-19.5
       parent: 2
   - uid: 8004
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -35.5,8.5
       parent: 2
   - uid: 9086
@@ -39787,13 +39453,11 @@ entities:
   - uid: 12303
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -34.5,-2.5
       parent: 2
   - uid: 14214
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,-43.5
       parent: 2
 - proto: ESRound357
@@ -39879,7 +39543,6 @@ entities:
   - uid: 5027
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,5.5
       parent: 2
   - uid: 5131
@@ -40030,7 +39693,6 @@ entities:
   - uid: 14310
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 2
 - proto: ESSpawnerRandomDistributedArmory
@@ -40073,7 +39735,6 @@ entities:
   - uid: 3038
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-50.5
       parent: 2
 - proto: ESSpawnerRandomGrille50
@@ -40088,7 +39749,6 @@ entities:
   - uid: 3297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-18.5
       parent: 2
   - uid: 8332
@@ -40106,7 +39766,6 @@ entities:
   - uid: 3747
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-19.5
       parent: 2
   - uid: 7738
@@ -40189,7 +39848,6 @@ entities:
   - uid: 10129
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -17.5,8.5
       parent: 2
   - uid: 11488
@@ -40270,7 +39928,6 @@ entities:
   - uid: 14068
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-49.5
       parent: 2
 - proto: ESSpawnerRandomGrilleBroken75
@@ -40328,7 +39985,6 @@ entities:
   - uid: 9690
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,3.5
       parent: 2
   - uid: 11505
@@ -40641,7 +40297,6 @@ entities:
   - uid: 14172
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-53.5
       parent: 2
 - proto: ESSpawnerRandomMaintCanisterBroken
@@ -40649,7 +40304,6 @@ entities:
   - uid: 6471
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-53.5
       parent: 2
   - uid: 13312
@@ -40662,7 +40316,6 @@ entities:
   - uid: 1668
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-51.5
       parent: 2
   - uid: 1710
@@ -40693,7 +40346,6 @@ entities:
   - uid: 13778
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -69.5,-27.5
       parent: 2
   - uid: 14156
@@ -40730,13 +40382,11 @@ entities:
   - uid: 4911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -44.5,-38.5
       parent: 2
   - uid: 4914
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,8.5
       parent: 2
   - uid: 8149
@@ -40764,7 +40414,6 @@ entities:
   - uid: 5478
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,2.5
       parent: 2
   - uid: 11771
@@ -40775,7 +40424,6 @@ entities:
   - uid: 13779
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -70.5,-35.5
       parent: 2
   - uid: 14182
@@ -40790,6 +40438,11 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomMaintDoorVariant
   entities:
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -13.5,-37.5
+      parent: 2
   - uid: 1145
     components:
     - type: Transform
@@ -40808,7 +40461,6 @@ entities:
   - uid: 2851
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,20.5
       parent: 2
   - uid: 3307
@@ -40949,7 +40601,6 @@ entities:
   - uid: 13098
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-53.5
       parent: 2
   - uid: 13757
@@ -40965,37 +40616,31 @@ entities:
   - uid: 13948
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,-55.5
       parent: 2
   - uid: 13949
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-53.5
       parent: 2
   - uid: 13951
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-47.5
       parent: 2
   - uid: 13961
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-48.5
       parent: 2
   - uid: 14054
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-43.5
       parent: 2
   - uid: 14061
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-54.5
       parent: 2
 - proto: ESSpawnerRandomMaintDoorVariantImpassable
@@ -41040,6 +40685,11 @@ entities:
     - type: Transform
       pos: 24.5,12.5
       parent: 2
+  - uid: 5758
+    components:
+    - type: Transform
+      pos: -9.5,-25.5
+      parent: 2
   - uid: 8356
     components:
     - type: Transform
@@ -41063,7 +40713,6 @@ entities:
   - uid: 14055
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-45.5
       parent: 2
 - proto: ESSpawnerRandomMaintGirderOrGrilleSpawner
@@ -41071,13 +40720,11 @@ entities:
   - uid: 537
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-26.5
       parent: 2
   - uid: 3157
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -1.5,-50.5
       parent: 2
   - uid: 8090
@@ -41103,7 +40750,6 @@ entities:
   - uid: 9492
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,2.5
       parent: 2
   - uid: 9500
@@ -41119,7 +40765,6 @@ entities:
   - uid: 10342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,8.5
       parent: 2
   - uid: 11348
@@ -41130,7 +40775,6 @@ entities:
   - uid: 11730
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -68.5,-31.5
       parent: 2
   - uid: 12502
@@ -41176,7 +40820,6 @@ entities:
   - uid: 13910
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-50.5
       parent: 2
 - proto: ESSpawnerRandomMaintLootExposed100
@@ -41184,25 +40827,21 @@ entities:
   - uid: 533
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-23.5
       parent: 2
   - uid: 1015
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,6.5
       parent: 2
   - uid: 4244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-44.5
       parent: 2
   - uid: 4945
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-19.5
       parent: 2
   - uid: 4988
@@ -41218,7 +40857,6 @@ entities:
   - uid: 5335
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-44.5
       parent: 2
   - uid: 5677
@@ -41419,7 +41057,6 @@ entities:
   - uid: 10531
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,6.5
       parent: 2
   - uid: 11015
@@ -41560,13 +41197,11 @@ entities:
   - uid: 13784
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -70.5,-37.5
       parent: 2
   - uid: 14096
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,-49.5
       parent: 2
   - uid: 14118
@@ -41601,6 +41236,11 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomMaintLootExposed25
   entities:
+  - uid: 340
+    components:
+    - type: Transform
+      pos: -8.5,-22.5
+      parent: 2
   - uid: 1859
     components:
     - type: Transform
@@ -41610,6 +41250,16 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-33.5
+      parent: 2
+  - uid: 4810
+    components:
+    - type: Transform
+      pos: -15.5,-34.5
+      parent: 2
+  - uid: 4981
+    components:
+    - type: Transform
+      pos: -11.5,-34.5
       parent: 2
   - uid: 5205
     components:
@@ -41629,13 +41279,11 @@ entities:
   - uid: 9780
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,3.5
       parent: 2
   - uid: 9912
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,7.5
       parent: 2
   - uid: 11356
@@ -41796,25 +41444,21 @@ entities:
   - uid: 13787
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -71.5,-31.5
       parent: 2
   - uid: 13788
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -71.5,-35.5
       parent: 2
   - uid: 13789
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -68.5,-33.5
       parent: 2
   - uid: 14098
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,-50.5
       parent: 2
   - uid: 14162
@@ -41884,10 +41528,19 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomMaintLootExposed50
   entities:
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -15.5,-35.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -10.5,-24.5
+      parent: 2
   - uid: 4951
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-16.5
       parent: 2
   - uid: 8037
@@ -42098,7 +41751,6 @@ entities:
   - uid: 14097
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,-49.5
       parent: 2
   - uid: 14161
@@ -42266,7 +41918,6 @@ entities:
   - uid: 9399
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,3.5
       parent: 2
   - uid: 11386
@@ -42302,13 +41953,11 @@ entities:
   - uid: 13785
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -71.5,-27.5
       parent: 2
   - uid: 13786
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -70.5,-27.5
       parent: 2
   - uid: 14186
@@ -42331,25 +41980,21 @@ entities:
   - uid: 536
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,-26.5
       parent: 2
   - uid: 545
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-26.5
       parent: 2
   - uid: 612
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,-26.5
       parent: 2
   - uid: 653
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-8.5
       parent: 2
   - uid: 1019
@@ -42360,7 +42005,6 @@ entities:
   - uid: 1669
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-51.5
       parent: 2
   - uid: 1718
@@ -42371,7 +42015,6 @@ entities:
   - uid: 2600
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,-49.5
       parent: 2
   - uid: 2824
@@ -42392,7 +42035,6 @@ entities:
   - uid: 4949
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-16.5
       parent: 2
   - uid: 5168
@@ -42633,7 +42275,6 @@ entities:
   - uid: 10103
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,8.5
       parent: 2
   - uid: 11677
@@ -42954,7 +42595,6 @@ entities:
   - uid: 5165
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-18.5
       parent: 2
   - uid: 12476
@@ -42972,7 +42612,6 @@ entities:
   - uid: 9478
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,5.5
       parent: 2
   - uid: 11485
@@ -42987,6 +42626,11 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomTrashCombo25
   entities:
+  - uid: 869
+    components:
+    - type: Transform
+      pos: -14.5,-33.5
+      parent: 2
   - uid: 4788
     components:
     - type: Transform
@@ -42997,6 +42641,16 @@ entities:
     - type: Transform
       pos: -56.5,-40.5
       parent: 2
+  - uid: 5268
+    components:
+    - type: Transform
+      pos: -13.5,-36.5
+      parent: 2
+  - uid: 5326
+    components:
+    - type: Transform
+      pos: -12.5,-35.5
+      parent: 2
   - uid: 7561
     components:
     - type: Transform
@@ -43005,7 +42659,6 @@ entities:
   - uid: 9391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,2.5
       parent: 2
   - uid: 11471
@@ -43313,25 +42966,21 @@ entities:
   - uid: 9392
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,3.5
       parent: 2
   - uid: 9481
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,4.5
       parent: 2
   - uid: 9707
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,4.5
       parent: 2
   - uid: 10275
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,4.5
       parent: 2
   - uid: 12854
@@ -43416,7 +43065,6 @@ entities:
   - uid: 5206
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-45.5
       parent: 2
 - proto: ESSpawnerRandomTrashFood25
@@ -43444,13 +43092,11 @@ entities:
   - uid: 10273
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,9.5
       parent: 2
   - uid: 10274
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -14.5,9.5
       parent: 2
   - uid: 11352
@@ -43603,7 +43249,6 @@ entities:
   - uid: 4950
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-17.5
       parent: 2
   - uid: 13764
@@ -43651,7 +43296,6 @@ entities:
   - uid: 10272
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,9.5
       parent: 2
 - proto: ESSpawnerRandomTrashJunk25
@@ -43676,13 +43320,11 @@ entities:
   - uid: 10322
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,-46.5
       parent: 2
   - uid: 10323
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-47.5
       parent: 2
 - proto: ESSpawnerRandomTrashJunk75
@@ -43690,19 +43332,16 @@ entities:
   - uid: 4427
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-42.5
       parent: 2
   - uid: 5210
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-46.5
       parent: 2
   - uid: 5273
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-43.5
       parent: 2
 - proto: ESSpawnerRandomVendorDrink
@@ -43717,13 +43356,11 @@ entities:
   - uid: 1679
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,7.5
       parent: 2
   - uid: 1707
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,5.5
       parent: 2
   - uid: 9510
@@ -43759,7 +43396,6 @@ entities:
   - uid: 14067
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-49.5
       parent: 2
 - proto: ESSpawnPointAssistant
@@ -43797,13 +43433,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,-6.5
-      parent: 2
-- proto: ESSpawnPointBotanist
-  entities:
-  - uid: 3188
-    components:
-    - type: Transform
-      pos: -8.5,-20.5
       parent: 2
 - proto: ESSpawnPointCaptain
   entities:
@@ -43856,10 +43485,10 @@ entities:
       parent: 2
 - proto: ESSpawnPointJanitor
   entities:
-  - uid: 12356
+  - uid: 6815
     components:
     - type: Transform
-      pos: -14.5,-35.5
+      pos: -5.5,-22.5
       parent: 2
 - proto: ESSpawnPointMedicalDoctor
   entities:
@@ -44145,10 +43774,10 @@ entities:
       parent: 2
 - proto: ESVendingMachineNutri
   entities:
-  - uid: 9474
+  - uid: 5765
     components:
     - type: Transform
-      pos: -6.5,-22.5
+      pos: -3.5,-18.5
       parent: 2
 - proto: ESVendingMachineRobotics
   entities:
@@ -44166,10 +43795,10 @@ entities:
       parent: 2
 - proto: ESVendingMachineSeedsUnlocked
   entities:
-  - uid: 9468
+  - uid: 226
     components:
     - type: Transform
-      pos: -7.5,-22.5
+      pos: -3.5,-19.5
       parent: 2
   - uid: 9489
     components:
@@ -44493,13 +44122,6 @@ entities:
     - type: Transform
       pos: -15.5,-6.5
       parent: 2
-- proto: ESWardrobeBotanistFilled
-  entities:
-  - uid: 10988
-    components:
-    - type: Transform
-      pos: -10.5,-21.5
-      parent: 2
 - proto: ESWardrobeCargoFilled
   entities:
   - uid: 5169
@@ -44554,10 +44176,10 @@ entities:
       parent: 2
 - proto: ESWardrobeJanitorFilled
   entities:
-  - uid: 7280
+  - uid: 5914
     components:
     - type: Transform
-      pos: -11.5,-33.5
+      pos: -3.5,-24.5
       parent: 2
 - proto: ESWardrobeParamedicFilled
   entities:
@@ -44709,14 +44331,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-2.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 6800
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,-17.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -44933,6 +44547,11 @@ entities:
     - type: Transform
       pos: -29.5,-25.5
       parent: 2
+  - uid: 801
+    components:
+    - type: Transform
+      pos: -11.5,-36.5
+      parent: 2
   - uid: 1354
     components:
     - type: Transform
@@ -44974,6 +44593,11 @@ entities:
     components:
     - type: Transform
       pos: 18.5,-11.5
+      parent: 2
+  - uid: 810
+    components:
+    - type: Transform
+      pos: -15.5,-33.5
       parent: 2
   - uid: 1089
     components:
@@ -45160,28 +44784,29 @@ entities:
     - type: Transform
       pos: -44.5,-15.5
       parent: 2
+  - uid: 860
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 2
   - uid: 2630
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-49.5
       parent: 2
   - uid: 2831
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -13.5,-50.5
       parent: 2
   - uid: 3291
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-51.5
       parent: 2
   - uid: 8533
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-4.5
       parent: 2
     - type: DeviceNetwork
@@ -45224,13 +44849,11 @@ entities:
   - uid: 14403
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-21.5
       parent: 2
   - uid: 14404
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-15.5
       parent: 2
   - uid: 14405
@@ -45241,49 +44864,41 @@ entities:
   - uid: 14409
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -36.5,-10.5
       parent: 2
   - uid: 14414
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-7.5
       parent: 2
   - uid: 14420
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,8.5
       parent: 2
   - uid: 14426
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 2
   - uid: 14433
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,4.5
       parent: 2
   - uid: 14434
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,6.5
       parent: 2
   - uid: 14435
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,6.5
       parent: 2
   - uid: 14436
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-0.5
       parent: 2
   - uid: 14442
@@ -45296,39 +44911,25 @@ entities:
     - type: Transform
       pos: 5.5,-10.5
       parent: 2
-  - uid: 14451
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-18.5
-      parent: 2
   - uid: 14452
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -2.5,-16.5
       parent: 2
   - uid: 14459
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 28.5,-28.5
       parent: 2
   - uid: 14460
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,-20.5
       parent: 2
   - uid: 14465
     components:
     - type: Transform
       pos: 9.5,-32.5
-      parent: 2
-  - uid: 14467
-    components:
-    - type: Transform
-      pos: -11.5,-19.5
       parent: 2
   - uid: 14468
     components:
@@ -45338,37 +44939,27 @@ entities:
   - uid: 14489
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -11.5,-12.5
       parent: 2
   - uid: 14494
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-43.5
       parent: 2
   - uid: 14495
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-44.5
       parent: 2
   - uid: 14500
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 0.5,-35.5
       parent: 2
   - uid: 14501
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 1.5,-35.5
-      parent: 2
-  - uid: 14505
-    components:
-    - type: Transform
-      pos: -13.5,-32.5
       parent: 2
   - uid: 14508
     components:
@@ -45393,19 +44984,16 @@ entities:
   - uid: 14560
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-14.5
       parent: 2
   - uid: 14561
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 10.5,-18.5
       parent: 2
   - uid: 14562
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-14.5
       parent: 2
 - proto: FirelockEdge
@@ -45459,18 +45047,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -38.5,-17.5
-      parent: 2
-  - uid: 14314
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-22.5
-      parent: 2
-  - uid: 14315
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-21.5
       parent: 2
   - uid: 14319
     components:
@@ -45691,7 +45267,6 @@ entities:
   - uid: 2711
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-0.5
       parent: 2
     - type: DeviceNetwork
@@ -45720,7 +45295,6 @@ entities:
   - uid: 3146
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,0.5
       parent: 2
     - type: DeviceNetwork
@@ -45803,13 +45377,11 @@ entities:
   - uid: 4941
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-9.5
       parent: 2
   - uid: 6632
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-1.5
       parent: 2
     - type: DeviceNetwork
@@ -45818,13 +45390,11 @@ entities:
   - uid: 6860
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-24.5
       parent: 2
   - uid: 6982
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,5.5
       parent: 2
     - type: DeviceNetwork
@@ -45834,7 +45404,6 @@ entities:
   - uid: 6983
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,6.5
       parent: 2
     - type: DeviceNetwork
@@ -45844,7 +45413,6 @@ entities:
   - uid: 6984
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,7.5
       parent: 2
     - type: DeviceNetwork
@@ -45854,7 +45422,6 @@ entities:
   - uid: 6988
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-31.5
       parent: 2
     - type: DeviceNetwork
@@ -45866,7 +45433,6 @@ entities:
   - uid: 6989
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-30.5
       parent: 2
     - type: DeviceNetwork
@@ -45878,7 +45444,6 @@ entities:
   - uid: 6990
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-29.5
       parent: 2
     - type: DeviceNetwork
@@ -45890,7 +45455,6 @@ entities:
   - uid: 9307
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,8.5
       parent: 2
     - type: DeviceNetwork
@@ -45912,7 +45476,6 @@ entities:
   - uid: 10337
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-46.5
       parent: 2
     - type: DeviceNetwork
@@ -45921,7 +45484,6 @@ entities:
   - uid: 10341
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,1.5
       parent: 2
     - type: DeviceNetwork
@@ -45930,7 +45492,6 @@ entities:
   - uid: 11401
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-22.5
       parent: 2
     - type: DeviceNetwork
@@ -45939,7 +45500,6 @@ entities:
   - uid: 11628
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-5.5
       parent: 2
     - type: DeviceNetwork
@@ -45963,13 +45523,11 @@ entities:
   - uid: 14407
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-22.5
       parent: 2
   - uid: 14408
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -41.5,-14.5
       parent: 2
   - uid: 14416
@@ -45980,55 +45538,46 @@ entities:
   - uid: 14417
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -31.5,2.5
       parent: 2
   - uid: 14418
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -32.5,2.5
       parent: 2
   - uid: 14419
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -33.5,2.5
       parent: 2
   - uid: 14427
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,1.5
       parent: 2
   - uid: 14428
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 9.5,1.5
       parent: 2
   - uid: 14453
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-30.5
       parent: 2
   - uid: 14456
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-32.5
       parent: 2
   - uid: 14457
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,-32.5
       parent: 2
   - uid: 14458
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,-30.5
       parent: 2
   - uid: 14463
@@ -46041,27 +45590,19 @@ entities:
     - type: Transform
       pos: 22.5,-36.5
       parent: 2
-  - uid: 14466
-    components:
-    - type: Transform
-      pos: -8.5,-17.5
-      parent: 2
   - uid: 14478
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-6.5
       parent: 2
   - uid: 14479
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 2
   - uid: 14481
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-16.5
       parent: 2
     - type: DeviceNetwork
@@ -46070,7 +45611,6 @@ entities:
   - uid: 14484
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -30.5,-18.5
       parent: 2
     - type: DeviceNetwork
@@ -46079,7 +45619,6 @@ entities:
   - uid: 14485
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -28.5,-20.5
       parent: 2
     - type: DeviceNetwork
@@ -46088,7 +45627,6 @@ entities:
   - uid: 14486
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,-20.5
       parent: 2
     - type: DeviceNetwork
@@ -46097,7 +45635,6 @@ entities:
   - uid: 14488
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-15.5
       parent: 2
     - type: DeviceNetwork
@@ -46106,13 +45643,11 @@ entities:
   - uid: 14491
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 1.5,-40.5
       parent: 2
   - uid: 14492
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-40.5
       parent: 2
   - uid: 14506
@@ -46177,10 +45712,10 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 5317
+  - uid: 9474
     components:
     - type: Transform
-      pos: -13.5,-35.5
+      pos: -5.5,-23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -46549,6 +46084,14 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-43.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 3188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-26.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -47074,30 +46617,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 10533
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10536
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10567
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-26.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 10592
     components:
     - type: Transform
@@ -47223,35 +46742,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 10769
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-33.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10771
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -24.5,-47.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10790
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-38.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10791
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,-38.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -48345,6 +47840,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeBendAlt2
   entities:
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 3283
     components:
     - type: Transform
@@ -48465,6 +47968,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeManifold
   entities:
+  - uid: 870
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 2585
     components:
     - type: Transform
@@ -48698,6 +48209,22 @@ entities:
       color: '#990000FF'
 - proto: GasPipeStraight
   entities:
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 185
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 399
     components:
     - type: Transform
@@ -48934,6 +48461,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 2912
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 3175
     components:
     - type: Transform
@@ -49360,6 +48895,21 @@ entities:
       rot: 3.141592653589793 rad
       pos: -47.5,-18.5
       parent: 2
+  - uid: 5313
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 5315
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 5624
     components:
     - type: Transform
@@ -51508,6 +51058,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 10310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 10311
     components:
     - type: Transform
@@ -52214,14 +51772,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 10466
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-16.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10467
     components:
     - type: Transform
@@ -52298,14 +51848,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10481
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10485
     components:
     - type: Transform
@@ -52538,22 +52080,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 10527
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10528
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10532
     components:
     - type: Transform
@@ -52578,38 +52104,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10539
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10540
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10541
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -8.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10542
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10544
     components:
     - type: Transform
@@ -52741,70 +52235,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10563
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-26.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10564
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-26.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10565
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-26.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10566
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-26.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10568
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-25.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10569
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-24.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10570
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-23.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10572
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -7.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10573
     components:
     - type: Transform
@@ -53802,13 +53232,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 10767
-    components:
-    - type: Transform
-      pos: -13.5,-32.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10768
     components:
     - type: Transform
@@ -53921,42 +53344,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10787
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,-40.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10788
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -15.5,-39.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 10789
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -15.5,-42.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10792
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-38.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10793
-    components:
-    - type: Transform
-      pos: -13.5,-37.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -54013,14 +53405,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-29.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10803
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-29.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -55257,13 +54641,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 29.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 11092
-    components:
-    - type: Transform
-      pos: -1.5,-22.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -57619,6 +56996,44 @@ entities:
       color: '#0055CCFF'
 - proto: GasPipeStraightAlt2
   entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 808
+    components:
+    - type: Transform
+      pos: -12.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 10742
     components:
     - type: Transform
@@ -57814,6 +57229,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 5269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 6523
     components:
     - type: Transform
@@ -58261,21 +57684,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10535
-    components:
-    - type: Transform
-      pos: -5.5,-19.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10576
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-18.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10598
     components:
     - type: Transform
@@ -58385,13 +57793,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10766
-    components:
-    - type: Transform
-      pos: -13.5,-31.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 10786
     components:
     - type: Transform
@@ -58978,6 +58379,17 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-22.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5902
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 3680
     components:
     - type: Transform
@@ -59014,6 +58426,19 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 10355
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 5317
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-19.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11956
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 5882
@@ -59325,7 +58750,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 10884
+      - 812
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 10506
@@ -59347,28 +58772,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11953
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10529
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,-19.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 11956
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10543
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,-20.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 11955
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 10611
@@ -59451,17 +58854,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11958
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 10770
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,-33.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 11957
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 10801
@@ -59832,6 +59224,16 @@ entities:
       - 10355
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 5796
+    components:
+    - type: Transform
+      pos: -5.5,-24.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5902
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 7742
     components:
     - type: Transform
@@ -60087,6 +59489,19 @@ entities:
       - 10324
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 10350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-16.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 812
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 10368
     components:
     - type: Transform
@@ -60129,6 +59544,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11953
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 10466
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-17.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 11956
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 10605
@@ -60221,16 +59647,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11958
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10794
-    components:
-    - type: Transform
-      pos: -13.5,-36.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 11957
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 10856
@@ -60514,17 +59930,6 @@ entities:
       - 205
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 10480
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,-17.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 11956
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 10497
     components:
     - type: Transform
@@ -60534,27 +59939,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 11954
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10534
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-16.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 10884
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 10571
-    components:
-    - type: Transform
-      pos: -9.5,-22.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 11955
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 10969
@@ -60732,7 +60116,6 @@ entities:
   - uid: 188
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,1.5
       parent: 2
   - uid: 209
@@ -60750,20 +60133,9 @@ entities:
     - type: Transform
       pos: -45.5,-18.5
       parent: 2
-  - uid: 316
-    components:
-    - type: Transform
-      pos: -2.5,-23.5
-      parent: 2
-  - uid: 317
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 2
   - uid: 385
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-25.5
       parent: 2
   - uid: 404
@@ -60809,7 +60181,6 @@ entities:
   - uid: 1024
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-6.5
       parent: 2
   - uid: 1043
@@ -60835,7 +60206,6 @@ entities:
   - uid: 1096
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-16.5
       parent: 2
   - uid: 1136
@@ -60981,13 +60351,11 @@ entities:
   - uid: 1792
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-3.5
       parent: 2
   - uid: 1879
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,1.5
       parent: 2
   - uid: 1900
@@ -61328,7 +60696,6 @@ entities:
   - uid: 3108
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-20.5
       parent: 2
   - uid: 3133
@@ -61414,7 +60781,6 @@ entities:
   - uid: 3992
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,1.5
       parent: 2
   - uid: 4000
@@ -61430,7 +60796,6 @@ entities:
   - uid: 4342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-1.5
       parent: 2
   - uid: 4415
@@ -61726,79 +61091,66 @@ entities:
   - uid: 4670
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,-20.5
       parent: 2
   - uid: 4671
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -56.5,-20.5
       parent: 2
   - uid: 4672
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -57.5,-20.5
       parent: 2
   - uid: 4673
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-20.5
       parent: 2
   - uid: 4677
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-22.5
       parent: 2
   - uid: 4678
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -57.5,-22.5
       parent: 2
   - uid: 4679
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -56.5,-22.5
       parent: 2
   - uid: 4680
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,-23.5
       parent: 2
   - uid: 4681
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,-24.5
       parent: 2
   - uid: 4682
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,-25.5
       parent: 2
   - uid: 4683
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,-25.5
       parent: 2
   - uid: 4684
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,-24.5
       parent: 2
   - uid: 4685
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,-23.5
       parent: 2
   - uid: 4691
@@ -61819,25 +61171,21 @@ entities:
   - uid: 4701
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-48.5
       parent: 2
   - uid: 4702
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-48.5
       parent: 2
   - uid: 4703
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-48.5
       parent: 2
   - uid: 4704
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-48.5
       parent: 2
   - uid: 4712
@@ -61868,37 +61216,31 @@ entities:
   - uid: 4807
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,-48.5
       parent: 2
   - uid: 4858
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-48.5
       parent: 2
   - uid: 4859
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -46.5,-48.5
       parent: 2
   - uid: 4874
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-48.5
       parent: 2
   - uid: 4875
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-48.5
       parent: 2
   - uid: 4886
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-48.5
       parent: 2
   - uid: 4938
@@ -62219,7 +61561,6 @@ entities:
   - uid: 6522
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-42.5
       parent: 2
   - uid: 6575
@@ -62240,55 +61581,46 @@ entities:
   - uid: 6608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,18.5
       parent: 2
   - uid: 6610
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,17.5
       parent: 2
   - uid: 6611
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,20.5
       parent: 2
   - uid: 6612
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,19.5
       parent: 2
   - uid: 6613
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,20.5
       parent: 2
   - uid: 6614
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,20.5
       parent: 2
   - uid: 6623
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-44.5
       parent: 2
   - uid: 6646
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,2.5
       parent: 2
   - uid: 6648
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,2.5
       parent: 2
   - uid: 6680
@@ -62319,7 +61651,6 @@ entities:
   - uid: 6703
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-37.5
       parent: 2
   - uid: 6719
@@ -62445,13 +61776,11 @@ entities:
   - uid: 7703
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -75.5,-20.5
       parent: 2
   - uid: 7704
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -74.5,-20.5
       parent: 2
   - uid: 7708
@@ -62522,25 +61851,21 @@ entities:
   - uid: 8636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,12.5
       parent: 2
   - uid: 8637
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,12.5
       parent: 2
   - uid: 8833
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,-11.5
       parent: 2
   - uid: 9691
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,2.5
       parent: 2
   - uid: 10352
@@ -62561,13 +61886,11 @@ entities:
   - uid: 11039
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,-19.5
       parent: 2
   - uid: 11142
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-13.5
       parent: 2
   - uid: 11500
@@ -62593,13 +61916,11 @@ entities:
   - uid: 11870
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-15.5
       parent: 2
   - uid: 11871
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-14.5
       parent: 2
   - uid: 12010
@@ -63060,13 +62381,11 @@ entities:
   - uid: 12783
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,-53.5
       parent: 2
   - uid: 12784
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -20.5,-53.5
       parent: 2
   - uid: 13224
@@ -63307,37 +62626,31 @@ entities:
   - uid: 14041
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-53.5
       parent: 2
   - uid: 14042
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-54.5
       parent: 2
   - uid: 14050
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-46.5
       parent: 2
   - uid: 14051
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-46.5
       parent: 2
   - uid: 14052
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-46.5
       parent: 2
   - uid: 14053
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-46.5
       parent: 2
   - uid: 14170
@@ -63348,7 +62661,6 @@ entities:
   - uid: 14446
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-14.5
       parent: 2
 - proto: GrilleBroken
@@ -63590,19 +62902,12 @@ entities:
     - type: Transform
       pos: -6.5,-6.5
       parent: 2
-- proto: HolopadServiceBotany
-  entities:
-  - uid: 1124
-    components:
-    - type: Transform
-      pos: -5.5,-21.5
-      parent: 2
 - proto: HolopadServiceJanitor
   entities:
-  - uid: 5311
+  - uid: 343
     components:
     - type: Transform
-      pos: -13.5,-34.5
+      pos: -4.5,-23.5
       parent: 2
 - proto: HolopadServiceKitchen
   entities:
@@ -63648,6 +62953,21 @@ entities:
     components:
     - type: Transform
       pos: -24.5,-7.5
+      parent: 2
+  - uid: 5753
+    components:
+    - type: Transform
+      pos: -10.5,-21.5
+      parent: 2
+  - uid: 6921
+    components:
+    - type: Transform
+      pos: -8.5,-21.5
+      parent: 2
+  - uid: 6922
+    components:
+    - type: Transform
+      pos: -9.5,-21.5
       parent: 2
   - uid: 8770
     components:
@@ -63719,50 +63039,25 @@ entities:
       parent: 2
 - proto: hydroponicsTray
   entities:
-  - uid: 179
+  - uid: 227
     components:
     - type: Transform
-      pos: -8.5,-24.5
+      pos: -7.5,-18.5
       parent: 2
-  - uid: 180
+  - uid: 228
     components:
     - type: Transform
-      pos: -6.5,-24.5
+      pos: -8.5,-18.5
       parent: 2
-  - uid: 329
+  - uid: 5920
     components:
     - type: Transform
-      pos: -7.5,-24.5
+      pos: -5.5,-18.5
       parent: 2
-  - uid: 330
+  - uid: 9468
     components:
     - type: Transform
-      pos: -5.5,-24.5
-      parent: 2
-  - uid: 331
-    components:
-    - type: Transform
-      pos: -9.5,-18.5
-      parent: 2
-  - uid: 332
-    components:
-    - type: Transform
-      pos: -10.5,-22.5
-      parent: 2
-  - uid: 333
-    components:
-    - type: Transform
-      pos: -4.5,-24.5
-      parent: 2
-  - uid: 334
-    components:
-    - type: Transform
-      pos: -10.5,-23.5
-      parent: 2
-  - uid: 336
-    components:
-    - type: Transform
-      pos: -10.5,-18.5
+      pos: -6.5,-18.5
       parent: 2
 - proto: IngotGold
   entities:
@@ -64059,25 +63354,10 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-  - uid: 9554
-    components:
-    - type: Transform
-      pos: -9.5,-17.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
   - uid: 9556
     components:
     - type: Transform
       pos: -17.5,-5.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9564
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-35.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -64142,11 +63422,11 @@ entities:
       parent: 2
 - proto: JanitorialTrolley
   entities:
-  - uid: 5318
+  - uid: 6640
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -15.5,-33.5
+      pos: -3.5,-21.5
       parent: 2
 - proto: JetpackBlueFilled
   entities:
@@ -64233,11 +63513,6 @@ entities:
     - type: Transform
       pos: -21.5,-10.5
       parent: 2
-  - uid: 4981
-    components:
-    - type: Transform
-      pos: -3.5,-20.5
-      parent: 2
   - uid: 8822
     components:
     - type: Transform
@@ -64257,6 +63532,12 @@ entities:
       parent: 2
 - proto: Lamp
   entities:
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.429731,-33.236565
+      parent: 2
   - uid: 2942
     components:
     - type: Transform
@@ -64488,13 +63769,6 @@ entities:
     - type: Transform
       pos: -64.01732,7.4866257
       parent: 2
-- proto: LockerCabinet
-  entities:
-  - uid: 7584
-    components:
-    - type: Transform
-      pos: -52.5,-24.5
-      parent: 2
 - proto: LockerBoozeFilled
   entities:
   - uid: 152
@@ -64502,12 +63776,12 @@ entities:
     - type: Transform
       pos: -16.5,-6.5
       parent: 2
-- proto: LockerBotanistFilled
+- proto: LockerCabinet
   entities:
-  - uid: 6972
+  - uid: 7584
     components:
     - type: Transform
-      pos: -10.5,-20.5
+      pos: -52.5,-24.5
       parent: 2
 - proto: LockerCaptainFilledNoLaser
   entities:
@@ -64813,6 +64087,18 @@ entities:
     - type: Transform
       pos: -51.5,-34.5
       parent: 2
+- proto: MaintenancePlantSpawner
+  entities:
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -10.5,-22.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -8.5,-23.5
+      parent: 2
 - proto: MaterialDiamond1
   entities:
   - uid: 2221
@@ -64893,22 +64179,22 @@ entities:
       fixtures: {}
 - proto: MopBucket
   entities:
-  - uid: 6815
+  - uid: 3688
     components:
     - type: Transform
-      pos: -12.5,-36.5
+      pos: -6.5,-22.5
       parent: 2
 - proto: MopItem
   entities:
-  - uid: 5797
+  - uid: 5919
     components:
     - type: Transform
-      pos: -11.488404,-36.50251
+      pos: -6.575731,-21.294624
       parent: 2
-  - uid: 6820
+  - uid: 6800
     components:
     - type: Transform
-      pos: -11.667739,-36.425655
+      pos: -6.528856,-21.427437
       parent: 2
 - proto: Morgue
   entities:
@@ -65155,6 +64441,13 @@ entities:
       fixtures: {}
 - proto: Paper
   entities:
+  - uid: 5267
+    components:
+    - type: Transform
+      pos: -13.504331,-33.443806
+      parent: 2
+    - type: Paper
+      content: the ratman cometh
   - uid: 11309
     components:
     - type: Transform
@@ -65201,6 +64494,12 @@ entities:
         The engine should now be operational. It will likely need refueling partway through the shift. Additional canisters can be found in the secure storage.
 - proto: PaperBin
   entities:
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-36.5
+      parent: 2
   - uid: 1887
     components:
     - type: Transform
@@ -65359,10 +64658,21 @@ entities:
       parent: 2
 - proto: Pen
   entities:
+  - uid: 868
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.496776,-35.43467
+      parent: 2
   - uid: 4983
     components:
     - type: Transform
       pos: -4.5090218,-38.582287
+      parent: 2
+  - uid: 5760
+    components:
+    - type: Transform
+      pos: -15.507651,-36.100044
       parent: 2
   - uid: 8918
     components:
@@ -65533,16 +64843,6 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: PosterContrabandBeachStarYamamoto
-  entities:
-  - uid: 1880
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-34.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: PosterContrabandClown
   entities:
   - uid: 1881
@@ -65622,16 +64922,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -21.5,-36.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
-- proto: PosterContrabandHaveaPuff
-  entities:
-  - uid: 1886
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,-23.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -65768,6 +65058,13 @@ entities:
       fixtures: {}
 - proto: PosterLegitBotanyFear
   entities:
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -9.5,-20.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 14309
     components:
     - type: Transform
@@ -66329,7 +65626,6 @@ entities:
   - uid: 8446
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 25.5,-6.5
       parent: 2
   - uid: 8451
@@ -67190,6 +66486,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -27.5,5.5
       parent: 2
+  - uid: 3265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-21.5
+      parent: 2
   - uid: 3465
     components:
     - type: Transform
@@ -67338,11 +66640,6 @@ entities:
     components:
     - type: Transform
       pos: 8.5,-33.5
-      parent: 2
-  - uid: 6817
-    components:
-    - type: Transform
-      pos: -11.5,-36.5
       parent: 2
   - uid: 6976
     components:
@@ -67613,12 +66910,6 @@ entities:
     - type: Transform
       pos: 11.5,-40.5
       parent: 2
-  - uid: 14217
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,-33.5
-      parent: 2
   - uid: 14243
     components:
     - type: Transform
@@ -67790,55 +67081,46 @@ entities:
   - uid: 4643
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,-22.5
       parent: 2
   - uid: 4644
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,-22.5
       parent: 2
   - uid: 4645
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,-22.5
       parent: 2
   - uid: 4646
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-23.5
       parent: 2
   - uid: 4647
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-24.5
       parent: 2
   - uid: 4648
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-25.5
       parent: 2
   - uid: 4649
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-25.5
       parent: 2
   - uid: 4650
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-24.5
       parent: 2
   - uid: 4651
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-23.5
       parent: 2
   - uid: 5090
@@ -67871,19 +67153,16 @@ entities:
   - uid: 478
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-14.5
       parent: 2
   - uid: 694
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-15.5
       parent: 2
   - uid: 695
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-13.5
       parent: 2
   - uid: 907
@@ -67929,7 +67208,6 @@ entities:
   - uid: 1230
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,1.5
       parent: 2
   - uid: 1344
@@ -68005,7 +67283,6 @@ entities:
   - uid: 1495
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-16.5
       parent: 2
   - uid: 1603
@@ -68241,7 +67518,6 @@ entities:
   - uid: 2578
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -26.5,-25.5
       parent: 2
   - uid: 2883
@@ -68352,25 +67628,21 @@ entities:
   - uid: 3075
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-16.5
       parent: 2
   - uid: 3076
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-15.5
       parent: 2
   - uid: 3080
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,-15.5
       parent: 2
   - uid: 3100
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-20.5
       parent: 2
   - uid: 3152
@@ -68381,13 +67653,11 @@ entities:
   - uid: 3658
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-20.5
       parent: 2
   - uid: 3659
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-20.5
       parent: 2
   - uid: 3773
@@ -68448,13 +67718,11 @@ entities:
   - uid: 4248
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -42.5,-1.5
       parent: 2
   - uid: 4289
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 2
   - uid: 4411
@@ -68530,25 +67798,21 @@ entities:
   - uid: 4637
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-20.5
       parent: 2
   - uid: 4638
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,-20.5
       parent: 2
   - uid: 4639
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -57.5,-20.5
       parent: 2
   - uid: 4640
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,-20.5
       parent: 2
   - uid: 4641
@@ -68569,43 +67833,36 @@ entities:
   - uid: 4694
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -33.5,-48.5
       parent: 2
   - uid: 4695
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,-48.5
       parent: 2
   - uid: 4696
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-48.5
       parent: 2
   - uid: 4697
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -32.5,-48.5
       parent: 2
   - uid: 4698
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -48.5,-48.5
       parent: 2
   - uid: 4699
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -46.5,-48.5
       parent: 2
   - uid: 4700
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-48.5
       parent: 2
   - uid: 4717
@@ -68616,7 +67873,6 @@ entities:
   - uid: 4936
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,-48.5
       parent: 2
   - uid: 4999
@@ -68627,7 +67883,6 @@ entities:
   - uid: 5073
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-48.5
       parent: 2
   - uid: 5077
@@ -68863,7 +68118,6 @@ entities:
   - uid: 6505
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,-48.5
       parent: 2
   - uid: 6667
@@ -68899,7 +68153,6 @@ entities:
   - uid: 6702
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-37.5
       parent: 2
   - uid: 6776
@@ -68915,7 +68168,6 @@ entities:
   - uid: 7355
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -19.5,1.5
       parent: 2
   - uid: 7797
@@ -68961,43 +68213,36 @@ entities:
   - uid: 8836
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,20.5
       parent: 2
   - uid: 8837
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 24.5,20.5
       parent: 2
   - uid: 8838
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,20.5
       parent: 2
   - uid: 8839
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,19.5
       parent: 2
   - uid: 8840
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,17.5
       parent: 2
   - uid: 8841
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 25.5,18.5
       parent: 2
   - uid: 10356
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,1.5
       parent: 2
   - uid: 10617
@@ -69028,13 +68273,11 @@ entities:
   - uid: 11129
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 4.5,-14.5
       parent: 2
   - uid: 11391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -60.5,-19.5
       parent: 2
   - uid: 12479
@@ -69288,22 +68531,17 @@ entities:
       fixtures: {}
 - proto: Screwdriver
   entities:
-  - uid: 14220
+  - uid: 314
     components:
     - type: Transform
-      pos: -12.5,-33.5
+      pos: -6.580772,-21.341957
       parent: 2
 - proto: SeedExtractor
   entities:
-  - uid: 322
+  - uid: 175
     components:
     - type: Transform
-      pos: -7.5,-20.5
-      parent: 2
-  - uid: 323
-    components:
-    - type: Transform
-      pos: -7.5,-20.5
+      pos: -3.5,-17.5
       parent: 2
   - uid: 3697
     components:
@@ -69600,18 +68838,6 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 14318
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 2
-  - uid: 14321
-    components:
-    - type: Transform
-      pos: -2.5,-23.5
-      parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 1
   - uid: 14324
     components:
     - type: Transform
@@ -69658,20 +68884,6 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 14449
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-21.5
-      parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 1
-  - uid: 14450
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-22.5
-      parent: 2
   - uid: 14454
     components:
     - type: Transform
@@ -70532,35 +69744,6 @@ entities:
           - Close
     - type: Fixtures
       fixtures: {}
-  - uid: 14317
-    components:
-    - type: Transform
-      pos: -4.5,-17.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        14318:
-        - - On
-          - Open
-        - - Off
-          - Close
-        14321:
-        - - Off
-          - Close
-        - - On
-          - Open
-        14449:
-        - - On
-          - Open
-        - - Off
-          - Close
-        14450:
-        - - On
-          - Open
-        - - Off
-          - Close
-    - type: Fixtures
-      fixtures: {}
   - uid: 14340
     components:
     - type: MetaData
@@ -71042,21 +70225,12 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: SignHydro1
-  entities:
-  - uid: 595
-    components:
-    - type: Transform
-      pos: -2.5,-19.5
-      parent: 2
-    - type: Fixtures
-      fixtures: {}
 - proto: SignJanitor
   entities:
-  - uid: 5269
+  - uid: 337
     components:
     - type: Transform
-      pos: -14.5,-32.5
+      pos: -2.5,-21.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -71424,29 +70598,17 @@ entities:
       parent: 2
 - proto: SinkWide
   entities:
-  - uid: 276
+  - uid: 179
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,-16.5
-      parent: 2
-  - uid: 3231
-    components:
-    - type: Transform
-      pos: -6.5,-18.5
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-17.5
       parent: 2
   - uid: 7895
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -65.5,-27.5
-      parent: 2
-- proto: SmartFridge
-  entities:
-  - uid: 337
-    components:
-    - type: Transform
-      pos: -7.5,-17.5
       parent: 2
 - proto: SMESBasic
   entities:
@@ -72407,12 +71569,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -4.5,-8.5
       parent: 2
-  - uid: 342
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-21.5
-      parent: 2
   - uid: 434
     components:
     - type: Transform
@@ -73067,17 +72223,12 @@ entities:
       id: Detective's office
 - proto: SurveillanceCameraService
   entities:
-  - uid: 3748
+  - uid: 342
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -6.5,-18.5
+      pos: -4.5,-21.5
       parent: 2
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraService
-      nameSet: True
-      id: Botany
   - uid: 3749
     components:
     - type: Transform
@@ -73119,13 +72270,6 @@ entities:
       - SurveillanceCameraService
       nameSet: True
       id: Newsroom
-  - uid: 14381
-    components:
-    - type: Transform
-      pos: -14.5,-36.5
-      parent: 2
-    - type: SurveillanceCamera
-      id: Janitor's closet
   - uid: 14383
     components:
     - type: Transform
@@ -73197,25 +72341,21 @@ entities:
   - uid: 53
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-4.5
       parent: 2
   - uid: 54
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-6.5
       parent: 2
   - uid: 55
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-5.5
       parent: 2
   - uid: 58
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-7.5
       parent: 2
   - uid: 86
@@ -73248,10 +72388,15 @@ entities:
     - type: Transform
       pos: -3.5,-11.5
       parent: 2
-  - uid: 184
+  - uid: 177
     components:
     - type: Transform
-      pos: -3.5,-20.5
+      pos: -7.5,-17.5
+      parent: 2
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -15.5,-34.5
       parent: 2
   - uid: 242
     components:
@@ -73313,16 +72458,6 @@ entities:
     - type: Transform
       pos: -4.5,-13.5
       parent: 2
-  - uid: 344
-    components:
-    - type: Transform
-      pos: -6.5,-21.5
-      parent: 2
-  - uid: 345
-    components:
-    - type: Transform
-      pos: -7.5,-21.5
-      parent: 2
   - uid: 425
     components:
     - type: Transform
@@ -73356,13 +72491,11 @@ entities:
   - uid: 534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-23.5
       parent: 2
   - uid: 557
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-23.5
       parent: 2
   - uid: 567
@@ -73388,7 +72521,6 @@ entities:
   - uid: 610
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-33.5
       parent: 2
   - uid: 619
@@ -73404,14 +72536,27 @@ entities:
   - uid: 624
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-21.5
       parent: 2
   - uid: 648
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-3.5
+      parent: 2
+  - uid: 807
+    components:
+    - type: Transform
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 859
+    components:
+    - type: Transform
+      pos: -15.5,-36.5
+      parent: 2
+  - uid: 871
+    components:
+    - type: Transform
+      pos: -11.5,-34.5
       parent: 2
   - uid: 943
     components:
@@ -73431,13 +72576,11 @@ entities:
   - uid: 991
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-3.5
       parent: 2
   - uid: 1017
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-4.5
       parent: 2
   - uid: 1091
@@ -73454,6 +72597,11 @@ entities:
     components:
     - type: Transform
       pos: 2.5,9.5
+      parent: 2
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: -11.5,-35.5
       parent: 2
   - uid: 1139
     components:
@@ -73548,13 +72696,11 @@ entities:
   - uid: 1371
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,4.5
       parent: 2
   - uid: 1383
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 29.5,8.5
       parent: 2
   - uid: 1497
@@ -73565,7 +72711,6 @@ entities:
   - uid: 1498
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-21.5
       parent: 2
   - uid: 1504
@@ -73591,7 +72736,6 @@ entities:
   - uid: 1677
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -29.5,-22.5
       parent: 2
   - uid: 1720
@@ -73609,10 +72753,14 @@ entities:
     - type: Transform
       pos: 2.5,-47.5
       parent: 2
+  - uid: 1886
+    components:
+    - type: Transform
+      pos: -15.5,-35.5
+      parent: 2
   - uid: 1943
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-19.5
       parent: 2
   - uid: 2065
@@ -73653,13 +72801,11 @@ entities:
   - uid: 2623
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-33.5
       parent: 2
   - uid: 2624
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-34.5
       parent: 2
   - uid: 2808
@@ -73680,43 +72826,36 @@ entities:
   - uid: 2977
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-17.5
       parent: 2
   - uid: 2978
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-18.5
       parent: 2
   - uid: 3058
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-18.5
       parent: 2
   - uid: 3079
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-7.5
       parent: 2
   - uid: 3083
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-7.5
       parent: 2
   - uid: 3084
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-17.5
       parent: 2
   - uid: 3085
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-19.5
       parent: 2
   - uid: 3092
@@ -73732,7 +72871,6 @@ entities:
   - uid: 3209
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-15.5
       parent: 2
   - uid: 3220
@@ -73754,6 +72892,11 @@ entities:
     components:
     - type: Transform
       pos: 20.5,8.5
+      parent: 2
+  - uid: 3689
+    components:
+    - type: Transform
+      pos: -11.5,-33.5
       parent: 2
   - uid: 3700
     components:
@@ -73778,7 +72921,6 @@ entities:
   - uid: 3764
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-19.5
       parent: 2
   - uid: 3799
@@ -73814,13 +72956,11 @@ entities:
   - uid: 4088
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,-12.5
       parent: 2
   - uid: 4172
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -52.5,-12.5
       parent: 2
   - uid: 4219
@@ -73871,7 +73011,6 @@ entities:
   - uid: 5030
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,6.5
       parent: 2
   - uid: 5038
@@ -73882,7 +73021,6 @@ entities:
   - uid: 5170
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,3.5
       parent: 2
   - uid: 5211
@@ -73904,6 +73042,11 @@ entities:
     components:
     - type: Transform
       pos: -21.5,-39.5
+      parent: 2
+  - uid: 5332
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
       parent: 2
   - uid: 5390
     components:
@@ -73929,6 +73072,11 @@ entities:
     components:
     - type: Transform
       pos: -14.5,-18.5
+      parent: 2
+  - uid: 5915
+    components:
+    - type: Transform
+      pos: -6.5,-17.5
       parent: 2
   - uid: 5975
     components:
@@ -73958,13 +73106,11 @@ entities:
   - uid: 6705
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-39.5
       parent: 2
   - uid: 6706
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-40.5
       parent: 2
   - uid: 6750
@@ -73985,19 +73131,16 @@ entities:
   - uid: 7416
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -53.5,9.5
       parent: 2
   - uid: 7438
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,-47.5
       parent: 2
   - uid: 7439
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -39.5,-47.5
       parent: 2
   - uid: 7512
@@ -74023,13 +73166,11 @@ entities:
   - uid: 7635
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -60.5,-30.5
       parent: 2
   - uid: 7636
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,-30.5
       parent: 2
   - uid: 7699
@@ -74045,19 +73186,16 @@ entities:
   - uid: 7821
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-41.5
       parent: 2
   - uid: 7823
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-42.5
       parent: 2
   - uid: 7824
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -57.5,-40.5
       parent: 2
   - uid: 8146
@@ -74088,55 +73226,46 @@ entities:
   - uid: 8384
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,11.5
       parent: 2
   - uid: 8385
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,11.5
       parent: 2
   - uid: 8638
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 27.5,-8.5
       parent: 2
   - uid: 8639
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 28.5,-8.5
       parent: 2
   - uid: 8891
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,17.5
       parent: 2
   - uid: 8892
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,16.5
       parent: 2
   - uid: 8897
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,17.5
       parent: 2
   - uid: 8898
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,18.5
       parent: 2
   - uid: 9024
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -62.5,-37.5
       parent: 2
   - uid: 9026
@@ -74192,25 +73321,21 @@ entities:
   - uid: 9483
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-18.5
       parent: 2
   - uid: 9571
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -25.5,-19.5
       parent: 2
   - uid: 9572
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -24.5,-19.5
       parent: 2
   - uid: 11010
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-20.5
       parent: 2
   - uid: 11612
@@ -74251,7 +73376,6 @@ entities:
   - uid: 12786
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -16.5,-54.5
       parent: 2
   - uid: 12840
@@ -74272,7 +73396,6 @@ entities:
   - uid: 13175
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -52.5,15.5
       parent: 2
   - uid: 13222
@@ -74328,19 +73451,16 @@ entities:
   - uid: 13776
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -71.5,-27.5
       parent: 2
   - uid: 13777
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -70.5,-27.5
       parent: 2
   - uid: 13781
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -70.5,-37.5
       parent: 2
   - uid: 14147
@@ -74492,25 +73612,21 @@ entities:
   - uid: 524
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-15.5
       parent: 2
   - uid: 656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-13.5
       parent: 2
   - uid: 688
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-12.5
       parent: 2
   - uid: 1026
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 18.5,-3.5
       parent: 2
   - uid: 5215
@@ -74536,7 +73652,6 @@ entities:
   - uid: 8532
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-3.5
       parent: 2
   - uid: 8599
@@ -74571,16 +73686,6 @@ entities:
     - type: Transform
       pos: 2.5,-20.5
       parent: 2
-  - uid: 228
-    components:
-    - type: Transform
-      pos: -2.5,-22.5
-      parent: 2
-  - uid: 229
-    components:
-    - type: Transform
-      pos: -2.5,-21.5
-      parent: 2
   - uid: 258
     components:
     - type: Transform
@@ -74604,7 +73709,6 @@ entities:
   - uid: 1279
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,11.5
       parent: 2
   - uid: 2091
@@ -74635,7 +73739,6 @@ entities:
   - uid: 2590
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,5.5
       parent: 2
   - uid: 3073
@@ -74656,13 +73759,11 @@ entities:
   - uid: 5822
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -15.5,5.5
       parent: 2
   - uid: 5823
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,5.5
       parent: 2
 - proto: TableWood
@@ -75274,20 +74375,20 @@ entities:
       parent: 2
 - proto: TrashBag
   entities:
+  - uid: 861
+    components:
+    - type: Transform
+      pos: -6.1772933,-21.521187
+      parent: 2
+  - uid: 5797
+    components:
+    - type: Transform
+      pos: -6.3960433,-21.614937
+      parent: 2
   - uid: 9075
     components:
     - type: Transform
       pos: -83.5,-11.5
-      parent: 2
-  - uid: 14587
-    components:
-    - type: Transform
-      pos: -11.37136,-36.65018
-      parent: 2
-  - uid: 14588
-    components:
-    - type: Transform
-      pos: -11.163027,-36.53552
       parent: 2
 - proto: TurnstileGenpopEnter
   entities:
@@ -75606,7 +74707,6 @@ entities:
   - uid: 148
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 17.5,-10.5
       parent: 2
   - uid: 198
@@ -75617,7 +74717,6 @@ entities:
   - uid: 200
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,-24.5
       parent: 2
   - uid: 222
@@ -75683,7 +74782,6 @@ entities:
   - uid: 368
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-15.5
       parent: 2
   - uid: 387
@@ -75734,7 +74832,6 @@ entities:
   - uid: 424
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 3.5,-14.5
       parent: 2
   - uid: 446
@@ -75790,7 +74887,6 @@ entities:
   - uid: 474
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-16.5
       parent: 2
   - uid: 480
@@ -75856,7 +74952,6 @@ entities:
   - uid: 500
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-24.5
       parent: 2
   - uid: 504
@@ -75867,13 +74962,11 @@ entities:
   - uid: 508
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,-18.5
       parent: 2
   - uid: 514
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -23.5,-24.5
       parent: 2
   - uid: 516
@@ -75884,25 +74977,21 @@ entities:
   - uid: 532
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-11.5
       parent: 2
   - uid: 549
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-14.5
       parent: 2
   - uid: 558
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-17.5
       parent: 2
   - uid: 569
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-11.5
       parent: 2
   - uid: 627
@@ -75968,13 +75057,11 @@ entities:
   - uid: 693
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-12.5
       parent: 2
   - uid: 716
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-13.5
       parent: 2
   - uid: 717
@@ -75985,13 +75072,11 @@ entities:
   - uid: 722
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 19.5,-17.5
       parent: 2
   - uid: 728
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-13.5
       parent: 2
   - uid: 729
@@ -76007,37 +75092,31 @@ entities:
   - uid: 763
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 20.5,-12.5
       parent: 2
   - uid: 875
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-16.5
       parent: 2
   - uid: 904
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -24.5,-28.5
       parent: 2
   - uid: 905
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -22.5,-28.5
       parent: 2
   - uid: 908
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -23.5,-28.5
       parent: 2
   - uid: 909
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-28.5
       parent: 2
   - uid: 981
@@ -76133,19 +75212,16 @@ entities:
   - uid: 1320
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-56.5
       parent: 2
   - uid: 1330
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-55.5
       parent: 2
   - uid: 1357
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,-25.5
       parent: 2
   - uid: 1562
@@ -76161,25 +75237,21 @@ entities:
   - uid: 1571
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-20.5
       parent: 2
   - uid: 1591
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-25.5
       parent: 2
   - uid: 1592
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-28.5
       parent: 2
   - uid: 1593
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-27.5
       parent: 2
   - uid: 1601
@@ -76190,43 +75262,36 @@ entities:
   - uid: 1608
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-28.5
       parent: 2
   - uid: 1609
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-28.5
       parent: 2
   - uid: 1613
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-21.5
       parent: 2
   - uid: 1629
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-56.5
       parent: 2
   - uid: 1642
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,-57.5
       parent: 2
   - uid: 1691
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-23.5
       parent: 2
   - uid: 1706
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -5.5,-57.5
       parent: 2
   - uid: 1913
@@ -76342,25 +75407,21 @@ entities:
   - uid: 1938
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-22.5
       parent: 2
   - uid: 1939
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -18.5,-24.5
       parent: 2
   - uid: 1940
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -19.5,-24.5
       parent: 2
   - uid: 1941
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -17.5,-24.5
       parent: 2
   - uid: 1948
@@ -76651,79 +75712,66 @@ entities:
   - uid: 2553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-24.5
       parent: 2
   - uid: 2770
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 2.5,-14.5
       parent: 2
   - uid: 2856
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,6.5
       parent: 2
   - uid: 2876
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-26.5
       parent: 2
   - uid: 2877
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-24.5
       parent: 2
   - uid: 2878
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-23.5
       parent: 2
   - uid: 2879
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-22.5
       parent: 2
   - uid: 2880
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-21.5
       parent: 2
   - uid: 2881
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-15.5
       parent: 2
   - uid: 2882
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-14.5
       parent: 2
   - uid: 2891
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-11.5
       parent: 2
   - uid: 2892
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-16.5
       parent: 2
   - uid: 2893
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-10.5
       parent: 2
   - uid: 2895
@@ -76739,13 +75787,11 @@ entities:
   - uid: 2915
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-24.5
       parent: 2
   - uid: 2916
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-27.5
       parent: 2
   - uid: 2921
@@ -76901,19 +75947,16 @@ entities:
   - uid: 3031
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-16.5
       parent: 2
   - uid: 3040
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-13.5
       parent: 2
   - uid: 3041
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-11.5
       parent: 2
   - uid: 3051
@@ -76929,13 +75972,11 @@ entities:
   - uid: 3055
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-13.5
       parent: 2
   - uid: 3056
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-15.5
       parent: 2
   - uid: 3057
@@ -76946,13 +75987,11 @@ entities:
   - uid: 3072
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-14.5
       parent: 2
   - uid: 3089
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-20.5
       parent: 2
   - uid: 3099
@@ -76963,7 +76002,6 @@ entities:
   - uid: 3106
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-20.5
       parent: 2
   - uid: 3107
@@ -76974,7 +76012,6 @@ entities:
   - uid: 3118
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-20.5
       parent: 2
   - uid: 3147
@@ -76990,13 +76027,11 @@ entities:
   - uid: 3172
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-13.5
       parent: 2
   - uid: 3208
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -20.5,-24.5
       parent: 2
   - uid: 3263
@@ -77022,13 +76057,11 @@ entities:
   - uid: 3284
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,3.5
       parent: 2
   - uid: 3285
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,9.5
       parent: 2
   - uid: 3309
@@ -77084,13 +76117,11 @@ entities:
   - uid: 3453
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-56.5
       parent: 2
   - uid: 3581
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-57.5
       parent: 2
   - uid: 3582
@@ -77116,13 +76147,11 @@ entities:
   - uid: 3600
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,2.5
       parent: 2
   - uid: 3601
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,1.5
       parent: 2
   - uid: 3606
@@ -77158,19 +76187,16 @@ entities:
   - uid: 3615
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,0.5
       parent: 2
   - uid: 3616
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,-0.5
       parent: 2
   - uid: 3617
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,-1.5
       parent: 2
   - uid: 3618
@@ -77266,7 +76292,6 @@ entities:
   - uid: 3798
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-18.5
       parent: 2
   - uid: 3802
@@ -77352,7 +76377,6 @@ entities:
   - uid: 3953
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,6.5
       parent: 2
   - uid: 3960
@@ -77458,7 +76482,6 @@ entities:
   - uid: 4236
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -55.5,25.5
       parent: 2
   - uid: 4246
@@ -77564,7 +76587,6 @@ entities:
   - uid: 4400
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-32.5
       parent: 2
   - uid: 4404
@@ -77790,7 +76812,6 @@ entities:
   - uid: 4525
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -60.5,-20.5
       parent: 2
   - uid: 4526
@@ -77806,43 +76827,36 @@ entities:
   - uid: 4652
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-22.5
       parent: 2
   - uid: 4653
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-22.5
       parent: 2
   - uid: 4654
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -59.5,-26.5
       parent: 2
   - uid: 4655
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -55.5,-26.5
       parent: 2
   - uid: 4656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -56.5,-26.5
       parent: 2
   - uid: 4657
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -58.5,-26.5
       parent: 2
   - uid: 4676
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,-20.5
       parent: 2
   - uid: 4707
@@ -77863,19 +76877,16 @@ entities:
   - uid: 4789
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -53.5,25.5
       parent: 2
   - uid: 4820
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-15.5
       parent: 2
   - uid: 4889
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -45.5,-48.5
       parent: 2
   - uid: 4959
@@ -77906,7 +76917,6 @@ entities:
   - uid: 5047
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,13.5
       parent: 2
   - uid: 5054
@@ -77967,13 +76977,11 @@ entities:
   - uid: 5081
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-48.5
       parent: 2
   - uid: 5088
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-49.5
       parent: 2
   - uid: 5130
@@ -77999,19 +77007,16 @@ entities:
   - uid: 5161
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-17.5
       parent: 2
   - uid: 5179
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -21.5,-19.5
       parent: 2
   - uid: 5197
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-55.5
       parent: 2
   - uid: 5199
@@ -78027,7 +77032,6 @@ entities:
   - uid: 5207
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
   - uid: 5220
@@ -78078,73 +77082,61 @@ entities:
   - uid: 5242
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-50.5
       parent: 2
   - uid: 5243
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-48.5
       parent: 2
   - uid: 5244
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-49.5
       parent: 2
   - uid: 5245
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-50.5
       parent: 2
   - uid: 5246
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-48.5
       parent: 2
   - uid: 5247
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-49.5
       parent: 2
   - uid: 5248
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-50.5
       parent: 2
   - uid: 5249
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-48.5
       parent: 2
   - uid: 5250
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-49.5
       parent: 2
   - uid: 5251
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-50.5
       parent: 2
   - uid: 5252
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,-48.5
       parent: 2
   - uid: 5261
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -49.5,-48.5
       parent: 2
   - uid: 5262
@@ -78160,7 +77152,6 @@ entities:
   - uid: 5276
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,8.5
       parent: 2
   - uid: 5278
@@ -78231,91 +77222,76 @@ entities:
   - uid: 5728
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-41.5
       parent: 2
   - uid: 5781
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-41.5
       parent: 2
   - uid: 5782
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-40.5
       parent: 2
   - uid: 5783
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-39.5
       parent: 2
   - uid: 5784
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-39.5
       parent: 2
   - uid: 5785
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-36.5
       parent: 2
   - uid: 5786
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-39.5
       parent: 2
   - uid: 5792
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-48.5
       parent: 2
   - uid: 5808
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,9.5
       parent: 2
   - uid: 5809
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,10.5
       parent: 2
   - uid: 5810
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,10.5
       parent: 2
   - uid: 5811
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,10.5
       parent: 2
   - uid: 5812
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -9.5,10.5
       parent: 2
   - uid: 5813
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,7.5
       parent: 2
   - uid: 5814
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,6.5
       parent: 2
   - uid: 5956
@@ -78576,7 +77552,6 @@ entities:
   - uid: 6204
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,20.5
       parent: 2
   - uid: 6208
@@ -78627,7 +77602,6 @@ entities:
   - uid: 6220
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -66.5,20.5
       parent: 2
   - uid: 6245
@@ -78653,19 +77627,16 @@ entities:
   - uid: 6262
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,12.5
       parent: 2
   - uid: 6263
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,10.5
       parent: 2
   - uid: 6264
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,11.5
       parent: 2
   - uid: 6265
@@ -78731,43 +77702,36 @@ entities:
   - uid: 6278
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -29.5,-48.5
       parent: 2
   - uid: 6279
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -28.5,-48.5
       parent: 2
   - uid: 6280
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-48.5
       parent: 2
   - uid: 6285
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-39.5
       parent: 2
   - uid: 6291
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-36.5
       parent: 2
   - uid: 6293
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -39.5,-36.5
       parent: 2
   - uid: 6294
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -38.5,-36.5
       parent: 2
   - uid: 6295
@@ -78778,49 +77742,41 @@ entities:
   - uid: 6296
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -36.5,-36.5
       parent: 2
   - uid: 6297
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -35.5,-36.5
       parent: 2
   - uid: 6298
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-39.5
       parent: 2
   - uid: 6299
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-38.5
       parent: 2
   - uid: 6300
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-37.5
       parent: 2
   - uid: 6301
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-36.5
       parent: 2
   - uid: 6302
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-36.5
       parent: 2
   - uid: 6303
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -41.5,-36.5
       parent: 2
   - uid: 6313
@@ -78846,7 +77802,6 @@ entities:
   - uid: 6318
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -60.5,-43.5
       parent: 2
   - uid: 6321
@@ -78957,7 +77912,6 @@ entities:
   - uid: 6375
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -34.5,-38.5
       parent: 2
   - uid: 6376
@@ -79078,7 +78032,6 @@ entities:
   - uid: 6463
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,17.5
       parent: 2
   - uid: 6466
@@ -79189,13 +78142,11 @@ entities:
   - uid: 6504
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,15.5
       parent: 2
   - uid: 6507
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 29.5,14.5
       parent: 2
   - uid: 6508
@@ -79206,25 +78157,21 @@ entities:
   - uid: 6513
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,15.5
       parent: 2
   - uid: 6514
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 26.5,15.5
       parent: 2
   - uid: 6515
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 27.5,15.5
       parent: 2
   - uid: 6516
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 28.5,15.5
       parent: 2
   - uid: 6519
@@ -79240,7 +78187,6 @@ entities:
   - uid: 6525
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,20.5
       parent: 2
   - uid: 6527
@@ -79261,25 +78207,21 @@ entities:
   - uid: 6537
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,20.5
       parent: 2
   - uid: 6539
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -52.5,25.5
       parent: 2
   - uid: 6541
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,15.5
       parent: 2
   - uid: 6545
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -65.5,20.5
       parent: 2
   - uid: 6548
@@ -79290,73 +78232,61 @@ entities:
   - uid: 6550
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -65.5,18.5
       parent: 2
   - uid: 6551
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,16.5
       parent: 2
   - uid: 6554
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,19.5
       parent: 2
   - uid: 6562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,17.5
       parent: 2
   - uid: 6563
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,18.5
       parent: 2
   - uid: 6564
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,19.5
       parent: 2
   - uid: 6565
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,19.5
       parent: 2
   - uid: 6566
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,19.5
       parent: 2
   - uid: 6567
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,19.5
       parent: 2
   - uid: 6568
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,19.5
       parent: 2
   - uid: 6569
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,19.5
       parent: 2
   - uid: 6572
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,19.5
       parent: 2
   - uid: 6573
@@ -79392,25 +78322,21 @@ entities:
   - uid: 6629
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,19.5
       parent: 2
   - uid: 6639
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,17.5
       parent: 2
   - uid: 6641
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,20.5
       parent: 2
   - uid: 6647
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,20.5
       parent: 2
   - uid: 6649
@@ -79421,7 +78347,6 @@ entities:
   - uid: 6650
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 25.5,16.5
       parent: 2
   - uid: 6651
@@ -79432,55 +78357,46 @@ entities:
   - uid: 6678
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,16.5
       parent: 2
   - uid: 6679
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,15.5
       parent: 2
   - uid: 6685
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,15.5
       parent: 2
   - uid: 6687
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,16.5
       parent: 2
   - uid: 6690
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -56.5,25.5
       parent: 2
   - uid: 6691
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -54.5,25.5
       parent: 2
   - uid: 6697
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-39.5
       parent: 2
   - uid: 6698
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-41.5
       parent: 2
   - uid: 6699
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -64.5,-40.5
       parent: 2
   - uid: 6710
@@ -79491,73 +78407,61 @@ entities:
   - uid: 6733
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -63.5,23.5
       parent: 2
   - uid: 6739
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -66.5,18.5
       parent: 2
   - uid: 6740
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,23.5
       parent: 2
   - uid: 6741
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -51.5,25.5
       parent: 2
   - uid: 6742
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -48.5,25.5
       parent: 2
   - uid: 6744
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,25.5
       parent: 2
   - uid: 6790
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,17.5
       parent: 2
   - uid: 6843
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,-24.5
       parent: 2
   - uid: 6847
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,18.5
       parent: 2
   - uid: 6849
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,18.5
       parent: 2
   - uid: 6850
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -37.5,19.5
       parent: 2
   - uid: 6851
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,19.5
       parent: 2
   - uid: 6852
@@ -79608,7 +78512,6 @@ entities:
   - uid: 7618
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,18.5
       parent: 2
   - uid: 7668
@@ -79624,7 +78527,6 @@ entities:
   - uid: 7749
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -4.5,-57.5
       parent: 2
   - uid: 7782
@@ -79635,7 +78537,6 @@ entities:
   - uid: 7943
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,15.5
       parent: 2
   - uid: 8002
@@ -79651,19 +78552,16 @@ entities:
   - uid: 8159
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -64.5,16.5
       parent: 2
   - uid: 8365
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,13.5
       parent: 2
   - uid: 8432
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,-57.5
       parent: 2
   - uid: 9166
@@ -79694,37 +78592,31 @@ entities:
   - uid: 9499
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-37.5
       parent: 2
   - uid: 9509
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -17.5,-36.5
       parent: 2
   - uid: 9514
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,-57.5
       parent: 2
   - uid: 9515
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -19.5,-36.5
       parent: 2
   - uid: 9529
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-39.5
       parent: 2
   - uid: 9530
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-40.5
       parent: 2
   - uid: 10349
@@ -79745,31 +78637,26 @@ entities:
   - uid: 10929
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-39.5
       parent: 2
   - uid: 11120
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-10.5
       parent: 2
   - uid: 11134
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-14.5
       parent: 2
   - uid: 11144
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-10.5
       parent: 2
   - uid: 11145
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-15.5
       parent: 2
   - uid: 11172
@@ -79780,49 +78667,41 @@ entities:
   - uid: 11351
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-38.5
       parent: 2
   - uid: 11368
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-36.5
       parent: 2
   - uid: 11390
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-36.5
       parent: 2
   - uid: 11489
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -20.5,-36.5
       parent: 2
   - uid: 11490
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -22.5,-37.5
       parent: 2
   - uid: 11491
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-36.5
       parent: 2
   - uid: 11492
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -16.5,-38.5
       parent: 2
   - uid: 11493
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -21.5,-40.5
       parent: 2
   - uid: 11495
@@ -79858,19 +78737,16 @@ entities:
   - uid: 11649
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,-57.5
       parent: 2
   - uid: 11650
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -10.5,-57.5
       parent: 2
   - uid: 11653
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-4.5
       parent: 2
   - uid: 11727
@@ -79926,13 +78802,11 @@ entities:
   - uid: 11808
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -11.5,-55.5
       parent: 2
   - uid: 11819
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -10.5,-55.5
       parent: 2
   - uid: 11840
@@ -79958,61 +78832,51 @@ entities:
   - uid: 11861
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -61.5,23.5
       parent: 2
   - uid: 11869
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-15.5
       parent: 2
   - uid: 11991
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-14.5
       parent: 2
   - uid: 12274
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -62.5,23.5
       parent: 2
   - uid: 12275
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,24.5
       parent: 2
   - uid: 12276
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -59.5,23.5
       parent: 2
   - uid: 12277
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -60.5,23.5
       parent: 2
   - uid: 12279
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,24.5
       parent: 2
   - uid: 12280
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -56.5,24.5
       parent: 2
   - uid: 12281
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -57.5,24.5
       parent: 2
   - uid: 12469
@@ -80368,7 +79232,6 @@ entities:
   - uid: 12716
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,-55.5
       parent: 2
   - uid: 12718
@@ -80599,217 +79462,181 @@ entities:
   - uid: 13900
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-49.5
       parent: 2
   - uid: 13911
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-48.5
       parent: 2
   - uid: 13923
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-55.5
       parent: 2
   - uid: 13924
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-55.5
       parent: 2
   - uid: 13925
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-54.5
       parent: 2
   - uid: 13926
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-53.5
       parent: 2
   - uid: 13927
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-52.5
       parent: 2
   - uid: 13933
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-54.5
       parent: 2
   - uid: 13953
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-45.5
       parent: 2
   - uid: 13954
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,-45.5
       parent: 2
   - uid: 13955
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,-44.5
       parent: 2
   - uid: 13957
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 21.5,-42.5
       parent: 2
   - uid: 13958
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-46.5
       parent: 2
   - uid: 13959
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-47.5
       parent: 2
   - uid: 13963
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-53.5
       parent: 2
   - uid: 13964
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-53.5
       parent: 2
   - uid: 13965
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-53.5
       parent: 2
   - uid: 13966
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-53.5
       parent: 2
   - uid: 13967
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-54.5
       parent: 2
   - uid: 13968
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-55.5
       parent: 2
   - uid: 13969
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-55.5
       parent: 2
   - uid: 13970
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-55.5
       parent: 2
   - uid: 13971
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-55.5
       parent: 2
   - uid: 13972
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-56.5
       parent: 2
   - uid: 13973
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-55.5
       parent: 2
   - uid: 13976
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-56.5
       parent: 2
   - uid: 13977
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-56.5
       parent: 2
   - uid: 13978
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-56.5
       parent: 2
   - uid: 13979
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-56.5
       parent: 2
   - uid: 13980
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-50.5
       parent: 2
   - uid: 13981
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-51.5
       parent: 2
   - uid: 13982
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-52.5
       parent: 2
   - uid: 13983
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-52.5
       parent: 2
   - uid: 13984
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-52.5
       parent: 2
   - uid: 13985
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-52.5
       parent: 2
   - uid: 14343
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-17.5
       parent: 2
 - proto: WallSolid
@@ -80882,7 +79709,6 @@ entities:
   - uid: 26
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 13.5,-8.5
       parent: 2
   - uid: 42
@@ -80903,7 +79729,6 @@ entities:
   - uid: 60
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 8.5,-43.5
       parent: 2
   - uid: 65
@@ -81126,35 +79951,10 @@ entities:
     - type: Transform
       pos: -2.5,-17.5
       parent: 2
-  - uid: 175
-    components:
-    - type: Transform
-      pos: -3.5,-17.5
-      parent: 2
-  - uid: 176
-    components:
-    - type: Transform
-      pos: -4.5,-17.5
-      parent: 2
-  - uid: 177
-    components:
-    - type: Transform
-      pos: -5.5,-17.5
-      parent: 2
-  - uid: 178
-    components:
-    - type: Transform
-      pos: -6.5,-17.5
-      parent: 2
   - uid: 181
     components:
     - type: Transform
-      pos: -9.5,-17.5
-      parent: 2
-  - uid: 182
-    components:
-    - type: Transform
-      pos: -10.5,-17.5
+      pos: -2.5,-23.5
       parent: 2
   - uid: 183
     components:
@@ -81169,7 +79969,6 @@ entities:
   - uid: 193
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,-20.5
       parent: 2
   - uid: 202
@@ -81182,15 +79981,9 @@ entities:
     - type: Transform
       pos: -3.5,-13.5
       parent: 2
-  - uid: 227
-    components:
-    - type: Transform
-      pos: -2.5,-19.5
-      parent: 2
   - uid: 252
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-13.5
       parent: 2
   - uid: 278
@@ -81212,11 +80005,6 @@ entities:
     components:
     - type: Transform
       pos: -4.5,-25.5
-      parent: 2
-  - uid: 282
-    components:
-    - type: Transform
-      pos: -5.5,-25.5
       parent: 2
   - uid: 283
     components:
@@ -81278,11 +80066,6 @@ entities:
     - type: Transform
       pos: -11.5,-15.5
       parent: 2
-  - uid: 315
-    components:
-    - type: Transform
-      pos: -2.5,-24.5
-      parent: 2
   - uid: 325
     components:
     - type: Transform
@@ -81301,7 +80084,6 @@ entities:
   - uid: 365
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -2.5,-27.5
       parent: 2
   - uid: 367
@@ -81317,13 +80099,11 @@ entities:
   - uid: 370
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-25.5
       parent: 2
   - uid: 371
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 1.5,-27.5
       parent: 2
   - uid: 372
@@ -81379,7 +80159,6 @@ entities:
   - uid: 465
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-2.5
       parent: 2
   - uid: 604
@@ -81390,79 +80169,106 @@ entities:
   - uid: 617
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-8.5
       parent: 2
   - uid: 730
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-22.5
       parent: 2
   - uid: 731
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 15.5,-22.5
       parent: 2
   - uid: 732
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,-22.5
       parent: 2
   - uid: 733
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-22.5
       parent: 2
   - uid: 734
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-22.5
       parent: 2
   - uid: 735
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-21.5
       parent: 2
   - uid: 736
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-20.5
       parent: 2
   - uid: 737
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-19.5
+      parent: 2
+  - uid: 804
+    components:
+    - type: Transform
+      pos: -7.5,-20.5
+      parent: 2
+  - uid: 805
+    components:
+    - type: Transform
+      pos: -11.5,-19.5
+      parent: 2
+  - uid: 806
+    components:
+    - type: Transform
+      pos: -10.5,-20.5
+      parent: 2
+  - uid: 811
+    components:
+    - type: Transform
+      pos: -8.5,-20.5
+      parent: 2
+  - uid: 864
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 2
+  - uid: 865
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 2
+  - uid: 866
+    components:
+    - type: Transform
+      pos: -7.5,-23.5
+      parent: 2
+  - uid: 873
+    components:
+    - type: Transform
+      pos: -2.5,-20.5
       parent: 2
   - uid: 932
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,-20.5
       parent: 2
   - uid: 940
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-19.5
       parent: 2
   - uid: 941
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-17.5
       parent: 2
   - uid: 942
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-15.5
       parent: 2
   - uid: 993
@@ -81483,7 +80289,6 @@ entities:
   - uid: 1022
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-7.5
       parent: 2
   - uid: 1032
@@ -81509,7 +80314,6 @@ entities:
   - uid: 1127
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-7.5
       parent: 2
   - uid: 1137
@@ -81845,7 +80649,6 @@ entities:
   - uid: 1424
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-8.5
       parent: 2
   - uid: 1484
@@ -82161,7 +80964,6 @@ entities:
   - uid: 1636
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -7.5,1.5
       parent: 2
   - uid: 1638
@@ -82172,7 +80974,6 @@ entities:
   - uid: 1640
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -9.5,1.5
       parent: 2
   - uid: 1641
@@ -82183,7 +80984,6 @@ entities:
   - uid: 1643
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,1.5
       parent: 2
   - uid: 1644
@@ -82244,7 +81044,6 @@ entities:
   - uid: 1667
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,1.5
       parent: 2
   - uid: 1670
@@ -82310,7 +81109,6 @@ entities:
   - uid: 1747
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -14.5,1.5
       parent: 2
   - uid: 1752
@@ -82332,6 +81130,11 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-32.5
+      parent: 2
+  - uid: 1880
+    components:
+    - type: Transform
+      pos: -9.5,-20.5
       parent: 2
   - uid: 1898
     components:
@@ -82466,7 +81269,6 @@ entities:
   - uid: 2549
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-52.5
       parent: 2
   - uid: 2551
@@ -82477,7 +81279,6 @@ entities:
   - uid: 2561
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-51.5
       parent: 2
   - uid: 2568
@@ -82488,85 +81289,71 @@ entities:
   - uid: 2581
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-33.5
       parent: 2
   - uid: 2583
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-41.5
       parent: 2
   - uid: 2586
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-41.5
       parent: 2
   - uid: 2587
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-41.5
       parent: 2
   - uid: 2588
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-41.5
       parent: 2
   - uid: 2610
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-34.5
       parent: 2
   - uid: 2611
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-35.5
       parent: 2
   - uid: 2612
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 15.5,-36.5
       parent: 2
   - uid: 2613
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-36.5
       parent: 2
   - uid: 2614
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-35.5
       parent: 2
   - uid: 2615
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-34.5
       parent: 2
   - uid: 2616
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 11.5,-33.5
       parent: 2
   - uid: 2617
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-36.5
       parent: 2
   - uid: 2618
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 14.5,-36.5
       parent: 2
   - uid: 2732
@@ -82737,7 +81524,6 @@ entities:
   - uid: 3011
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -51.5,19.5
       parent: 2
   - uid: 3121
@@ -82748,13 +81534,11 @@ entities:
   - uid: 3153
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-46.5
       parent: 2
   - uid: 3156
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-46.5
       parent: 2
   - uid: 3158
@@ -82775,13 +81559,11 @@ entities:
   - uid: 3186
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -2.5,-48.5
       parent: 2
   - uid: 3187
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-5.5
       parent: 2
   - uid: 3204
@@ -82792,8 +81574,22 @@ entities:
   - uid: 3205
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-21.5
+      parent: 2
+  - uid: 3212
+    components:
+    - type: Transform
+      pos: -7.5,-22.5
+      parent: 2
+  - uid: 3229
+    components:
+    - type: Transform
+      pos: -7.5,-21.5
+      parent: 2
+  - uid: 3231
+    components:
+    - type: Transform
+      pos: -7.5,-24.5
       parent: 2
   - uid: 3286
     components:
@@ -82808,31 +81604,26 @@ entities:
   - uid: 3289
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 0.5,-48.5
       parent: 2
   - uid: 3304
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-51.5
       parent: 2
   - uid: 3305
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 14.5,-41.5
       parent: 2
   - uid: 3306
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-41.5
       parent: 2
   - uid: 3343
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-42.5
       parent: 2
   - uid: 3344
@@ -82843,7 +81634,6 @@ entities:
   - uid: 3379
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-45.5
       parent: 2
   - uid: 3380
@@ -82869,7 +81659,6 @@ entities:
   - uid: 3387
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-42.5
       parent: 2
   - uid: 3394
@@ -82880,7 +81669,6 @@ entities:
   - uid: 3395
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 3.5,-52.5
       parent: 2
   - uid: 3396
@@ -82891,7 +81679,6 @@ entities:
   - uid: 3448
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-22.5
       parent: 2
   - uid: 3450
@@ -82962,13 +81749,11 @@ entities:
   - uid: 3660
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-20.5
       parent: 2
   - uid: 3661
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-24.5
       parent: 2
   - uid: 3731
@@ -82989,13 +81774,11 @@ entities:
   - uid: 3736
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -48.5,23.5
       parent: 2
   - uid: 3745
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-23.5
       parent: 2
   - uid: 3775
@@ -83196,7 +81979,6 @@ entities:
   - uid: 4937
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,10.5
       parent: 2
   - uid: 4958
@@ -83217,19 +81999,16 @@ entities:
   - uid: 4990
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -11.5,1.5
       parent: 2
   - uid: 4991
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -12.5,1.5
       parent: 2
   - uid: 4997
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 9.5,-7.5
       parent: 2
   - uid: 5000
@@ -83245,13 +82024,11 @@ entities:
   - uid: 5032
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -1.5,-48.5
       parent: 2
   - uid: 5033
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 7.5,-47.5
       parent: 2
   - uid: 5126
@@ -83297,49 +82074,41 @@ entities:
   - uid: 5164
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-15.5
       parent: 2
   - uid: 5166
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-17.5
       parent: 2
   - uid: 5178
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-16.5
       parent: 2
   - uid: 5180
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -18.5,-19.5
       parent: 2
   - uid: 5196
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -3.5,-54.5
       parent: 2
   - uid: 5198
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-53.5
       parent: 2
   - uid: 5200
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-54.5
       parent: 2
   - uid: 5203
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 2.5,-52.5
       parent: 2
   - uid: 5213
@@ -83365,7 +82134,6 @@ entities:
   - uid: 5265
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 6.5,-40.5
       parent: 2
   - uid: 5277
@@ -83373,178 +82141,174 @@ entities:
     - type: Transform
       pos: 13.5,22.5
       parent: 2
+  - uid: 5311
+    components:
+    - type: Transform
+      pos: -3.5,-20.5
+      parent: 2
+  - uid: 5318
+    components:
+    - type: Transform
+      pos: -4.5,-20.5
+      parent: 2
+  - uid: 5328
+    components:
+    - type: Transform
+      pos: -2.5,-24.5
+      parent: 2
+  - uid: 5330
+    components:
+    - type: Transform
+      pos: -6.5,-20.5
+      parent: 2
   - uid: 5338
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-39.5
       parent: 2
   - uid: 5339
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-40.5
       parent: 2
   - uid: 5340
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-42.5
       parent: 2
   - uid: 5341
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,-41.5
       parent: 2
   - uid: 5342
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,-42.5
       parent: 2
   - uid: 5343
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,-42.5
       parent: 2
   - uid: 5344
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,-42.5
       parent: 2
   - uid: 5345
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,-42.5
       parent: 2
   - uid: 5346
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-42.5
       parent: 2
   - uid: 5347
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-41.5
       parent: 2
   - uid: 5348
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,-39.5
       parent: 2
   - uid: 5351
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,8.5
       parent: 2
   - uid: 5352
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,10.5
       parent: 2
   - uid: 5353
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,11.5
       parent: 2
   - uid: 5354
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -29.5,11.5
       parent: 2
   - uid: 5355
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -28.5,11.5
       parent: 2
   - uid: 5356
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -26.5,11.5
       parent: 2
   - uid: 5357
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -27.5,11.5
       parent: 2
   - uid: 5358
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,11.5
       parent: 2
   - uid: 5359
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,10.5
       parent: 2
   - uid: 5361
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -25.5,8.5
       parent: 2
   - uid: 5362
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -30.5,9.5
+      parent: 2
+  - uid: 5447
+    components:
+    - type: Transform
+      pos: -13.5,-32.5
       parent: 2
   - uid: 5474
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -60.5,6.5
       parent: 2
   - uid: 5620
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 5.5,-47.5
       parent: 2
   - uid: 5621
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-40.5
       parent: 2
   - uid: 5625
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,4.5
       parent: 2
   - uid: 5644
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,-13.5
       parent: 2
   - uid: 5647
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-11.5
       parent: 2
   - uid: 5648
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,-10.5
       parent: 2
   - uid: 5651
@@ -83555,25 +82319,21 @@ entities:
   - uid: 5683
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,-41.5
       parent: 2
   - uid: 5684
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -42.5,-41.5
       parent: 2
   - uid: 5686
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,-41.5
       parent: 2
   - uid: 5754
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -13.5,-20.5
       parent: 2
   - uid: 5755
@@ -83584,37 +82344,31 @@ entities:
   - uid: 5764
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -15.5,-25.5
       parent: 2
   - uid: 5787
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-43.5
       parent: 2
   - uid: 5788
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-45.5
       parent: 2
   - uid: 5789
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,-47.5
       parent: 2
   - uid: 5790
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-35.5
       parent: 2
   - uid: 5791
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-3.5
       parent: 2
   - uid: 5802
@@ -83625,13 +82379,11 @@ entities:
   - uid: 5803
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -12.5,5.5
       parent: 2
   - uid: 5804
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -16.5,7.5
       parent: 2
   - uid: 5807
@@ -83642,13 +82394,17 @@ entities:
   - uid: 5815
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -6.5,2.5
       parent: 2
   - uid: 5818
     components:
     - type: Transform
       pos: -12.5,2.5
+      parent: 2
+  - uid: 5916
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
       parent: 2
   - uid: 5950
     components:
@@ -83698,7 +82454,6 @@ entities:
   - uid: 5967
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 20.5,-7.5
       parent: 2
   - uid: 5968
@@ -83709,55 +82464,46 @@ entities:
   - uid: 5971
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-5.5
       parent: 2
   - uid: 5972
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-4.5
       parent: 2
   - uid: 5973
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-37.5
       parent: 2
   - uid: 5974
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-6.5
       parent: 2
   - uid: 5976
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,-7.5
       parent: 2
   - uid: 5977
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,-38.5
       parent: 2
   - uid: 5980
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 11.5,-38.5
       parent: 2
   - uid: 5981
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,-7.5
       parent: 2
   - uid: 5982
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 22.5,-14.5
       parent: 2
   - uid: 5986
@@ -84353,25 +83099,21 @@ entities:
   - uid: 6258
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-37.5
       parent: 2
   - uid: 6260
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-38.5
       parent: 2
   - uid: 6261
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 8.5,-38.5
       parent: 2
   - uid: 6281
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 7.5,-34.5
       parent: 2
   - uid: 6282
@@ -84772,79 +83514,66 @@ entities:
   - uid: 6509
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,13.5
       parent: 2
   - uid: 6510
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,14.5
       parent: 2
   - uid: 6511
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,15.5
       parent: 2
   - uid: 6512
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 24.5,11.5
       parent: 2
   - uid: 6518
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -12.5,10.5
       parent: 2
   - uid: 6524
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 23.5,15.5
       parent: 2
   - uid: 6526
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 21.5,15.5
       parent: 2
   - uid: 6528
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 19.5,15.5
       parent: 2
   - uid: 6529
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 18.5,15.5
       parent: 2
   - uid: 6530
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,15.5
       parent: 2
   - uid: 6533
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,15.5
       parent: 2
   - uid: 6534
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 13.5,15.5
       parent: 2
   - uid: 6535
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,15.5
       parent: 2
   - uid: 6538
@@ -84855,25 +83584,21 @@ entities:
   - uid: 6542
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 12.5,14.5
       parent: 2
   - uid: 6543
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,11.5
       parent: 2
   - uid: 6544
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,13.5
       parent: 2
   - uid: 6546
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 23.5,-9.5
       parent: 2
   - uid: 6547
@@ -84884,43 +83609,36 @@ entities:
   - uid: 6552
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 2
   - uid: 6553
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 2
   - uid: 6555
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,13.5
       parent: 2
   - uid: 6556
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -4.5,13.5
       parent: 2
   - uid: 6557
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -5.5,13.5
       parent: 2
   - uid: 6559
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -7.5,13.5
       parent: 2
   - uid: 6560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -8.5,13.5
       parent: 2
   - uid: 6570
@@ -84931,7 +83649,6 @@ entities:
   - uid: 6571
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 10.5,18.5
       parent: 2
   - uid: 6579
@@ -84987,19 +83704,16 @@ entities:
   - uid: 6601
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,13.5
       parent: 2
   - uid: 6602
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,11.5
       parent: 2
   - uid: 6603
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -15.5,10.5
       parent: 2
   - uid: 6605
@@ -85020,13 +83734,11 @@ entities:
   - uid: 6630
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,18.5
       parent: 2
   - uid: 6631
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 14.5,16.5
       parent: 2
   - uid: 6634
@@ -85067,55 +83779,46 @@ entities:
   - uid: 6652
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-47.5
       parent: 2
   - uid: 6653
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-44.5
       parent: 2
   - uid: 6654
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-43.5
       parent: 2
   - uid: 6655
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -21.5,-46.5
       parent: 2
   - uid: 6656
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -22.5,-46.5
       parent: 2
   - uid: 6657
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,10.5
       parent: 2
   - uid: 6658
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,9.5
       parent: 2
   - uid: 6659
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -40.5,8.5
       parent: 2
   - uid: 6665
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -37.5,13.5
       parent: 2
   - uid: 6666
@@ -85126,25 +83829,21 @@ entities:
   - uid: 6671
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -31.5,13.5
       parent: 2
   - uid: 6672
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,13.5
       parent: 2
   - uid: 6673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -30.5,12.5
       parent: 2
   - uid: 6674
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -38.5,8.5
       parent: 2
   - uid: 6675
@@ -85310,25 +84009,21 @@ entities:
   - uid: 6831
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -41.5,12.5
       parent: 2
   - uid: 6832
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -50.5,6.5
       parent: 2
   - uid: 6833
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -50.5,3.5
       parent: 2
   - uid: 6837
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -44.5,12.5
       parent: 2
   - uid: 6858
@@ -85344,8 +84039,12 @@ entities:
   - uid: 6986
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -8.5,1.5
+      parent: 2
+  - uid: 7351
+    components:
+    - type: Transform
+      pos: -5.5,-20.5
       parent: 2
   - uid: 7361
     components:
@@ -85385,13 +84084,11 @@ entities:
   - uid: 7631
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-33.5
       parent: 2
   - uid: 7632
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -58.5,-30.5
       parent: 2
   - uid: 7714
@@ -85462,7 +84159,6 @@ entities:
   - uid: 8000
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -50.5,19.5
       parent: 2
   - uid: 8001
@@ -85553,19 +84249,16 @@ entities:
   - uid: 8391
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,16.5
       parent: 2
   - uid: 8565
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -40.5,15.5
       parent: 2
   - uid: 8579
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,11.5
       parent: 2
   - uid: 8585
@@ -85606,7 +84299,6 @@ entities:
   - uid: 8634
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,12.5
       parent: 2
   - uid: 8635
@@ -85617,13 +84309,11 @@ entities:
   - uid: 8662
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 17.5,-7.5
       parent: 2
   - uid: 8667
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 16.5,-6.5
       parent: 2
   - uid: 8763
@@ -85804,7 +84494,6 @@ entities:
   - uid: 9200
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: -39.5,16.5
       parent: 2
   - uid: 9201
@@ -85915,7 +84604,6 @@ entities:
   - uid: 11001
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 16.5,-2.5
       parent: 2
   - uid: 11138
@@ -86676,253 +85364,211 @@ entities:
   - uid: 13893
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-41.5
       parent: 2
   - uid: 13894
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-41.5
       parent: 2
   - uid: 13895
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 18.5,-41.5
       parent: 2
   - uid: 13896
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-41.5
       parent: 2
   - uid: 13897
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 20.5,-41.5
       parent: 2
   - uid: 13898
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-52.5
       parent: 2
   - uid: 13899
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-52.5
       parent: 2
   - uid: 13901
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-52.5
       parent: 2
   - uid: 13902
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 5.5,-52.5
       parent: 2
   - uid: 13903
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 6.5,-52.5
       parent: 2
   - uid: 13904
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-44.5
       parent: 2
   - uid: 13905
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-45.5
       parent: 2
   - uid: 13906
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-45.5
       parent: 2
   - uid: 13907
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-49.5
       parent: 2
   - uid: 13908
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-50.5
       parent: 2
   - uid: 13909
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,-50.5
       parent: 2
   - uid: 13912
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-52.5
       parent: 2
   - uid: 13913
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 10.5,-50.5
       parent: 2
   - uid: 13914
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-50.5
       parent: 2
   - uid: 13915
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-50.5
       parent: 2
   - uid: 13916
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-49.5
       parent: 2
   - uid: 13917
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 11.5,-49.5
       parent: 2
   - uid: 13918
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-49.5
       parent: 2
   - uid: 13919
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-47.5
       parent: 2
   - uid: 13920
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 13.5,-46.5
       parent: 2
   - uid: 13921
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-46.5
       parent: 2
   - uid: 13922
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,-45.5
       parent: 2
   - uid: 13928
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-51.5
       parent: 2
   - uid: 13929
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-50.5
       parent: 2
   - uid: 13930
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-49.5
       parent: 2
   - uid: 13931
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-48.5
       parent: 2
   - uid: 13932
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-47.5
       parent: 2
   - uid: 13934
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-45.5
       parent: 2
   - uid: 13935
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 16.5,-44.5
       parent: 2
   - uid: 13936
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-44.5
       parent: 2
   - uid: 13937
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 15.5,-43.5
       parent: 2
   - uid: 13950
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-45.5
       parent: 2
   - uid: 13952
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-45.5
       parent: 2
   - uid: 13960
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 19.5,-47.5
       parent: 2
   - uid: 13962
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 17.5,-47.5
       parent: 2
   - uid: 13974
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 9.5,-52.5
       parent: 2
   - uid: 13975
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 7.5,-53.5
       parent: 2
 - proto: WallWeaponCapacitorRecharger
@@ -87027,6 +85673,11 @@ entities:
     - type: Transform
       pos: -26.5,-7.5
       parent: 2
+  - uid: 5449
+    components:
+    - type: Transform
+      pos: -10.5,-23.5
+      parent: 2
   - uid: 8038
     components:
     - type: Transform
@@ -87079,15 +85730,15 @@ entities:
       parent: 2
 - proto: WaterTankHighCapacity
   entities:
-  - uid: 185
+  - uid: 6972
     components:
     - type: Transform
-      pos: -5.5,-18.5
+      pos: -6.5,-24.5
       parent: 2
-  - uid: 11752
+  - uid: 8672
     components:
     - type: Transform
-      pos: -15.5,-36.5
+      pos: -10.5,-19.5
       parent: 2
   - uid: 14523
     components:
@@ -87226,33 +85877,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-35.5
       parent: 2
-- proto: WindoorHydroponicsLocked
-  entities:
-  - uid: 339
-    components:
-    - type: Transform
-      pos: -8.5,-17.5
-      parent: 2
-  - uid: 340
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-22.5
-      parent: 2
-  - uid: 341
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-21.5
-      parent: 2
 - proto: WindoorKitchenLocked
   entities:
-  - uid: 338
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,-17.5
-      parent: 2
   - uid: 1143
     components:
     - type: Transform
@@ -87441,20 +86067,9 @@ entities:
     - type: Transform
       pos: -13.5,-2.5
       parent: 2
-  - uid: 226
-    components:
-    - type: Transform
-      pos: -2.5,-23.5
-      parent: 2
-  - uid: 314
-    components:
-    - type: Transform
-      pos: -2.5,-20.5
-      parent: 2
   - uid: 1078
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-42.5
       parent: 2
   - uid: 1187
@@ -87490,49 +86105,41 @@ entities:
   - uid: 2579
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -24.5,-2.5
       parent: 2
   - uid: 2847
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 4.5,-44.5
       parent: 2
   - uid: 2900
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -27.5,-2.5
       parent: 2
   - uid: 2901
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -26.5,-2.5
       parent: 2
   - uid: 2902
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -25.5,-2.5
       parent: 2
   - uid: 4290
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 8.5,5.5
       parent: 2
   - uid: 4291
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
       pos: 12.5,5.5
       parent: 2
   - uid: 4926
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-3.5
       parent: 2
   - uid: 5253
@@ -87548,13 +86155,11 @@ entities:
   - uid: 5475
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -47.5,2.5
       parent: 2
   - uid: 6540
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -52.5,26.5
       parent: 2
   - uid: 6747
@@ -87605,13 +86210,11 @@ entities:
   - uid: 9162
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -43.5,2.5
       parent: 2
   - uid: 11642
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 12.5,-6.5
       parent: 2
   - uid: 11645
@@ -87622,49 +86225,41 @@ entities:
   - uid: 11859
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -52.5,27.5
       parent: 2
   - uid: 12455
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -52.5,28.5
       parent: 2
   - uid: 12456
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -51.5,28.5
       parent: 2
   - uid: 12457
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -50.5,28.5
       parent: 2
   - uid: 12458
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -49.5,28.5
       parent: 2
   - uid: 12459
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -48.5,28.5
       parent: 2
   - uid: 12460
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -48.5,27.5
       parent: 2
   - uid: 12461
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: -48.5,26.5
       parent: 2
 - proto: WindowDirectional

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -59496,8 +59496,6 @@ entities:
       pos: -10.5,-16.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 812
     - type: AtmosPipeColor


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
removed the botany area from toast and divvied its space up between chef and a moved janitor closet
also i ran fixrotations and it hit like things which is why there are 2200 deletions. teehee

## Media
<img width="1814" height="1556" alt="chefbotany" src="https://github.com/user-attachments/assets/71165673-0462-471c-9f9e-997cee436733" />
