### PR TITLE
viewcone angle modifying

### DIFF
--- a/Content.Client/_ES/Viewcone/ComponentTree/ESViewconeOccludableTreeComponent.cs
+++ b/Content.Client/_ES/Viewcone/ComponentTree/ESViewconeOccludableTreeComponent.cs
@@ -1,4 +1,4 @@
-using Content.Shared._ES.Viewcone;
+using Content.Shared._ES.Viewcone.Components;
 using Robust.Shared.ComponentTrees;
 using Robust.Shared.Physics;
 

--- a/Content.Client/_ES/Viewcone/ComponentTree/ESViewconeOccludableTreeSystem.cs
+++ b/Content.Client/_ES/Viewcone/ComponentTree/ESViewconeOccludableTreeSystem.cs
@@ -1,5 +1,5 @@
 using System.Numerics;
-using Content.Shared._ES.Viewcone;
+using Content.Shared._ES.Viewcone.Components;
 using Robust.Client.GameObjects;
 using Robust.Shared.ComponentTrees;
 using Robust.Shared.Physics;

--- a/Content.Client/_ES/Viewcone/ESViewconeClientNoOccludeComponent.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeClientNoOccludeComponent.cs
@@ -1,4 +1,4 @@
-using Content.Shared._ES.Viewcone;
+using Content.Shared._ES.Viewcone.Components;
 
 namespace Content.Client._ES.Viewcone;
 

--- a/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
+++ b/Content.Client/_ES/Viewcone/ESViewconeOverlayManagementSystem.cs
@@ -1,6 +1,6 @@
 using Content.Client._ES.Viewcone.Overlays;
 using Content.Client.Eye;
-using Content.Shared._ES.Viewcone;
+using Content.Shared._ES.Viewcone.Components;
 using Content.Shared.MouseRotator;
 using Content.Shared.Movement.Pulling.Events;
 using Robust.Client.GameObjects;
@@ -8,7 +8,6 @@ using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
 using Robust.Shared.Map;
-using Robust.Shared.Physics;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
 

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeConeOverlay.cs
@@ -1,13 +1,9 @@
 using Content.Client.Eye;
 using Content.Shared._ES.Viewcone;
-using Content.Shared.MouseRotator;
+using Content.Shared._ES.Viewcone.Components;
 using Robust.Client.Graphics;
-using Robust.Client.Input;
-using Robust.Client.Player;
 using Robust.Shared.Enums;
-using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
 
 namespace Content.Client._ES.Viewcone.Overlays;
 
@@ -18,6 +14,7 @@ public sealed class ESViewconeConeOverlay : Overlay
 {
     [Dependency] private readonly IEntityManager _ent = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    private readonly ESViewconeAngleSystem _angle;
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
@@ -34,6 +31,9 @@ public sealed class ESViewconeConeOverlay : Overlay
     public ESViewconeConeOverlay()
     {
         IoCManager.InjectDependencies(this);
+
+        _angle = _ent.EntitySysManager.GetEntitySystem<ESViewconeAngleSystem>();
+
         _viewconeShader = _proto.Index(ShaderPrototype).InstanceUnique();
         ZIndex = -6;
     }
@@ -52,7 +52,10 @@ public sealed class ESViewconeConeOverlay : Overlay
             if (args.Viewport.Eye != eye.Eye)
                 continue;
 
-            _coneAngle = viewcone.ConeAngle;
+            // todo dont really like that this has to get the angle twice (once here and once in the alpha overlay)
+            // but its not really like its a huge inefficiency (this only has to happen twice per frame and its like a trivial event relay with no logic)
+            // and i really dont want to make it stateful
+            _coneAngle = _angle.GetModifiedViewconeAngle((uid, viewcone));
             _coneFeather = viewcone.ConeFeather;
             _coneIgnoreRadius = (viewcone.ConeIgnoreRadius - viewcone.ConeIgnoreFeather) * 50f;
             _coneIgnoreFeather = Math.Max(viewcone.ConeIgnoreFeather * 200f, 8f);

--- a/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
+++ b/Content.Client/_ES/Viewcone/Overlays/ESViewconeSetAlphaOverlay.cs
@@ -1,5 +1,7 @@
 using Content.Client._ES.Viewcone.ComponentTree;
+using Content.Client.Eye;
 using Content.Shared._ES.Viewcone;
+using Content.Shared._ES.Viewcone.Components;
 using Content.Shared.MouseRotator;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -19,6 +21,7 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
 {
     [Dependency] private readonly IEntityManager _ent = default!;
     private readonly ESViewconeOverlayManagementSystem _cone;
+    private readonly ESViewconeAngleSystem _angle;
     private readonly ESViewconeOccludableTreeSystem _tree;
     private readonly TransformSystem _xform;
     private readonly SpriteSystem _sprite;
@@ -33,6 +36,7 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
         IoCManager.InjectDependencies(this);
 
         _cone = _ent.EntitySysManager.GetEntitySystem<ESViewconeOverlayManagementSystem>();
+        _angle = _ent.EntitySysManager.GetEntitySystem<ESViewconeAngleSystem>();
         _tree = _ent.EntitySysManager.GetEntitySystem<ESViewconeOccludableTreeSystem>();
         _xform  = _ent.EntitySysManager.GetEntitySystem<TransformSystem>();
         _sprite = _ent.EntitySysManager.GetEntitySystem<SpriteSystem>();
@@ -46,9 +50,9 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
             return false;
 
         // This is really stupid but there isn't another way to reverse an eye entity from just an IEye afaict
-        // It's not really inefficient though. theres barely any of those fuckin things anyway (? verify that) (maybe this scales with players in view) (shit)
-        var enumerator = _ent.AllEntityQueryEnumerator<EyeComponent, ESViewconeComponent>();
-        while (enumerator.MoveNext(out var uid, out var eye, out var viewcone))
+        // It's not really inefficient though. theres only 1 of these anyway usually with the lerpingeye bound
+        var enumerator = _ent.AllEntityQueryEnumerator<LerpingEyeComponent, EyeComponent, ESViewconeComponent>();
+        while (enumerator.MoveNext(out var uid, out _, out var eye, out var viewcone))
         {
             if (args.Viewport.Eye != eye.Eye)
                 continue;
@@ -74,7 +78,7 @@ public sealed class ESViewconeSetAlphaOverlay : Overlay
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         // !! Thank You Bhijn God (TYBG) for 95% of the rest of this methods code !!
         // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-        var radConeAngle = MathHelper.DegreesToRadians(cone.ConeAngle);
+        var radConeAngle = MathHelper.DegreesToRadians(_angle.GetModifiedViewconeAngle((ent, cone)));
         var radConeFeather = MathHelper.DegreesToRadians(cone.ConeFeather);
 
         _cone.CachedBaseAlphas.Clear();

--- a/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
+++ b/Content.Server/Shuttles/Systems/ArrivalsSystem.cs
@@ -521,6 +521,9 @@ public sealed class ArrivalsSystem : EntitySystem
 
     private void SetupArrivalsStation()
     {
+        if (!_cfgManager.GetCVar(CCVars.ArrivalsPlanet))
+            return;
+
         var path = new ResPath(_cfgManager.GetCVar(CCVars.ArrivalsMap));
         _mapSystem.CreateMap(out var mapId, runMapInit: false);
         var mapUid = _mapSystem.GetMap(mapId);

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -1,3 +1,4 @@
+using Content.Shared._ES.Viewcone.Components;
 using Content.Shared.Armor;
 using Content.Shared.Atmos;
 using Content.Shared.Chat;
@@ -36,6 +37,10 @@ public partial class InventorySystem
 {
     public void InitializeRelay()
     {
+        // ES START events
+        SubscribeLocalEvent<InventoryComponent, ESViewconeGetAngleModifierEvent>(RefRelayInventoryEvent);
+        // ES END
+
         SubscribeLocalEvent<InventoryComponent, DamageModifyEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, ElectrocutionAttemptEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, SlipAttemptEvent>(RelayInventoryEvent);

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -70,7 +70,7 @@ public sealed partial class StatusEffectsSystem
         SubscribeLocalEvent<StatusEffectContainerComponent, Content.Shared.Verbs.GetVerbsEvent<Content.Shared.Verbs.AlternativeVerb>>(RelayStatusEffectEvent); // Offbrand
         // ES START
         SubscribeLocalEvent<StatusEffectContainerComponent, GetMeleeDamageEvent>(RefRelayStatusEffectEvent);
-        SubscribeLocalEvent<StatusEffectContainerComponent, ESViewconeGetAngleModifierEvent>(RefRelayStatusEffectEvent);
+        SubscribeLocalEvent<StatusEffectContainerComponent, ESViewconeGetAngleModifierEvent>(RelayStatusEffectEvent);
         // ES END
     }
 

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -1,3 +1,4 @@
+using Content.Shared._ES.Viewcone.Components;
 using Content.Shared.Body.Events;
 using Content.Shared.Damage.Events;
 using Content.Shared.Mobs.Events;
@@ -69,6 +70,7 @@ public sealed partial class StatusEffectsSystem
         SubscribeLocalEvent<StatusEffectContainerComponent, Content.Shared.Verbs.GetVerbsEvent<Content.Shared.Verbs.AlternativeVerb>>(RelayStatusEffectEvent); // Offbrand
         // ES START
         SubscribeLocalEvent<StatusEffectContainerComponent, GetMeleeDamageEvent>(RefRelayStatusEffectEvent);
+        SubscribeLocalEvent<StatusEffectContainerComponent, ESViewconeGetAngleModifierEvent>(RefRelayStatusEffectEvent);
         // ES END
     }
 

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeComponent.cs
@@ -1,7 +1,7 @@
 using System.Numerics;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared._ES.Viewcone;
+namespace Content.Shared._ES.Viewcone.Components;
 
 /// <summary>
 /// ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡠⠀⠀⠀⡀⢄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
@@ -32,8 +32,15 @@ namespace Content.Shared._ES.Viewcone;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ESViewconeComponent : Component
 {
+    /// <summary>
+    ///     Base cone angle, without any modifications (from equipment or otherwise).
+    /// </summary>
+    /// <remarks>
+    ///     You probably don't want to refer to this directly if you're using it for actual calculations.
+    ///     Instead, use <see cref="ESViewconeAngleSystem.GetModifiedViewconeAngle"/>
+    /// </remarks>
     [DataField, AutoNetworkedField]
-    public float ConeAngle = 225f;
+    public float BaseConeAngle = 225f;
 
     [DataField, AutoNetworkedField]
     public float ConeFeather = 3f;

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
@@ -1,0 +1,36 @@
+using Content.Shared.Inventory;
+
+namespace Content.Shared._ES.Viewcone.Components;
+
+/// <summary>
+///     Intended to be used on inventory items or status effects (i.e. this is relayed).
+///     Modifies the viewcone angle of the relevant entity additively.
+/// </summary>
+[RegisterComponent, AutoGenerateComponentState]
+public sealed partial class ESViewconeModifierComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public float AngleModifier = 0f;
+}
+
+/// <summary>
+///     Raised clientside by-ref and broadcast on an entity with a viewcone, and relayed to inventory & status effects.
+///     Modifies their viewcone angle additively.
+/// </summary>
+[ByRefEvent]
+public record struct ESViewconeGetAngleModifierEvent : IInventoryRelayEvent
+{
+    public SlotFlags TargetSlots => SlotFlags.HEAD | SlotFlags.EYES | SlotFlags.MASK;
+
+    private float _angleModifier;
+
+    public float GetAngleModifier()
+    {
+        return _angleModifier;
+    }
+
+    public void ModifyAngle(float angle)
+    {
+        _angleModifier += angle;
+    }
+}

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._ES.Viewcone.Components;
 
@@ -6,7 +7,7 @@ namespace Content.Shared._ES.Viewcone.Components;
 ///     Intended to be used on inventory items or status effects (i.e. this is relayed).
 ///     Modifies the viewcone angle of the relevant entity additively.
 /// </summary>
-[RegisterComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ESViewconeModifierComponent : Component
 {
     [DataField(required: true), AutoNetworkedField]

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeModifierComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class ESViewconeModifierComponent : Component
 ///     Modifies their viewcone angle additively.
 /// </summary>
 [ByRefEvent]
-public record struct ESViewconeGetAngleModifierEvent : IInventoryRelayEvent
+public record ESViewconeGetAngleModifierEvent : IInventoryRelayEvent
 {
     public SlotFlags TargetSlots => SlotFlags.HEAD | SlotFlags.EYES | SlotFlags.MASK;
 

--- a/Content.Shared/_ES/Viewcone/Components/ESViewconeOccludableComponent.cs
+++ b/Content.Shared/_ES/Viewcone/Components/ESViewconeOccludableComponent.cs
@@ -1,9 +1,8 @@
-using Content.Shared.Wall;
 using Robust.Shared.ComponentTrees;
 using Robust.Shared.GameStates;
 using Robust.Shared.Physics;
 
-namespace Content.Shared._ES.Viewcone;
+namespace Content.Shared._ES.Viewcone.Components;
 
 /// <summary>
 ///     Marks an entity as one which should fade away clientside if you have a viewcone and it's out of view

--- a/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._ES.Viewcone.Components;
+using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.StatusEffectNew;
 
@@ -13,9 +14,20 @@ public sealed class ESViewconeAngleSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<ESViewconeModifierComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ESViewconeModifierComponent, ESViewconeGetAngleModifierEvent>(OnAngleModify);
         SubscribeLocalEvent<ESViewconeModifierComponent, InventoryRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleInventoryModify);
         SubscribeLocalEvent<ESViewconeModifierComponent, StatusEffectRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleStatusEffectModify);
+    }
+
+    private void OnExamined(Entity<ESViewconeModifierComponent> ent, ref ExaminedEvent args)
+    {
+        var loc = "es-viewcone-modifier-examine-increase";
+        if (ent.Comp.AngleModifier < 0)
+            loc = "es-viewcone-modifier-examine-decrease";
+
+        var degrees = (int) MathF.Abs(ent.Comp.AngleModifier);
+        args.PushMarkup(Loc.GetString(loc, ("degrees", degrees)));
     }
 
     private void OnAngleModify(Entity<ESViewconeModifierComponent> ent, ref ESViewconeGetAngleModifierEvent args)

--- a/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
@@ -1,0 +1,52 @@
+using Content.Shared._ES.Viewcone.Components;
+using Content.Shared.Inventory;
+using Content.Shared.StatusEffectNew;
+
+namespace Content.Shared._ES.Viewcone;
+
+/// <summary>
+///     Public API for getting the actual modified viewcone angle (including equipment etc) rather than just the base angle
+/// </summary>
+public sealed class ESViewconeAngleSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESViewconeModifierComponent, ESViewconeGetAngleModifierEvent>(OnAngleModify);
+        SubscribeLocalEvent<ESViewconeModifierComponent, InventoryRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleInventoryModify);
+        SubscribeLocalEvent<ESViewconeModifierComponent, StatusEffectRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleStatusEffectModify);
+    }
+
+
+    private void OnAngleModify(Entity<ESViewconeModifierComponent> ent, ref ESViewconeGetAngleModifierEvent args)
+    {
+        args.ModifyAngle(ent.Comp.AngleModifier);
+    }
+
+    private void OnAngleInventoryModify(Entity<ESViewconeModifierComponent> ent, ref InventoryRelayedEvent<ESViewconeGetAngleModifierEvent> args)
+    {
+        args.Args.ModifyAngle(ent.Comp.AngleModifier);
+    }
+
+    private void OnAngleStatusEffectModify(Entity<ESViewconeModifierComponent> ent, ref StatusEffectRelayedEvent<ESViewconeGetAngleModifierEvent> args)
+    {
+        args.Args.ModifyAngle(ent.Comp.AngleModifier);
+    }
+
+    /// <summary>
+    ///     Returns the modified viewcone angle for an entity, calculated from the base, taking into account
+    ///     equipment & status effects & whatnot
+    /// </summary>
+    public float GetModifiedViewconeAngle(Entity<ESViewconeComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return 0f;
+
+        var ev = new ESViewconeGetAngleModifierEvent();
+        RaiseLocalEvent(ent, ref ev, true);
+
+        // clamps to 0, 360 since this is additive and could easily go over with stacking equipment items and shit
+        return Math.Clamp(ent.Comp.BaseConeAngle + ev.GetAngleModifier(), 0f, 360f);
+    }
+}

--- a/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeAngleSystem.cs
@@ -18,7 +18,6 @@ public sealed class ESViewconeAngleSystem : EntitySystem
         SubscribeLocalEvent<ESViewconeModifierComponent, StatusEffectRelayedEvent<ESViewconeGetAngleModifierEvent>>(OnAngleStatusEffectModify);
     }
 
-
     private void OnAngleModify(Entity<ESViewconeModifierComponent> ent, ref ESViewconeGetAngleModifierEvent args)
     {
         args.ModifyAngle(ent.Comp.AngleModifier);

--- a/Content.Shared/_ES/Viewcone/ESViewconeEffectSystem.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeEffectSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._ES.Viewcone.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
@@ -30,7 +31,7 @@ public sealed class ESViewconeEffectSystem : EntitySystem
             return;
 
         var ent = SpawnNextToOrDrop(effect, source);
-        var viewconeEffect = EnsureComp<Components.ESViewconeOccludableComponent>(ent);
+        var viewconeEffect = EnsureComp<ESViewconeOccludableComponent>(ent);
         viewconeEffect.Inverted = true;
         viewconeEffect.Source = source;
         Dirty(ent, viewconeEffect);

--- a/Content.Shared/_ES/Viewcone/ESViewconeEffectSystem.cs
+++ b/Content.Shared/_ES/Viewcone/ESViewconeEffectSystem.cs
@@ -30,7 +30,7 @@ public sealed class ESViewconeEffectSystem : EntitySystem
             return;
 
         var ent = SpawnNextToOrDrop(effect, source);
-        var viewconeEffect = EnsureComp<ESViewconeOccludableComponent>(ent);
+        var viewconeEffect = EnsureComp<Components.ESViewconeOccludableComponent>(ent);
         viewconeEffect.Inverted = true;
         viewconeEffect.Source = source;
         Dirty(ent, viewconeEffect);

--- a/Resources/Locale/en-US/_ES/viewcone/modifier-examine.ftl
+++ b/Resources/Locale/en-US/_ES/viewcone/modifier-examine.ftl
@@ -1,0 +1,2 @@
+es-viewcone-modifier-examine-increase = Wearing this will increase your field of vision's angle by [color=green]{$degrees}[/color] degrees.
+es-viewcone-modifier-examine-decrease = Wearing this will decrease your field of vision's angle by [color=crimson]{$degrees}[/color] degrees.

--- a/Resources/Prototypes/_ES/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Head/helmets.yml
@@ -10,7 +10,7 @@
         Piercing: 1
 
 - type: entity
-  parent: [ESBaseHeadArmor, ClothingHeadBase]
+  parent: [ESBaseHeadArmor, BaseClothingViewconeMedium, ClothingHeadBase]
   id: ESClothingHeadHelmetSecurity
   name: helmet
   description: Standard security gear. Protects the head from impacts.

--- a/Resources/Prototypes/_ES/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Head/helmets.yml
@@ -10,7 +10,7 @@
         Piercing: 1
 
 - type: entity
-  parent: [ESBaseHeadArmor, BaseClothingViewconeMedium, ClothingHeadBase]
+  parent: [ClothingHeadBase, ESBaseHeadArmor, BaseClothingViewconeMedium]
   id: ESClothingHeadHelmetSecurity
   name: helmet
   description: Standard security gear. Protects the head from impacts.

--- a/Resources/Prototypes/_ES/Entities/Clothing/Head/protective_helmets.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Head/protective_helmets.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingHeadLightBase
+  parent: [ClothingHeadLightBase, BaseClothingViewconeMedium]
   id: ESClothingHeadHelmetFire
   name: fire helmet
   suffix: ES
@@ -33,7 +33,7 @@
   - type: ESChameleonClothingWhitelist
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseClothingViewconeMedium]
   id: ESClothingHeadHatHoodRadiation
   name: radiation hood
   suffix: ES
@@ -59,7 +59,7 @@
   - type: ESChameleonClothingWhitelist
 
 - type: entity
-  parent: ClothingHeadBase
+  parent: [ClothingHeadBase, BaseClothingViewconeMedium]
   id: ESClothingHeadHatHoodBio
   name: bio hood
   suffix: ES

--- a/Resources/Prototypes/_ES/Entities/Clothing/Head/space-helmets.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/Head/space-helmets.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingHeadEVAHelmetBase # TODO: new base
+  parent: [ClothingHeadEVAHelmetBase, BaseClothingViewconeMedium]  # TODO: new base
   id: ESClothingHeadHelmetSpace
   name: EVA helmet
   description: A classic helmet design with a wide glass dome for optimal viewing angles. Suspicious and rotund.

--- a/Resources/Prototypes/_ES/Entities/Clothing/base_viewcone.yml
+++ b/Resources/Prototypes/_ES/Entities/Clothing/base_viewcone.yml
@@ -1,0 +1,30 @@
+# Generic bases for clothing (head, eyes, mask) that should modify viewcone angle.
+- type: entity
+  id: BaseClothingViewconeSmall
+  abstract: true
+  components:
+  - type: ESViewconeModifier
+    angleModifier: -30
+
+- type: entity
+  id: BaseClothingViewconeMedium
+  abstract: true
+  components:
+  - type: ESViewconeModifier
+    angleModifier: -60
+
+- type: entity
+  id: BaseClothingViewconeLarge
+  abstract: true
+  components:
+  - type: ESViewconeModifier
+    angleModifier: -90
+
+- type: entity
+  id: BaseClothingViewconeBlinding
+  abstract: true
+  components:
+  - type: ESViewconeModifier
+    angleModifier: -360
+
+

--- a/Resources/Prototypes/_Offbrand/status_effects.yml
+++ b/Resources/Prototypes/_Offbrand/status_effects.yml
@@ -330,7 +330,7 @@
   - type: BlockMovementWhenPulledStatusEffect
   - type: DisruptOnAttackStatusEffect
   - type: ESViewconeModifier
-    angleModifier: -120
+    angleModifier: -180
 
 - type: entity
   parent: MobStatusEffectBase

--- a/Resources/Prototypes/_Offbrand/status_effects.yml
+++ b/Resources/Prototypes/_Offbrand/status_effects.yml
@@ -251,6 +251,8 @@
   components:
   - type: PopupOnAppliedStatusEffect
     message: minor-pain-applied
+  - type: ESViewconeModifier
+    angleModifier: -30
 
 - type: entity
   parent: MobStatusEffectBase
@@ -277,6 +279,8 @@
     updateInterval: 5
     effects:
     - [StatusEffectPainStuttering, 5]
+  - type: ESViewconeModifier
+    angleModifier: -60
 
 - type: entity
   parent: MobStatusEffectBase
@@ -294,6 +298,8 @@
     attackRateConstant: -0.05
   - type: GunAccuracyStatusEffect
     angleRangeModifier: 6
+  - type: ESViewconeModifier
+    angleModifier: -90
 
 - type: entity
   parent: MobStatusEffectBase
@@ -323,6 +329,8 @@
   - type: SilencedStatusEffect
   - type: BlockMovementWhenPulledStatusEffect
   - type: DisruptOnAttackStatusEffect
+  - type: ESViewconeModifier
+    angleModifier: -120
 
 - type: entity
   parent: MobStatusEffectBase


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

i decided raising the event twice (its literally just on client) when the cone renders is better than doing it statefully and having to deal with all that bullshit

no other changes bseides pain status effects + helmet rn we will see how it goes then later

the arrivals station thing is cuz i noticed it was still trying to fucking spawn the arrivals planet map even with the cvar turned off in release. we just need to rip out all the old arrivals code later

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

blackout pain (lower pain levels are smaller changes)

<img width="712" height="686" alt="image" src="https://github.com/user-attachments/assets/db2b8c86-31f8-451b-98a1-9b0b8b76681f" />


helmet

<img width="778" height="721" alt="image" src="https://github.com/user-attachments/assets/aae24262-fa97-4eb5-94b6-952f5f186c31" />
