### PR TITLE
Fix parasite win being too long

### DIFF
--- a/Content.Server/_ES/Troupes/Parasite/Components/ESParasiteRuleComponent.cs
+++ b/Content.Server/_ES/Troupes/Parasite/Components/ESParasiteRuleComponent.cs
@@ -11,6 +11,9 @@ public sealed partial class ESParasiteRuleComponent : Component
     [DataField]
     public bool ObjectivesCompleted;
 
+    [DataField]
+    public bool SwarmStarted;
+
     /// <summary>
     /// Whether the "finale" has been triggered via all the objectives being completed and the timer passing.
     /// After this point,
@@ -22,7 +25,7 @@ public sealed partial class ESParasiteRuleComponent : Component
     public TimeSpan SwarmDelay = TimeSpan.FromMinutes(1);
 
     [DataField]
-    public TimeSpan WinDelay = TimeSpan.FromMinutes(6);
+    public TimeSpan WinDelay = TimeSpan.FromMinutes(2.5);
 
     [DataField]
     public SoundSpecifier BurstSound = new SoundCollectionSpecifier("desecration");

--- a/Content.Server/_ES/Troupes/Parasite/ESParasiteRuleSystem.cs
+++ b/Content.Server/_ES/Troupes/Parasite/ESParasiteRuleSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.RoundEnd;
 using Content.Server.Station.Systems;
 using Content.Shared._ES.Core.Timer;
 using Content.Shared._ES.Core.Timer.Components;
+using Content.Shared._ES.Masks;
 using Content.Shared._ES.Objectives.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Systems;
@@ -18,6 +19,7 @@ using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Server.Audio;
 using Robust.Server.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server._ES.Troupes.Parasite;
 
@@ -70,6 +72,7 @@ public sealed class ESParasiteRuleSystem : EntitySystem
 
     private void OnSwarmTimer(Entity<ESParasiteRuleComponent> ent, ref ESParasiteSwarmTimerEvent args)
     {
+        ent.Comp.SwarmStarted = true;
         TransformTroupeMembers(ent);
     }
 
@@ -83,6 +86,9 @@ public sealed class ESParasiteRuleSystem : EntitySystem
         foreach (var hit in args.HitEntities)
         {
             if (!_mind.TryGetMind(hit, out var mind))
+                continue;
+
+            if (_mind.IsCharacterDeadIc(mind))
                 continue;
 
             if (_mask.GetTroupeOrNull(mind.Value.AsNullable()) == ent.Comp.IgnoreTroupe)
@@ -112,7 +118,7 @@ public sealed class ESParasiteRuleSystem : EntitySystem
         }
 
         _entityTimer.SpawnTimer(ent, ent.Comp.SwarmDelay, new ESParasiteSwarmTimerEvent());
-        _entityTimer.SpawnTimer(ent, ent.Comp.WinDelay, new ESParasiteWinCheckTimerEvent());
+        _entityTimer.SpawnTimer(ent, ent.Comp.SwarmDelay + ent.Comp.WinDelay, new ESParasiteWinCheckTimerEvent());
     }
 
     private void TransformTroupeMembers(Entity<ESParasiteRuleComponent> ent)
@@ -131,6 +137,21 @@ public sealed class ESParasiteRuleSystem : EntitySystem
         }
     }
 
+    private bool AllPlayersConverted(EntityUid troupe)
+    {
+        var nonTroupeCount = 0;
+        foreach (var mind in _mask.GetNotTroupeMembers(troupe))
+        {
+            if (!TryComp<MindComponent>(mind, out var mindComp))
+                continue;
+
+            if (!_mind.IsCharacterDeadIc(mindComp))
+                ++nonTroupeCount;
+        }
+
+        return nonTroupeCount == 0;
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -138,6 +159,15 @@ public sealed class ESParasiteRuleSystem : EntitySystem
         var query = EntityQueryEnumerator<ESParasiteRuleComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {
+            if (!comp.SwarmStarted)
+                continue;
+
+            if (AllPlayersConverted(uid))
+            {
+                _roundEnd.EndRound(TimeSpan.FromMinutes(1));
+                continue;
+            }
+
             if (!comp.WinStarted)
                 continue;
 

--- a/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
+++ b/Content.Shared/_ES/Masks/ESSharedMaskSystem.cs
@@ -330,9 +330,18 @@ public abstract class ESSharedMaskSystem : EntitySystem
         }
     }
 
+    /// <inheritdoc cref="GetNotTroupeMembers(ProtoId{ESTroupePrototype})"/>
+    public IEnumerable<EntityUid> GetNotTroupeMembers(Entity<ESTroupeRuleComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return [];
+
+        return GetNotTroupeMembers(ent.Comp.Troupe);
+    }
+
     /// <summary>
     /// Returns all minds who are members of a troupe that is NOT the specified troupe.
-    /// Set difference between all player minds and <see cref="GetTroupeMembers"/>
+    /// Set difference between all player minds and <see cref="GetTroupeMembers(ProtoId{ESTroupePrototype})"/>
     /// </summary>
     public IEnumerable<EntityUid> GetNotTroupeMembers(ProtoId<ESTroupePrototype> troupe)
     {


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1565 

Changes:
- Swarm max length on parasite finale is now 2.5 minutes instead of 5 minutes
- Round now instantly ends if swarm has started and parasites have 100% of crew 
  - I actually wanted to have this but i lazily left it out thinking "well when are they ever gonna get _everyone_?" Happened the first round. Apparently it's not that hard when people aren't dicking off in space constantly.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
