### PR TITLE
Move subverter into normal traitor pool

### DIFF
--- a/Content.Shared/_ES/Masks/Traitor/Components/ESAddMaskOnUseComponent.cs
+++ b/Content.Shared/_ES/Masks/Traitor/Components/ESAddMaskOnUseComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class ESAddMaskOnUseComponent : Component
     /// Whether the target must be in crit to be converted
     /// </summary>
     [DataField]
-    public bool RequireCrit = true;
+    public bool RequireIncapacitated = true;
 
     /// <summary>
     /// Whether having a mindshield will prevent conversion
@@ -53,7 +53,7 @@ public sealed partial class ESAddMaskOnUseComponent : Component
     public LocId UsedExamineMessage = "es-subverter-chip-examined-used";
 
     [DataField]
-    public LocId NotCritMessage = "es-subverter-chip-not-crit";
+    public LocId NotIncapacitatedMessage = "es-subverter-chip-not-crit";
 
     [DataField]
     public LocId MindshieldedMessage = "es-subverter-chip-mindshielded";

--- a/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
@@ -1,14 +1,13 @@
 ﻿using Content.Shared._ES.Masks.Traitor.Components;
 using Content.Shared._ES.Masks.Traitor.Events;
 using Content.Shared._Offbrand.Wounds;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Systems;
-using Content.Shared.Damage.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Mind;
 using Content.Shared.Mindshield.Components;
-using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Prototypes;
 
@@ -16,6 +15,7 @@ namespace Content.Shared._ES.Masks.Traitor;
 
 public sealed class ESAddMaskOnUseSystem : EntitySystem
 {
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly ESSharedMaskSystem _mask = default!;
     [Dependency] private readonly SharedDoAfterSystem _doafter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -48,9 +48,11 @@ public sealed class ESAddMaskOnUseSystem : EntitySystem
             return;
         }
 
-        if (ent.Comp.RequireCrit && !_health.IsCritical((EntityUid)args.Target))
+        if (ent.Comp.RequireIncapacitated &&
+            !_health.IsCritical(args.Target.Value) &&
+            _actionBlocker.CanInteract(args.Target.Value, null))
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.NotCritMessage), args.User, args.User);
+            _popup.PopupClient(Loc.GetString(ent.Comp.NotIncapacitatedMessage), args.User, args.User);
             return;
         }
 
@@ -80,7 +82,7 @@ public sealed class ESAddMaskOnUseSystem : EntitySystem
         if (args.Cancelled || args.Handled || args.Target is not { } target)
             return;
 
-        if (_health.IsCritical(target) && ent.Comp.RequireCrit)
+        if (ent.Comp.RequireIncapacitated)
         {
             // TODO ES with offmed this should really be doing something more interesting honestly
             _rejuv.PerformRejuvenate(target);

--- a/Resources/Locale/en-US/_ES/masks/traitor/subverter.ftl
+++ b/Resources/Locale/en-US/_ES/masks/traitor/subverter.ftl
@@ -2,5 +2,5 @@
 es-subverter-chip-implanting = Implanting subversion chip!
 es-subverter-chip-examined-usable = [color=green]This chip has not been used.[/color]
 es-subverter-chip-examined-used = [color=red]This chip has been used![/color]
-es-subverter-chip-not-crit = Target not crit!
+es-subverter-chip-not-crit = Target aware!
 es-subverter-chip-mindshielded = Target mindshielded!

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -86,9 +86,11 @@
   table:
     all:
     - id: ESSubverterChip
-      amount: 2
+    - id: ESSleepyPen
     - id: ESWeaponPistol9mm
+      amount: 2
     - id: ESMagazine9mm
+      amount: 2
 
 # Demolitionist
 - type: entity

--- a/Resources/Prototypes/_ES/MaskSets/powertraitors.yml
+++ b/Resources/Prototypes/_ES/MaskSets/powertraitors.yml
@@ -1,5 +1,5 @@
 - type: esMaskSet
   id: PowerTraitors # Higher power tots.
   masks:
-    ESSubverter: 1
-    ESDemolitionist: 0.6
+    ESSubverter: 0.5
+    ESDemolitionist: 1

--- a/Resources/Prototypes/_ES/MaskSets/traitors.yml
+++ b/Resources/Prototypes/_ES/MaskSets/traitors.yml
@@ -4,3 +4,4 @@
     ESMarauder: 1.5
     ESAssassin: 1
     ESInfiltrator: 1
+    ESSubverter: 0.5

--- a/Resources/Prototypes/_ES/Masquerades/sycophancy.yml
+++ b/Resources/Prototypes/_ES/Masquerades/sycophancy.yml
@@ -16,9 +16,9 @@
       16: [ "#Firmsafes" ] # 1 generic crew, 3 traitors, 2 parasite.
       17: [ "#Filler" ]
       18: [ "ESArmsDealer" ]
-      19: [ "ESMarauder" ] # 1 generic crew, 4 traitors, 2 parasite.
+      19: [ "#Traitors" ] # 1 generic crew, 4 traitors, 2 parasite.
       20: [ "#Filler" ]
-      21: [ "#Filler", "-ESMarauder", "#PowerTraitors" ] # 1 generic crew, 4 traitors, 2 parasites.
+      21: [ "#Filler", "-#Traitors", "#PowerTraitors" ] # 1 generic crew, 4 traitors, 2 parasites.
       22: [ "#Filler" ]
       24: [ "#TraitorGunners" ] # 2 generic crew, 4 traitors, 2 parasites.
       25: [ "ESMarauder" ] # 2 generic crew, 5 traitors, 2 parasites.

--- a/Resources/Prototypes/_ES/Masquerades/traitors.yml
+++ b/Resources/Prototypes/_ES/Masquerades/traitors.yml
@@ -20,9 +20,9 @@
       16: ["#Firmsafes"] # 1 generic crew, 3 traitors.
       17: ["#Filler"]
       18: ["ESArmsDealer"]
-      19: ["ESMarauder"] # 1 generic crew, 4 traitors.
+      19: ["#Traitors"] # 1 generic crew, 4 traitors.
       20: ["#Filler"]
-      21: ["#Filler", "-ESMarauder", "#PowerTraitors"] # 1 generic crew, 4 traitors.
+      21: ["#Filler", "-#Traitors", "#PowerTraitors"] # 1 generic crew, 4 traitors.
       22: ["#Filler"]
       24: ["#TraitorGunners"] # 2 generic crew, 4 traitors.
       25: ["ESMarauder"] # 2 generic crew, 5 traitors.


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1267 
Closes #1657 

Changes:
- Subversion chips now work when a player is sleeping, stunned, or otherwise unable to interact. They also still work in crit
- Subverter is now in the normal traitor pool at half weight
- Decreased chance in power traitor pool
- Reblanaced some traitor masquerades to give them a chance to show up.

eventually i might want to sunset the idea of 'power traitors' in general and just have them be more evenly balanced weird guys that show up in higher pop ranges sometimes. For now this is fine.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
