### PR TITLE
Small plasma can

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -395,7 +395,7 @@
       gasMixture:
         volume: 1500
         moles:
-          Plasma: 750
+          Plasma: 900
         temperature: 293.15
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -393,7 +393,7 @@
         - state: orange
     - type: GasCanister
       gasMixture:
-        volume: 1500
+        volume: 500
         moles:
           Plasma: 900
         temperature: 293.15

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -395,7 +395,7 @@
       gasMixture:
         volume: 1500
         moles:
-          Plasma: 500
+          Plasma: 750
         temperature: 293.15
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -395,7 +395,7 @@
       gasMixture:
         volume: 1500
         moles:
-          Plasma: 2769.36 # plasma
+          Plasma: 500
         temperature: 293.15
     - type: Destructible
       thresholds:


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
I tested it a bunch and this (about 1/3) hits the sweet spot of 1 swap in a shift to cover the AME while being an amount less. If less plasma in the can is desired then I can tweak the consumption values on the antimatter
Small problem is the can starts off in the yellow light thing but Idk seems like a marginal amount of effort to fix
