### PR TITLE
Add guidebooks for crew masks

### DIFF
--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -3,7 +3,7 @@ es-mask-arms-dealer-name = Arms Dealer
 es-mask-arms-dealer-desc = As an Arms Dealer, help people out--by passing out guns to whoever you think might be able to use it responsibly.
 
 es-mask-avenger-name = Avenger
-es-mask-avenger-desc = As an avenger, protect your target from being killed at all costs. If that fails, kill their murderer.
+es-mask-avenger-desc = As an Avenger, protect your target from being killed at all costs. If that fails, kill their murderer.
 
 es-mask-crewmember-name = Crewmember
 es-mask-crewmember-desc = As a Crewmember, use your unclouded judgment to help make sure the crew completes their objective and gets out safely.
@@ -12,10 +12,7 @@ es-mask-guzzler-name = Guzzler
 es-mask-guzzler-desc = As a Guzzler, you have nothing but an endless desire to Consume Liquid. Guzzle everything you can get your hands on.
 
 es-mask-hater-name = Hater
-es-mask-hater-desc = As a hater, do everything in your power to make your target fail their objectives.
-
-es-mask-insider-name = Insider
-es-mask-insider-desc = As an insider, investigate the people on station and try to find out their alleigances using your special dossier.
+es-mask-hater-desc = As a Hater, do everything in your power to make your target fail their objectives.
 
 es-mask-mercenary-name = Mercenary
 es-mask-mercenary-desc = As a Mercenary, help the station by using your sidearm to dispatch anybody who isn't aligned with the crew.
@@ -27,7 +24,7 @@ es-mask-phantom-name = Phantom
 es-mask-phantom-desc = As a Phantom, reincarnate as a vengeful spirit on death and haunt your murderer until they also die.
 
 es-mask-secretary-name = Secretary
-es-mask-secretary-desc = As a secretary, do whatever you can to help your target complete their objectives.
+es-mask-secretary-desc = As a Secretary, do whatever you can to help your target complete their objectives.
 
 es-mask-rebel-name = Rebel
 es-mask-rebel-desc = As a Rebel, sabotage machines around the station in fervent protest. Try not to get pinned as a Traitor.
@@ -63,20 +60,20 @@ es-mask-demolitionist-desc = As a Demolitionist, you have been trained by the Sy
 es-mask-troupe-parasite-examine = They're a fellow host of the [bold][color=tan]parasitic infection[/color][/bold]. Conspire with them to spread the infection.
 
 es-mask-burstworm-name = Burstworm
-es-mask-burstworm-desc = As a burstworm, explode in a burst of devilish parasitic worms when you are killed, infecting anyone they bite.
+es-mask-burstworm-desc = As a Burstworm, explode in a burst of devilish parasitic worms when you are killed, infecting anyone they bite.
 
 es-mask-hemophage-name = Hemophage
-es-mask-hemophage-desc = As a hemophage, spread your infected blood all across the station. When you are killed, anyone in contact with it will be swarmed with parasites.
+es-mask-hemophage-desc = As a Hemophage, spread your infected blood all across the station. When you are killed, anyone in contact with it will be swarmed with parasites.
 
 es-mask-host-name = Host
-es-mask-host-desc = As a host, partake in the festivites and swarm with your fellow parasites!
+es-mask-host-desc = As a Host, partake in the festivites and swarm with your fellow parasites!
 
 es-mask-psychid-name = Psychid
-es-mask-psychid-desc = As a psychid, be killed in order to swap bodies and create a new psychid, spreading the parasitic infection even more.
+es-mask-psychid-desc = As a Psychid, be killed in order to swap bodies and create a new psychid, spreading the parasitic infection even more.
 
 # Oddballs
 es-mask-sleeper-agent-name = Sleeper Agent
-es-mask-sleeper-agent-desc = As a covert operative, you're a member of crew and win with them, unless the entire traitors team dies, upon which you switch sides and gain a new mask.
+es-mask-sleeper-agent-desc = As a Sleeper Agent, you're a member of crew and win with them, unless the entire traitors team dies, upon which you switch sides and gain a new mask.
 
 # Meta
 es-objective-issuer-mask = Mask

--- a/Resources/Prototypes/_ES/Guidebook/TroupesAndMasks/crew.yml
+++ b/Resources/Prototypes/_ES/Guidebook/TroupesAndMasks/crew.yml
@@ -2,4 +2,83 @@
   id: Crew
   hidden: false
   name: Crew
+  children:
+  - ArmsDealer
+  - Avenger
+  - Crewmember
+  - Guzzler
+  - Hater
+  - Mercenary
+  - Nobleman
+  - Phantom
+  - Rebel
+  - Secretary
+  - SleeperAgent
+  - Vigilante
+  - VIP
   text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew.xml"
+
+- type: guideEntry
+  id: ArmsDealer
+  name: Arms Dealer
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/ArmsDealer.xml"
+
+- type: guideEntry
+  id: Avenger
+  name: Avenger
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Avenger.xml"
+
+- type: guideEntry
+  id: Crewmember
+  name: Crewmember
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Crewmember.xml"
+
+- type: guideEntry
+  id: Guzzler
+  name: Guzzler
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Guzzler.xml"
+
+- type: guideEntry
+  id: Hater
+  name: Hater
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Hater.xml"
+
+- type: guideEntry
+  id: Mercenary
+  name: Mercenary
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Mercenary.xml"
+
+- type: guideEntry
+  id: Nobleman
+  name: Nobleman
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Nobleman.xml"
+
+- type: guideEntry
+  id: Phantom
+  name: Phantom
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Phantom.xml"
+
+- type: guideEntry
+  id: Rebel
+  name: Rebel
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Rebel.xml"
+
+- type: guideEntry
+  id: Secretary
+  name: Secretary
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Secretary.xml"
+
+- type: guideEntry
+  id: SleeperAgent
+  name: Sleeper Agent
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/SleeperAgent.xml"
+
+- type: guideEntry
+  id: Vigilante
+  name: Vigilante
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Vigilante.xml"
+
+- type: guideEntry
+  id: VIP
+  name: VIP
+  text: "/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/VIP.xml"

--- a/Resources/Prototypes/_ES/Masks/crew.yml
+++ b/Resources/Prototypes/_ES/Masks/crew.yml
@@ -49,7 +49,7 @@
   name: es-mask-hater-name
   troupe: ESCrew
   description: es-mask-hater-desc
-  color: lightseagreen
+  color: peru
   assignmentOrder: 11 # Needs to be assigned after other masks
   objectives:
     all:
@@ -86,7 +86,7 @@
   name: es-mask-phantom-name
   troupe: ESCrew
   description: es-mask-phantom-desc
-  color: lavender
+  color: plum
   weight: 0.5
   mindComponents:
   - type: ESReincarnateMind

--- a/Resources/Prototypes/_ES/Objectives/Crew/arms_dealer.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/arms_dealer.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveHoldSummonedGuns
+  name: Hand out guns
   description: Use your ability to summon firearms and make sure crew members hold onto them until the end of the shift.
   components:
   - type: ESObjective

--- a/Resources/Prototypes/_ES/Objectives/Crew/avenger.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/avenger.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveAvengerProtectRandom
-  name: Protect...
+  name: Protect your target
   description: You must protect them with your life and shield them from harm.
   components:
   - type: ESObjective

--- a/Resources/Prototypes/_ES/Objectives/Crew/guzzler.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/guzzler.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveGuzzle
-  name: Guzzle
+  name: Guzzle a certain amount of fluids
   description: Consume as much liquid as you can, from anywhere you can get it!
   components:
   - type: ESObjective
@@ -18,7 +18,7 @@
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveGuzzleSpecialInterest
-  name: Guzzle Special Interest
+  name: Guzzle your special interest
   description: Consume as much of your Special Interest as you can!
   components:
   - type: ESObjective
@@ -53,7 +53,7 @@
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveGuzzleUniqueReagents
-  name: Guzzle
+  name: Guzzle unique flavors
   description: Consume as many unique liquids as you can, from anywhere you can get them!
   components:
   - type: ESObjective

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/ArmsDealer.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/ArmsDealer.xml
@@ -1,0 +1,25 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESArmsDealer"/>
+
+    The Arms Dealer is a crew mask who wants to distribute guns to anyone they can.
+    Although they don't want to cause too much chaos, all they care about is that someone is holding onto one of their guns, and it isn't rotting away inside an evidence locker
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveHoldSummonedGuns"/>
+    </Box>
+
+    The guns themselves can be access through a variety of caches hidden throughout the station.
+    These contain a few random guns, which the Arms Dealer then has to distribute.
+
+    <Box>
+      <GuideEntityEmbed Entity="ESWeaponPistol9mm"/>
+      <GuideEntityEmbed Entity="ESWeaponPistol9mmSilenced" Caption="silenced 9mm handgun"/>
+    </Box>
+
+    <Box>
+      <GuideEntityEmbed Entity="ESWeaponRevolver357"/>
+      <GuideEntityEmbed Entity="ESWeaponDoubleBarrelShotgun"/>
+    </Box>
+
+    <ESGuideTipsEmbed Mask="ESArmsDealer"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Avenger.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Avenger.xml
@@ -1,0 +1,21 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESAvenger"/>
+
+    Avengers are a mask tasked with protecting a random person on the station from dying.
+    They do not have any unique tools to do so, and must rely only on what they can find in their environment.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveAvengerProtectRandom"/>
+    </Box>
+
+    In the event that the Avenger's target is killed by another player, the protect objective will be replaced with a new objective: to get revenge.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveAvengerKill"/>
+    </Box>
+
+    Although this objective doesn't specify who must be killed, the Avenger will gain a new action, allowing them to check their surroundings for their target.
+    Using this, they can slowly narrow in on their target before securing the kill.
+
+    <ESGuideTipsEmbed Mask="ESAvenger"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Crewmember.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Crewmember.xml
@@ -1,0 +1,9 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESCrewmember"/>
+
+    The Crewmember is the default member of the crew troupe and has no special abilities.
+
+    In most masquerades, if someone joins into the round late, they'll always spawn as the Crewmember.
+
+    <ESGuideTipsEmbed Mask="ESCrewmember"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Guzzler.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Guzzler.xml
@@ -1,0 +1,16 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESGuzzler"/>
+
+    The Guzzler is a weird freak who runs around the station drinking weird crusty maint juice.
+    They never contribute anything and are generally a burden on everyone around them.
+
+    <ESGuideObjectiveEmbed Objective="ESObjectiveGuzzle"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectiveGuzzleUniqueReagents"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectiveGuzzleSpecialInterest"/>
+
+    They should frankly just drink a bit of this and be done with it all.
+
+    <GuideReagentEmbed Reagent="Toxin"/>
+
+    <ESGuideTipsEmbed Mask="ESGuzzler"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Hater.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Hater.xml
@@ -1,0 +1,22 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESHater"/>
+
+    Haters function as the evil version of the [textlink="Secretary" link="Secretary"], being assigned to a random person to ensure that they do not complete all of their objectives.
+    Like the Secretary, they only target masks which have personal objectives.
+
+    <Box>
+        <ESGuideObjectiveEmbed Objective="ESObjectiveHaterHate"/>
+    </Box>
+
+    The Hater wins if their target does not complete all of their objectives.
+    Even if it's a partial success or they complete a few objectives, the Hater will still count it as a win.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveHaterDontKill"/>
+    </Box>
+
+    Additionally, the Hater is prohibited from killing their target (that would be illegal) and doing so voids the success of their other objective.
+    Even if their target has an objective to be killed, the Hater cannot be the one to do so.
+
+  <ESGuideTipsEmbed Mask="ESHater"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Mercenary.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Mercenary.xml
@@ -1,0 +1,20 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESMercenary"/>
+
+    The Mercenary is a member of the crew who's dead-set on hunting down all masks who are members of other troupes.
+    Unlike the moral [textlink="Vigilante" link="Vigilante"], the Mercenary doesn't care about the actions of who they kill, just who they belong to.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveKillNonCrew"/>
+    </Box>
+
+    <Box>
+      <GuideEntityEmbed Entity="ESWeaponRevolver357"/>
+      <GuideEntityEmbed Entity="ESWeaponPistol9mm"/>
+    </Box>
+
+    To help with this, the Mercenary receives a sidearm inside a cache.
+    Make sure to take your engagement carefully though, since killing someone who isn't a bad guy may lead the crew into thinking you're a traitor.
+
+    <ESGuideTipsEmbed Mask="ESMercenary"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Nobleman.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Nobleman.xml
@@ -1,0 +1,13 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESNobleman"/>
+
+    The Nobleman is a member of the crew who is blood-bound not to take the life of another.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveNoblemanDontKill"/>
+    </Box>
+
+    If they are the primary killer of someone, the Nobleman will be forced to kill themselves out of pure dishonor for their nobility.
+
+    <ESGuideTipsEmbed Mask="ESNobleman"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Phantom.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Phantom.xml
@@ -1,0 +1,26 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESPhantom"/>
+
+    Phantoms are members of the crew who want to reincarnate and haunt their target until they die.
+    Much like [textlink="parasites" link="Parasites"], they do this by being killed.
+
+    <ESGuideObjectiveEmbed Objective="ESObjectivePhantomDie"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectivePhantomAvenge"/>
+
+    Once the Phantom dies, they will come back again as a [color=red]vengeful phantom[/color].
+
+    <Box>
+      <GuideEntityEmbed Entity="ESMobPhantom"/>
+    </Box>
+
+    The vengeful phantom has two states: incorporeal and corporeal.
+
+    When incorporeal, the Phantom is unable to interact with any objects.
+    However, they can phase through walls and generally roam all across the station.
+
+    The Phantom can use their action to take corporeal form, allowing them to pick up objects and interact with things.
+    However, they cannot use combat mode and attack directly.
+    If they are hit in this form, they will become incorporeal again and will need to wait for a long cooldown before taking form again.
+
+    <ESGuideTipsEmbed Mask="ESPhantom"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Rebel.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Rebel.xml
@@ -1,0 +1,14 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESRebel"/>
+
+    Rebels are members of the crew which have [textlink="traitor-like" link="Traitors"] sabotage objectives and traitor caches, but are otherwise members of the crew.
+    Although they may often be mistaken for traitors, and their objectives may cause havoc, they are still good guys who want the crew to succeed.
+
+    <ESGuideObjectiveEmbed Objective="ESObjectiveRebelSabotageCommunications"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectiveRebelSabotageCrewMonitoring"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectiveRebelSabotageIDComputer"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectiveRebelSabotageCriminalRecords"/>
+    <ESGuideObjectiveEmbed Objective="ESObjectiveRebelSabotageTelecom"/>
+
+    <ESGuideTipsEmbed Mask="ESRebel"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Secretary.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Secretary.xml
@@ -1,0 +1,17 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESSecretary"/>
+
+    Secretaries are members of the crew who are assigned to other people to help them complete their objectives.
+    They can be assigned to help any mask which has personal objectives, including other Secretaries.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveSecretaryAssist"/>
+    </Box>
+
+    The Secretary wins if their assigned target completes all of their objectives.
+
+    Note that the only thing Secretaries care about are the individual goals of the mask.
+    It doesn't matter if their target accomplishes their troupe's goals nor if the die.
+
+  <ESGuideTipsEmbed Mask="ESSecretary"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/SleeperAgent.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/SleeperAgent.xml
@@ -1,0 +1,10 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESSleeperAgent"/>
+
+    The Sleeper Agent is a member of a crew who is waiting to turn and defect to the Syndicate at a moment's notice.
+
+    If all other [textlink="traitors" link="Traitors"] on-board the station die, the Sleeper Agent will be given a random traitor mask and tasked with finishing their work.
+    If the other traitors do not die, however, the Sleeper Agent will remain a crew member, simply needing to bide their time and stay alive in the event they are called upon.
+
+  <ESGuideTipsEmbed Mask="ESSleeperAgent"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/VIP.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/VIP.xml
@@ -1,0 +1,14 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESVIP"/>
+
+    VIPs are members of the crew who are identical to the [textlink="Crewmember" link="Crewmember"] other than the fact that they spawn with a VIP card
+
+    <Box>
+        <GuideEntityEmbed Entity="ESItemCardVIP"/>
+    </Box>
+
+    The VIP card confirms that whoever holds it is without question the VIP and not part of any other troupe.
+    Keep in mind: the card itself doesn't specify the owner, so it can be stolen easily.
+
+    <ESGuideTipsEmbed Mask="ESVIP"/>
+</Document>

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Vigilante.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/Vigilante.xml
@@ -1,0 +1,24 @@
+<Document>
+    <ESGuideMaskEmbed Mask="ESVigilante"/>
+
+    Vigilantes are members of the crew who are tasked with taking down people who have taken the life of another.
+    Note that this is not necessarily a traitor or other evil troupe, but rather just a person who has killed someone, regardless of mask.
+
+    <Box>
+      <ESGuideObjectiveEmbed Objective="ESObjectiveVigilanteKillKiller"/>
+    </Box>
+
+    In order to help with this, Vigilantes receive a cache with a random assortment of gear.
+
+    <Box>
+      <GuideEntityEmbed Entity="ESWeaponRevolver357"/>
+      <GuideEntityEmbed Entity="ESWeaponPistol9mm"/>
+      <GuideEntityEmbed Entity="ESWeaponKnife"/>
+      <GuideEntityEmbed Entity="ExGrenade"/>
+    </Box>
+
+    Be aware: a Vigilante has no way of determining [italic]who[/italic] has actually killed someone, so they'll need to rely on observation and communication in order to complete their goal.
+    If all else fails, taking a stab at trying to kill a more powerful job like a security officer, captain, or coroner may lead to success.
+
+    <ESGuideTipsEmbed Mask="ESVigilante"/>
+</Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Adds 13 new guidebooks pages for all the crew masks.
Figure that I should just get them all out of the way.

Also does some miscellaneous fixes and tweaks to some objective/mask stuff that I saw.

closes #426 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A
