### PR TITLE
custom hud layouting + scaling fixes

### DIFF
--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -13,6 +13,7 @@ significantly modified from old lobbygui, basically everything diff-->
     xmlns:hotbar="clr-namespace:Content.Client.UserInterface.Systems.Hotbar.Widgets"
     xmlns:alerts="clr-namespace:Content.Client.UserInterface.Systems.Alerts.Widgets"
     xmlns:actions="clr-namespace:Content.Client.UserInterface.Systems.Actions.Widgets"
+    xmlns:screens="clr-namespace:Content.Client._ES.Screens"
     VerticalExpand="False"
     VerticalAlignment="Bottom"
     HorizontalAlignment="Center">
@@ -21,37 +22,26 @@ significantly modified from old lobbygui, basically everything diff-->
                  Stretch="KeepAspectCovered" />-->
     <!-- ES START -->
     <Control Access="Public" Visible="False" Name="CharacterSetupState" VerticalExpand="True" />
-    <HFillStack Name="FullScreenContainer">
-        <PanelContainer Name="LeftPanel" HorizontalExpand="True">
+    <screens:HudViewportContainer Name="FullScreenContainer" PanelRatio="0.5">
+        <PanelContainer Name="LeftPanel">
             <PanelContainer.PanelOverride>
                 <graphics:StyleBoxFlat BackgroundColor="#000000" />
             </PanelContainer.PanelOverride>
         </PanelContainer>
-        <VFillStack HorizontalExpand="True">
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#000000" />
-                </PanelContainer.PanelOverride>
-            </PanelContainer>
-            <LayoutContainer Name="ViewportContainer" HorizontalExpand="True" VerticalExpand="True">
-                <!-- Character setup state -->
-                <!-- This is injected on startup. Funky! -->
-                <controls:MainViewport Name="MainViewport" Margin="0 0 100 0"/>
-                <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
-                <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
-                    <actions:ActionsBar Name="Actions" Access="Protected" />
-                    <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical" />
-                </BoxContainer>
-                <alerts:AlertsUI Name="Alerts" Access="Protected" />
-            </LayoutContainer>
-            <PanelContainer VerticalExpand="True">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#000000" />
-                </PanelContainer.PanelOverride>
-            </PanelContainer>
-        </VFillStack>
 
-        <PanelContainer Name="SeparatedChatPanel" MinWidth="300">
+        <LayoutContainer Name="ViewportContainer">
+            <!-- Character setup state -->
+            <!-- This is injected on startup. Funky! -->
+            <controls:MainViewport Name="MainViewport" VerticalAlignment="Center" />
+            <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
+            <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
+                <actions:ActionsBar Name="Actions" Access="Protected" />
+                <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical" />
+            </BoxContainer>
+            <alerts:AlertsUI Name="Alerts" Access="Protected" />
+        </LayoutContainer>
+
+        <PanelContainer Name="SeparatedChatPanel">
             <PanelContainer.PanelOverride>
                 <graphics:StyleBoxFlat BackgroundColor="#2B2C3B" />
             </PanelContainer.PanelOverride>
@@ -97,5 +87,5 @@ significantly modified from old lobbygui, basically everything diff-->
                 <widgets:ChatBox Name="Chat" Access="Public" VerticalExpand="True" Margin="3 3 3 3" MinHeight="50" />
             </BoxContainer>
         </PanelContainer>
-    </HFillStack>
+    </screens:HudViewportContainer>
 </lobbyUi:LobbyGui>

--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -5,8 +5,6 @@ using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Configuration;
 
-// ES MODIFIED : right-aligned main viewport instead of centered
-
 namespace Content.Client.UserInterface.Controls
 {
     /// <summary>
@@ -109,15 +107,6 @@ namespace Content.Client.UserInterface.Controls
 
         private int? CalcSnappingFactor()
         {
-            // Margin tolerance is tolerance of "the window is too big"
-            // where we add a margin to the viewport to make it fit.
-            var cfgToleranceMargin = _cfg.GetCVar(CCVars.ViewportSnapToleranceMargin);
-            // Clip tolerance is tolerance of "the window is too small"
-            // where we are clipping the viewport to make it fit.
-            var cfgToleranceClip = _cfg.GetCVar(CCVars.ViewportSnapToleranceClip);
-
-            var cfgVerticalFit = _cfg.GetCVar(CCVars.ViewportVerticalFit);
-
             // erm
             if (Root == null)
                 return null;
@@ -129,12 +118,17 @@ namespace Content.Client.UserInterface.Controls
 
             var minPossible = Math.Min(possibleSize.X, possibleSize.Y);
 
-            if (minPossible >= 1)
-            {
-                return (int)Math.Floor(minPossible);
-            }
+            // check closest fits on a .5 increment basis
+            // (0.5 = no snap, 1 = snap, 1.5 = no snap, etc)
+            if (minPossible < 0.5)
+                return null; // too tiny
 
-            // uhhh too tiny try again later
+            var doubledScale = (int)Math.Floor(minPossible * 2f);
+            // if its even, this is an integer fit
+            // if it isnt, it fits closer to a .5 increment, so just let scaling handle it
+            if ((doubledScale % 2 == 0))
+                return doubledScale / 2;
+
             return null;
         }
 

--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -112,22 +112,22 @@ namespace Content.Client.UserInterface.Controls
                 return null;
 
             // Instead of all that, we just snap to the largest integer scale that fits.
-            // If that (pre-clamp) scale is <1, we return null and let the scaling logic handle it.
+            // If that (pre-clamp) scale is <1, or we arent close enough to an integer fit, we return null and let the scaling logic handle it.
             // TODO: This should probably enforce margins around the viewport.
             var possibleSize = ((Vector2)Root.PixelSize) / ((Vector2)Viewport.ViewportSize);
 
             var minPossible = Math.Min(possibleSize.X, possibleSize.Y);
 
-            // check closest fits on a .5 increment basis
-            // (0.5 = no snap, 1 = snap, 1.5 = no snap, etc)
+            // check closest fits on a .25 increment basis
+            // (0-1 = no snap, 1 = snap, >1.25 = no snap, etc)
             if (minPossible < 1)
                 return null; // too tiny, always scale
 
-            var doubledScale = (int)Math.Floor(minPossible * 2f);
+            var quadScale = (int)Math.Floor(minPossible * 4f);
             // if its even, this is an integer fit
-            // if it isnt, it fits closer to a .5 increment, so just let scaling handle it
-            if ((doubledScale % 2 == 0))
-                return doubledScale / 2;
+            // if it isnt, it fits closer to a .25 increment, so just let scaling handle it
+            if ((quadScale % 4 == 0))
+                return quadScale / 4;
 
             return null;
         }

--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -120,8 +120,8 @@ namespace Content.Client.UserInterface.Controls
 
             // check closest fits on a .5 increment basis
             // (0.5 = no snap, 1 = snap, 1.5 = no snap, etc)
-            if (minPossible < 0.5)
-                return null; // too tiny
+            if (minPossible < 1)
+                return null; // too tiny, always scale
 
             var doubledScale = (int)Math.Floor(minPossible * 2f);
             // if its even, this is an integer fit

--- a/Content.Client/Viewport/ScalingViewport.cs
+++ b/Content.Client/Viewport/ScalingViewport.cs
@@ -1,17 +1,11 @@
-using System;
-using System.Collections.Generic;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.CustomControls;
 using Robust.Shared.Graphics;
-using Robust.Shared.IoC;
 using Robust.Shared.Map;
-using Robust.Shared.Maths;
-using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Robust.Shared.ViewVariables;
 using SixLabors.ImageSharp.PixelFormats;
 
 // ES MODIFIED: support for changing horizontal alignment of the actual rendered viewport, instead of it always being centered
@@ -128,7 +122,7 @@ namespace Content.Client.Viewport
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
-            return _viewport is null ? Vector2.Zero : (GetDrawBox().Size / UIScale);
+            return _viewport is null ? Vector2.Zero : (GetViewportSize(availableSize).Size / UIScale);
         }
 
         protected override void KeyBindDown(GUIBoundKeyEventArgs args)
@@ -174,7 +168,7 @@ namespace Content.Client.Viewport
                 _queuedScreenshots.Clear();
             }
 
-            var drawBox = GetDrawBox();
+            var drawBox = GetViewportSize(PixelSize);
             var drawBoxGlobal = drawBox.Translated(GlobalPixelPosition);
             _viewport.RenderScreenOverlaysBelow(handle, this, drawBoxGlobal);
             handle.DrawingHandleScreen.DrawTextureRect(_viewport.RenderTarget.Texture, drawBox);
@@ -187,16 +181,15 @@ namespace Content.Client.Viewport
         }
 
         // Draw box in pixel coords to draw the viewport at.
-        private UIBox2i GetDrawBox()
+        private UIBox2i GetViewportSize(Vector2 availableSize)
         {
             DebugTools.AssertNotNull(_viewport);
 
             var vpSize = _viewport!.Size;
-            var ourSize = (Vector2) PixelSize;
 
             if (FixedStretchSize == null)
             {
-                var (ratioX, ratioY) = ourSize / vpSize;
+                var (ratioX, ratioY) = availableSize / vpSize;
                 var ratio = 1f;
                 switch (_ignoreDimension)
                 {
@@ -328,7 +321,7 @@ namespace Content.Client.Viewport
         {
             EnsureViewportCreated();
 
-            var drawBox = GetDrawBox();
+            var drawBox = GetViewportSize(PixelSize);
             var scaleFactor = drawBox.Size / (Vector2) _viewport!.Size;
 
             if (scaleFactor.X == 0 || scaleFactor.Y == 0)

--- a/Content.Client/Viewport/ScalingViewport.cs
+++ b/Content.Client/Viewport/ScalingViewport.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Utility;
 using SixLabors.ImageSharp.PixelFormats;
 
-// ES MODIFIED: support for changing horizontal alignment of the actual rendered viewport, instead of it always being centered
+// ES MODIFIED: a lot
 
 namespace Content.Client.Viewport
 {

--- a/Content.Client/Viewport/ScalingViewport.cs
+++ b/Content.Client/Viewport/ScalingViewport.cs
@@ -122,7 +122,7 @@ namespace Content.Client.Viewport
 
         protected override Vector2 MeasureOverride(Vector2 availableSize)
         {
-            return _viewport is null ? Vector2.Zero : (GetViewportSize(availableSize).Size / UIScale);
+            return _viewport is null ? Vector2.Zero : (GetViewportBox(availableSize).Size / UIScale);
         }
 
         protected override void KeyBindDown(GUIBoundKeyEventArgs args)
@@ -168,7 +168,7 @@ namespace Content.Client.Viewport
                 _queuedScreenshots.Clear();
             }
 
-            var drawBox = GetViewportSize(PixelSize);
+            var drawBox = GetViewportBox(PixelSize);
             var drawBoxGlobal = drawBox.Translated(GlobalPixelPosition);
             _viewport.RenderScreenOverlaysBelow(handle, this, drawBoxGlobal);
             handle.DrawingHandleScreen.DrawTextureRect(_viewport.RenderTarget.Texture, drawBox);
@@ -181,7 +181,7 @@ namespace Content.Client.Viewport
         }
 
         // Draw box in pixel coords to draw the viewport at.
-        private UIBox2i GetViewportSize(Vector2 availableSize)
+        private UIBox2i GetViewportBox(Vector2 availableSize)
         {
             DebugTools.AssertNotNull(_viewport);
 
@@ -321,7 +321,7 @@ namespace Content.Client.Viewport
         {
             EnsureViewportCreated();
 
-            var drawBox = GetViewportSize(PixelSize);
+            var drawBox = GetViewportBox(PixelSize);
             var scaleFactor = drawBox.Size / (Vector2) _viewport!.Size;
 
             if (scaleFactor.X == 0 || scaleFactor.Y == 0)

--- a/Content.Client/_ES/Screens/HudViewportContainer.cs
+++ b/Content.Client/_ES/Screens/HudViewportContainer.cs
@@ -1,0 +1,46 @@
+using System.Numerics;
+using Content.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.Controls;
+
+namespace Content.Client._ES.Screens;
+
+/// <summary>
+///     Handles layouting for the hud UI with a left panel, viewport, and right panel.
+///     All children will fill vertical space as much as possible.
+///     The viewport will be laid out first
+/// </summary>
+public sealed class HudViewportContainer : Container
+{
+    /// <summary>
+    ///     Determines how much space each panel gets compared to one another.
+    ///     1 means each panel receives an equal amount of space.
+    ///     2 would mean the left panel receives twice as much space as the right panel.
+    ///     0.5 would mean the right panel receives twice as much space as the left panel.
+    /// </summary>
+    public float PanelRatio { get; set; } = 1.0f;
+
+    protected override Vector2 ArrangeOverride(Vector2 finalSize)
+    {
+        if (ChildCount != 3)
+            throw new ArgumentOutOfRangeException($"Child count of {nameof(HudViewportContainer)} must be exactly 3");
+
+        var (finalWidth, finalHeight) = finalSize;
+
+        var leftPanel = GetChild(0);
+        var centerContainer = GetChild(1);
+        var rightPanel = GetChild(2);
+
+        // lay out viewport in the center
+        var viewportWidth = centerContainer.DesiredSize.X;
+        var panelSpace = (finalWidth - viewportWidth);
+        var rightPanelWidth = panelSpace / (PanelRatio + 1);
+        var leftPanelWidth = panelSpace - rightPanelWidth;
+        centerContainer.Arrange(UIBox2.FromDimensions(leftPanelWidth, 0, viewportWidth, finalHeight));
+
+        // lay out panels
+        leftPanel.Arrange(UIBox2.FromDimensions(0, 0, leftPanelWidth, finalHeight));
+        rightPanel.Arrange(UIBox2.FromDimensions(leftPanelWidth + viewportWidth, 0, rightPanelWidth, finalHeight));
+
+        return finalSize;
+    }
+}

--- a/Content.Client/_ES/Screens/PerformerGameScreen.xaml
+++ b/Content.Client/_ES/Screens/PerformerGameScreen.xaml
@@ -14,37 +14,26 @@
     VerticalExpand="False"
     VerticalAlignment="Bottom"
     HorizontalAlignment="Center">
-    <HFillStack Name="FullScreenContainer">
-        <PanelContainer Name="LeftPanel" Stack.ExpandAxis="Horizontal">
+    <screens:HudViewportContainer Name="FullScreenContainer" PanelRatio="0.5">
+        <PanelContainer Name="LeftPanel">
             <PanelContainer.PanelOverride>
                 <graphics:StyleBoxFlat BackgroundColor="#000000" />
             </PanelContainer.PanelOverride>
         </PanelContainer>
-        <VFillStack Stack.ExpandAxis="Horizontal">
-            <PanelContainer Stack.ExpandAxis="Vertical">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#000000" />
-                </PanelContainer.PanelOverride>
-            </PanelContainer>
-            <LayoutContainer Name="ViewportContainer" Stack.ExpandAxis="Vertical">
-                <controls:MainViewport Name="MainViewport" Margin="0 0 100 0"/>
-                <widgets:GhostGui Name="Ghost" Access="Protected" />
-                <inventory:InventoryGui Name="Inventory" Access="Protected" />
-                <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
-                <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
-                    <actions:ActionsBar Name="Actions" Access="Protected" />
-                    <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical" />
-                </BoxContainer>
-                <alerts:AlertsUI Name="Alerts" Access="Protected" Margin="0 250 0 0" />
-            </LayoutContainer>
-            <PanelContainer Stack.ExpandAxis="Vertical">
-                <PanelContainer.PanelOverride>
-                    <graphics:StyleBoxFlat BackgroundColor="#000000" />
-                </PanelContainer.PanelOverride>
-            </PanelContainer>
-        </VFillStack>
 
-        <PanelContainer Name="SeparatedChatPanel" Stack.ExpandAxis="Horizontal">
+        <LayoutContainer Name="ViewportContainer">
+            <controls:MainViewport Name="MainViewport" VerticalAlignment="Center"/>
+            <widgets:GhostGui Name="Ghost" Access="Protected" />
+            <inventory:InventoryGui Name="Inventory" Access="Protected" />
+            <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
+            <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
+                <actions:ActionsBar Name="Actions" Access="Protected" />
+                <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical" />
+            </BoxContainer>
+            <alerts:AlertsUI Name="Alerts" Access="Protected" Margin="0 250 0 0" />
+        </LayoutContainer>
+
+        <PanelContainer Name="SeparatedChatPanel">
             <PanelContainer.PanelOverride>
                 <graphics:StyleBoxFlat BackgroundColor="#2B2C3B" />
             </PanelContainer.PanelOverride>
@@ -52,8 +41,8 @@
             <VFillStack SeparationOverride="10" Margin="10">
                 <menuBar:GameTopMenuBar Name="TopBar" Access="Public" />
                 <chat:ChatBox StyleClasses="ChatOutput" Stack.ExpandAxis="Vertical" Name="Chat"
-                              Access="Protected" MinWidth="520" />
+                              Access="Protected" />
             </VFillStack>
         </PanelContainer>
-    </HFillStack>
+    </screens:HudViewportContainer>
 </screens:PerformerGameScreen>

--- a/Content.Client/_ES/Screens/StagehandGameScreen.xaml
+++ b/Content.Client/_ES/Screens/StagehandGameScreen.xaml
@@ -16,33 +16,30 @@
     VerticalExpand="False"
     VerticalAlignment="Bottom"
     HorizontalAlignment="Center">
-    <HFillStack Name="FullScreenContainer">
-        <FillPanel Name="LeftPanel" StyleClasses="PanelDark" MinWidth="300">
+    <screens:HudViewportContainer Name="FullScreenContainer" PanelRatio="0.8">
+        <FillPanel Name="LeftPanel" StyleClasses="PanelDark">
             <observe:ESStagehandObserveControl Name="ObserveControl"/>
         </FillPanel>
-        <VFillStack Stack.ExpandAxis="Horizontal">
-            <FillPanel StyleClasses="PanelDark"/>
-            <LayoutContainer Name="ViewportContainer" Stack.ExpandAxis="Vertical">
-                <controls:MainViewport Name="MainViewport"/>
-                <widgets:GhostGui Name="Ghost" Access="Protected" />
-                <inventory:InventoryGui Name="Inventory" Access="Protected" />
-                <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
-                <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
-                    <actions:ActionsBar Name="Actions" Access="Protected" />
-                    <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical" />
-                </BoxContainer>
-                <alerts:AlertsUI Name="Alerts" Access="Protected" Margin="0 250 0 0" />
-            </LayoutContainer>
-            <FillPanel StyleClasses="PanelDark"/>
-        </VFillStack>
+
+        <LayoutContainer Name="ViewportContainer">
+            <controls:MainViewport Name="MainViewport" VerticalAlignment="Center"/>
+            <widgets:GhostGui Name="Ghost" Access="Protected" />
+            <inventory:InventoryGui Name="Inventory" Access="Protected" />
+            <hotbar:HotbarGui Name="Hotbar" Access="Protected" />
+            <BoxContainer Name="TopLeftContainer" Orientation="Vertical">
+                <actions:ActionsBar Name="Actions" Access="Protected" />
+                <BoxContainer Name="VoteMenu" Access="Public" Orientation="Vertical" />
+            </BoxContainer>
+            <alerts:AlertsUI Name="Alerts" Access="Protected" Margin="0 250 0 0" />
+        </LayoutContainer>
 
         <FillPanel Name="SeparatedChatPanel" StyleClasses="PanelDark">
             <VFillStack SeparationOverride="10" Margin="10">
                 <menuBar:GameTopMenuBar Name="TopBar" Access="Public" />
                 <vote:ESVotingManagerControl Name="VoteControl" SetHeight="300"/>
                 <chat:ChatBox StyleClasses="ChatOutput" Stack.ExpandAxis="Vertical" Name="Chat"
-                              Access="Protected" MinWidth="520" />
+                              Access="Protected" />
             </VFillStack>
         </FillPanel>
-    </HFillStack>
+    </screens:HudViewportContainer>
 </screens:StagehandGameScreen>

--- a/Content.Client/_ES/Stagehand/Ui/ESStagehandObserveControl.xaml
+++ b/Content.Client/_ES/Stagehand/Ui/ESStagehandObserveControl.xaml
@@ -1,8 +1,7 @@
 <controls:ESStagehandObserveControl
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client._ES.Stagehand.Ui"
-    xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client"
-    MinWidth="200">
+    xmlns:graphics="clr-namespace:Robust.Client.Graphics;assembly=Robust.Client">
     <VFillStack>
         <FillPanel StyleClasses="PanelDark">
             <VScroll VerticalExpand="True" ReserveScrollbarSpace="True">


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

new control which lays out a leftpanel/viewport/rightpanel hud correctly (lays out viewport first with as much space as possible then puts the panels on either side). evenetually i want to do a splitcontainer type thing and allow you to control the panel ratio by just dragging whcih shouldnt be that hard

scaling now checks 0.5 increments. if it fits better to one of those then itll ditch integer scaling. it should maybe check even more granularly (like 0.25 or something) we'll see i guess. or use a different method for doing this. honestly the previous method probably would have worked fine if we just tweaked it and it basically did exactly this

it should hopefully scale to 720p and 1440p correctly now

this also gets rid of the paneling above/below the viewport because 1) i think it was causing issues and its annoying and 2) i dont like it and its annoying. this makes the layout a bit less stupid to look at sometimes like in stagehand idk

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9d444fe1-a476-460a-8759-ca0273a4a37f" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a67cd46e-05a3-487e-b933-3e43f4e27734" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/62e91c03-0b3b-467b-a767-9e43bf2d0d19" />
