### PR TITLE
back to .5 increment scaling + changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@
 
 N/A
 
-
 **Changelog**
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
 Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

--- a/Content.Client/UserInterface/Controls/MainViewport.cs
+++ b/Content.Client/UserInterface/Controls/MainViewport.cs
@@ -118,16 +118,16 @@ namespace Content.Client.UserInterface.Controls
 
             var minPossible = Math.Min(possibleSize.X, possibleSize.Y);
 
-            // check closest fits on a .25 increment basis
-            // (0-1 = no snap, 1 = snap, >1.25 = no snap, etc)
+            // check closest fits on a .5 increment basis
+            // (0-1 = no snap, 1 = snap, >1.5 = no snap, etc)
             if (minPossible < 1)
                 return null; // too tiny, always scale
 
-            var quadScale = (int)Math.Floor(minPossible * 4f);
+            var doubleScale = (int)Math.Floor(minPossible * 2f);
             // if its even, this is an integer fit
-            // if it isnt, it fits closer to a .25 increment, so just let scaling handle it
-            if ((quadScale % 4 == 0))
-                return quadScale / 4;
+            // if it isnt, it fits closer to a .5 increment, so just let scaling handle it
+            if ((doubleScale % 2 == 0))
+                return doubleScale / 2;
 
             return null;
         }


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

changelog failed last pr cuz i just missed a variable i think

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
Playtest:
- fix: Viewport scaling should work better in most situations, including on 720p/1440p monitors where it was previously kinda awful
