### PR TITLE
rm spare armor vest from secoff locker

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/job_lockers.yml
@@ -43,7 +43,6 @@
     - id: FlashlightSeclite
       prob: 0.8
     - id: ESClothingHeadHelmetSecurity
-    - id: ESClothingOuterArmorSecurity
     - id: ClothingBeltSecurityFilled
     - id: Flash
       prob: 0.5


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
title
Having a spare armor vest means sec can distribute them among sec aligned people, strengthening the both of them considerably as the armor vests are very impactful. I don't actually mind this very much because enlisting crew is pretty cool, but as it is, it scales with the amount of seccies on station when imho it would be nicer as maybe a singular vest that's mapped (I didnt do that in this pr).

Idk if we even want this but I thought I'd pop it up just in case.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: secoffs will no longer have a spare armor vest.