### PR TITLE
Add a command to simulate mask distribution for masquerades

### DIFF
--- a/Content.Server/_ES/Masks/Masquerades/MasqueradeCommands.cs
+++ b/Content.Server/_ES/Masks/Masquerades/MasqueradeCommands.cs
@@ -17,6 +17,7 @@ namespace Content.Server._ES.Masks.Masquerades;
 public sealed class MasqueradeCommands : ToolshedCommand
 {
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     public static readonly ProtoId<GamePresetPrototype> MasqueradePreset = "ESMasqueradeManaged";
 
@@ -32,6 +33,43 @@ public sealed class MasqueradeCommands : ToolshedCommand
         var set = _proto.Index(maskSet);
 
         return set.Pick(rng, count);
+    }
+
+    [CommandImplementation("sim")]
+    public IEnumerable<string> Simulate(
+        [CommandArgument] ProtoId<ESMasqueradePrototype> masquerade,
+        [CommandArgument] int playerCount,
+        [CommandArgument] int trials
+        )
+    {
+        var proto = _proto.Index(masquerade);
+
+        var allMasks = new List<(ESMaskPrototype Mask, int Count)>();
+        for (var i = 0; i < trials; ++i)
+        {
+            if (!proto.Masquerade.TryGetMasks(playerCount, _random, _proto, out var masks))
+                throw new Exception($"Failed to get masks for masquerade {masquerade} at pop level {playerCount}");
+
+            foreach (var grouping in masks.GroupBy(m => m))
+            {
+                allMasks.Add((_proto.Index(grouping.Key), grouping.Count()));
+            }
+        }
+
+        var ordered = allMasks
+            .GroupBy(n => n.Mask)
+            .OrderByDescending(p => p.Key.Troupe)
+            .ThenByDescending(p => (double) p.Sum(g => g.Count) / trials)
+            .ThenBy(p => p.Key.ID);
+
+        foreach (var grouping in ordered)
+        {
+            var mean = (double) grouping.Sum(g => g.Count) / trials;
+            var sum = grouping.Sum(d => Math.Pow(d.Count - mean, 2));
+            var stdDev = Math.Sqrt(sum / trials);
+
+            yield return $"{grouping.Key.ID} ({grouping.Key.Troupe}): μ={mean:F4}, σ={stdDev:F4}";
+        }
     }
 
     [CommandImplementation("force")]

--- a/Resources/Locale/en-US/_ES/commands/toolshed-descriptions.ftl
+++ b/Resources/Locale/en-US/_ES/commands/toolshed-descriptions.ftl
@@ -20,6 +20,8 @@ command-description-stationvariation-runPass =
     Spawns and raises the variation pass event on a variation game rule entity.
 command-description-mq-pickFromMaskSet =
     Picks masks from the given set using a seed.
+command-description-mq-sim =
+    Simulates and calculates the average mask distribution at a given player count.
 command-description-mq-force =
     Forces the masquerade to be the given one.
 command-description-mq-unforce =


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Adds the command `mq:sim <masquerade> <playerCount> <trials>` which produces a mask distribution at a given player count with n = `<trials>`

Generally just a nice balancing tool to see how often certain roles show up in a given mode, since our selection tends to be a bit indirect at times.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="779" height="376" alt="image" src="https://github.com/user-attachments/assets/d06ecd5e-7dcf-4b29-b675-2b887f2294fa" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

none.