### PR TITLE
allow braincrit people to succumb with an action again

### DIFF
--- a/Content.Server/Mobs/CritMobActionsSystem.cs
+++ b/Content.Server/Mobs/CritMobActionsSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Server.Administration;
 using Content.Server.Chat.Systems;
 using Content.Server.Popups;
+using Content.Shared._Offbrand.Wounds;
 using Content.Shared.Chat;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -18,11 +19,10 @@ public sealed class CritMobActionsSystem : EntitySystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DeathgaspSystem _deathgasp = default!;
-    [Dependency] private readonly IServerConsoleHost _host = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
-
+    [Dependency] private readonly BrainDamageSystem _brainDamage = default!;
     private const int MaxLastWordsLength = 30;
 
     public override void Initialize()
@@ -36,10 +36,10 @@ public sealed class CritMobActionsSystem : EntitySystem
 
     private void OnSuccumb(EntityUid uid, MobStateActionsComponent component, CritSuccumbEvent args)
     {
-        if (!TryComp<ActorComponent>(uid, out var actor) || !_mobState.IsCritical(uid))
+        if (!_mobState.IsCritical(uid))
             return;
 
-        _host.ExecuteCommand(actor.PlayerSession, "ghost");
+        _brainDamage.KillBrain(uid);
         args.Handled = true;
     }
 
@@ -81,7 +81,7 @@ public sealed class CritMobActionsSystem : EntitySystem
                 lastWords += "...";
 
                 _chat.TrySendInGameICMessage(uid, lastWords, InGameICChatType.Whisper, ChatTransmitRange.Normal, checkRadioPrefix: false, ignoreActionBlocker: true);
-                _host.ExecuteCommand(actor.PlayerSession, "ghost");
+                _brainDamage.KillBrain(uid);
             });
 
         args.Handled = true;

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -296,6 +296,11 @@
       70: DefaultBraingasp
     oxygenThresholds:
       0: DefaultBrainslump
+  - type: MobStateActions
+    actions:
+      Critical:
+      - ActionCritSuccumb
+      - ActionCritLastWords
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

being in braincrit already sets mobstate critical, this just readds the actions. no deathgasp because i ddecided i didnt care

kills brain when you succumb

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="799" height="835" alt="image" src="https://github.com/user-attachments/assets/1c57ae0b-c6e2-4fb7-8efd-cf35025f9b6b" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f2e4e2cf-cbe2-4374-a49c-790da8203af3" />

<img width="466" height="323" alt="image" src="https://github.com/user-attachments/assets/cbf781d8-a39a-488f-9bde-11f5009e04a7" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Being in braincrit now allows you to succumb with an action once more (or say last words)
