### PR TITLE
adds navmap beacon to nuke terminals

### DIFF
--- a/Resources/Locale/en-US/_ES/nuke/cryptonuke.ftl
+++ b/Resources/Locale/en-US/_ES/nuke/cryptonuke.ftl
@@ -35,3 +35,5 @@ es-cryptonuke-ui-button-hack-tooltip = The syndicate's tasks aren't finished! Un
 es-cryptonuke-ui-button-already-hacked-tooltip = Terminal is already hacked!
 
 es-cryptonuke-examine-compromised = This terminal has been [color=red][bold]hacked[/color][/bold]!
+
+es-cryptonuke-beacon = Nuclear Cryptographic Terminal

--- a/Resources/Locale/en-US/_ES/nuke/cryptonuke.ftl
+++ b/Resources/Locale/en-US/_ES/nuke/cryptonuke.ftl
@@ -36,4 +36,4 @@ es-cryptonuke-ui-button-already-hacked-tooltip = Terminal is already hacked!
 
 es-cryptonuke-examine-compromised = This terminal has been [color=red][bold]hacked[/color][/bold]!
 
-es-cryptonuke-beacon = Nuclear Cryptographic Terminal
+es-cryptonuke-beacon = Nuke Terminal

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
@@ -340,6 +340,7 @@
   - type: ESCryptoNukeConsole
   - type: PointLight
     color: "#ff6971"
+  - type: NavMapBeacon # default text is just the entity name
   - type: ActivatableUI
     key: enum.ESCryptoNukeConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
@@ -340,7 +340,9 @@
   - type: ESCryptoNukeConsole
   - type: PointLight
     color: "#ff6971"
-  - type: NavMapBeacon # default text is just the entity name
+  - type: NavMapBeacon
+    defaultText: es-cryptonuke-beacon
+    color: "#a91409"
   - type: ActivatableUI
     key: enum.ESCryptoNukeConsoleUiKey.Key
   - type: UserInterface


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
title 
the text colour is a bit eh I just pulled it off the text pallete thats used in the UI
the name could be a bit long for the map but whatever

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="484" height="386" alt="image" src="https://github.com/user-attachments/assets/118094a1-29bd-4f70-b5e8-3fe2fa11315c" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Nuclear cryptographic terminals now have a navmap beacon