### PR TITLE
added defibrillator to cargo lathe

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/lathes.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/lathes.yml
@@ -55,6 +55,7 @@
     - MaterialsStatic
     - ESBasicChemistryStatic
     - RollerBedsStatic
+    - ESMedicalToolsStatic
     - ESLightsStatic
     - ESServiceStatic
     - ESElectronicsStatic

--- a/Resources/Prototypes/_ES/Lathe/packs.yml
+++ b/Resources/Prototypes/_ES/Lathe/packs.yml
@@ -78,7 +78,7 @@
   recipes:
   - BoxFolderClipboardEmpty
   - BoxFolderPlasticClipboardEmpty
- 
+
 # Departmental
 # Cargo
 - type: latheRecipePack
@@ -107,6 +107,11 @@
   - HandLabeler
   - BaseChemistryEmptyVial
   - Dropper
+
+- type: latheRecipePack
+  id: ESMedicalToolsStatic
+  recipes:
+  - Defibrillator
 
 # Security
 - type: latheRecipePack


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Adds defibrillators to the cargo lathe under a new lathe pack ESMedicalToolsStatic (for all your medicated needs!)

## Media
<img width="453" height="186" alt="image" src="https://github.com/user-attachments/assets/facb7a28-dd5e-4f9e-a1d5-86706c3bfbca" />

**Changelog**

:cl:
- add: Defibrillators can now be made at the cargo lathe.
