### PR TITLE
Increased jerrycan inventory size

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Objects/Storage/ReagentContainers/jerrycan.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Storage/ReagentContainers/jerrycan.yml
@@ -20,6 +20,7 @@
     sprite: _ES/Objects/Storage/ReagentContainers/jerrycan.rsi
   - type: Item
     sprite: _ES/Objects/Storage/ReagentContainers/jerrycan.rsi
+    size: Normal
   - type: Icon
     sprite: _ES/Objects/Storage/ReagentContainers/jerrycan.rsi
     state: icon_empty

--- a/Resources/Prototypes/_ES/Entities/Objects/Storage/ReagentContainers/jerrycan.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Storage/ReagentContainers/jerrycan.yml
@@ -20,7 +20,9 @@
     sprite: _ES/Objects/Storage/ReagentContainers/jerrycan.rsi
   - type: Item
     sprite: _ES/Objects/Storage/ReagentContainers/jerrycan.rsi
-    size: Normal
+    size: Large
+    shape:
+    - 0,0,2,2
   - type: Icon
     sprite: _ES/Objects/Storage/ReagentContainers/jerrycan.rsi
     state: icon_empty


### PR DESCRIPTION

## About the PR
Jerrycans are now a 3x3 instead of 1x2

fixes #1772

## Media
<img width="880" height="1009" alt="image" src="https://github.com/user-attachments/assets/04acf914-47df-4d4b-826c-858442c9906b" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Jerrycans are now 3x3
