### PR TITLE
Sleeper Agent Tweaks

### DIFF
--- a/Content.Server/_ES/Masks/Superfan/ESSuperfanSystem.cs
+++ b/Content.Server/_ES/Masks/Superfan/ESSuperfanSystem.cs
@@ -1,13 +1,11 @@
 using System.Linq;
 using Content.Server._ES.Masks.Masquerades;
-using Content.Server.KillTracking;
 using Content.Server.Mind;
 using Content.Shared._ES.KillTracking.Components;
 using Content.Shared._ES.Masks;
 using Content.Shared.Mind;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
-using Robust.Shared.Utility;
 
 namespace Content.Server._ES.Masks.Superfan;
 
@@ -30,13 +28,9 @@ public sealed class ESSuperfanSystem : EntitySystem
 
     private void OnKillReported(ref ESPlayerKilledEvent ev)
     {
-        // TODO: This feels fishy. I'll leave the kill reporting rewrite nerds to
-        //       figure out having a kill report for entire troupes down the line.
-        foreach (var member in _mask.GetTroupeMembers(TraitorsTroupe))
-        {
-            if (!_mind.IsCharacterDeadIc(Comp<MindComponent>(member)))
-                return; // Well the troupe ain't dead.
-        }
+        // Only activate if our target troupe died.
+        if (_mask.GetTroupeOrNull(ev.Killed) != TraitorsTroupe)
+            return;
 
         if (!_masquerade.TryGetMasqueradeData(out var set))
             return; // Well, no masquerade means no conversion target.
@@ -47,10 +41,27 @@ public sealed class ESSuperfanSystem : EntitySystem
             return;
         }
 
-        var fanQuery = EntityQueryEnumerator<ESSuperfanComponent, MindComponent>();
-
-        while (fanQuery.MoveNext(out var ent, out var fan, out var mind))
+        var total = 0;
+        var dead = 0;
+        foreach (var member in _mask.GetTroupeMembers(TraitorsTroupe))
         {
+            total += 1;
+
+            if (_mind.IsCharacterDeadIc(Comp<MindComponent>(member)))
+                dead += 1;
+        }
+
+        // Chance to be converted is proportional to the number of dead troupe members.
+        var prob = total != 0
+            ? (float)dead / total
+            : 1;
+
+        var fanQuery = EntityQueryEnumerator<ESSuperfanComponent, MindComponent>();
+        while (fanQuery.MoveNext(out var ent, out _, out var mind))
+        {
+            if (!_random.Prob(prob))
+                continue;
+
             if (_mind.IsCharacterDeadIc(mind))
                 continue; // Don't assign the dead to tot masks.
 

--- a/Resources/Locale/en-US/_ES/masks/masks.ftl
+++ b/Resources/Locale/en-US/_ES/masks/masks.ftl
@@ -79,7 +79,7 @@ es-mask-psychid-desc = As a Psychid, be killed in order to swap bodies and creat
 
 # Oddballs
 es-mask-sleeper-agent-name = Sleeper Agent
-es-mask-sleeper-agent-desc = As a Sleeper Agent, you're a member of crew and win with them, unless the entire traitors team dies, upon which you switch sides and gain a new mask.
+es-mask-sleeper-agent-desc = As a Sleeper Agent, you're a member of crew and win with them. When a traitor dies, you have a chance to switch sides and gain a new mask.
 
 # Meta
 es-objective-issuer-mask = Mask

--- a/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/SleeperAgent.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/TroupesAndMasks/Crew/SleeperAgent.xml
@@ -3,8 +3,11 @@
 
     The Sleeper Agent is a member of a crew who is waiting to turn and defect to the Syndicate at a moment's notice.
 
-    If all other [textlink="traitors" link="Traitor"] on-board the station die, the Sleeper Agent will be given a random traitor mask and tasked with finishing their work.
-    If the other traitors do not die, however, the Sleeper Agent will remain a crew member, simply needing to bide their time and stay alive in the event they are called upon.
+    If a [textlink="traitor" link="Traitor"] on-board the station dies, the Sleeper Agent will have a chance to be woken up, converting them into a random traitor mask.
+    This chance scales based on the number of traitors who have died.
+
+    In the event that they are not woken up, however, the Sleeper Agent will remain a crew member.
+    They can choose either to work as a perfectly normal member of the crew, or scheme and prepare for their (potentially inevitable) conversion into a traitor.
 
   <ESGuideTipsEmbed Mask="SleeperAgent"/>
 </Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1809 

tweakies:
- sleeper agents now converts with a chance after a traitor death
- chance scales inversely to living players
- update guidebook to reflect this

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Sleeper agents now have a chance to convert after each traitor death, not just after the last one dies.
