### PR TITLE
Remove inappropriate rp levels

### DIFF
--- a/Content.Server/_ES/ServerStatus/ESRoleplayLevelsPrototype.cs
+++ b/Content.Server/_ES/ServerStatus/ESRoleplayLevelsPrototype.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using Content.Shared.Dataset;
 using Robust.Shared.Collections;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -23,12 +22,6 @@ public sealed partial class ESRoleplayLevelsPrototype : IPrototype, ISerializati
     /// </summary>
     [DataField(required: true)]
     public List<char> ForbidCharacters = default!;
-
-    /// <summary>
-    ///     Localized datasets we also add in to our list of roleplays.
-    /// </summary>
-    [DataField]
-    public List<ProtoId<LocalizedDatasetPrototype>> LocalizedDatasets = new();
 
     /// <summary>
     ///     The kinds of roleplays in this dataset.
@@ -60,16 +53,6 @@ public sealed partial class ESRoleplayLevelsPrototype : IPrototype, ISerializati
 
     public string GetPossibleRoleplay(ILocalizationManager loc, IPrototypeManager proto, IRobustRandom random)
     {
-        var roleplays = new List<string>();
-
-        foreach (var setProtoId in LocalizedDatasets)
-        {
-            var set = proto.Index(setProtoId);
-            roleplays.AddRange(set.Values.Where(x => !CheckForbidCharactersViolation(x)));
-        }
-
-        roleplays.AddRange(Roleplays);
-
-        return random.Pick(roleplays);
+        return random.Pick(Roleplays);
     }
 }

--- a/Resources/Prototypes/_ES/roleplayLevels.yml
+++ b/Resources/Prototypes/_ES/roleplayLevels.yml
@@ -1,8 +1,7 @@
 ﻿- type: esRoleplayLevels
   id: Default
   forbidCharacters: [ 'L', 'M', 'H', 'E', 'N' ]
-  localizedDatasets: [ ESNameAdjectives ]
-  roleplays:
+  roleplays: # WARNING! Any word in this list will appear ON THE HUB! Anything vulgar/inappropriate has a chance to get a HUB STRIKE
   - tubular
   - worm
   - cat
@@ -19,5 +18,39 @@
   - unspecified
   - bar
   - traitorous
-  - town-carpet
   - roleplay
+  - average
+  - dark
+  - unusual
+  - strange
+  - crazy
+  - stupid
+  - delightful
+  - silly
+  - ancient
+  - suspicious
+  - wacky
+  - whimsical
+  - jubilant
+  - joyous
+  - discount
+  - generic
+  - subpar
+  - spiritual
+  - fantastic
+  - bodacious
+  - ominous
+  - auspicious
+  - recursive
+  - introspective
+  - isolated
+  - peculiar
+  - radical
+  - pheem
+  - fail
+  - opposed to
+  - against
+  - pro
+  - anime
+  - silent
+  - rule-breaking


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1822

removed the dataset and just manually specified all the rp levels.

now that we're on the hubby we can't be accidentally advertising "spicy roleplay" as a non 18+ server.

i removed the capability for datasets because i basically never want a single word going into this list that we haven't actively vetted.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
