### PR TITLE
Thruster/Navigation Console Tweaks

### DIFF
--- a/Content.Server/_ES/Radstorm/Components/ESRadstormRoundEndRuleComponent.cs
+++ b/Content.Server/_ES/Radstorm/Components/ESRadstormRoundEndRuleComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class ESRadstormRoundEndRuleComponent : Component
     ///     Average time that the radstorm can start at. Used when randomly picking <see cref="RadstormTimeRemaining"/>.
     /// </summary>
     [DataField]
-    public TimeSpan RadstormStartTimeAvg = TimeSpan.FromMinutes(70f);
+    public TimeSpan RadstormStartTimeAvg = TimeSpan.FromMinutes(65f);
 
     /// <summary>
     ///     Standard deviation for time that the radstorm can start at. Used when randomly picking <see cref="RadstormTimeRemaining"/>.

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
@@ -406,7 +406,7 @@
     - map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       state: generic_panel_open
   - type: ESRadstormModifierMachine
-    modifier: 0.13
+    modifier: 0.5
     disableAnnouncement: es-radstorm-power-on-navigation-console
     enableAnnouncement: es-radstorm-power-off-navigation-console
   - type: PointLight

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/thruster.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/thruster.yml
@@ -41,7 +41,7 @@
         layer:
         - WallLayer
   - type: ESRadstormModifierMachine
-    modifier: 0.29
+    modifier: 1.00
     enableAnnouncement: es-radstorm-power-on-navigation-console
     disableAnnouncement: es-radstorm-power-off-navigation-console
   - type: AmbientSound


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

the machines weren't impactful enough so we're gonna make the impactful :godmode: 

the past few rounds have really just been going on, even when crew were not doing a real good job taking care of things. Hopefully a bit more active pressure will punish poor play and drag more rounds into a conclusion.

tweaks:
- Navigation console bumped from a 13% increase to a 50% increase in radstorm speed
- Thrusters bumped from 29% to 100% increaese in radstorm speed
- Average round time reduced by 5 minutes

closes #1808

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The radstorm now advances significantly quicker when thrusters run out of fuel or the navigation console loses power.
