### PR TITLE
bag of fixes

### DIFF
--- a/Content.Server/Resist/ResistLockerComponent.cs
+++ b/Content.Server/Resist/ResistLockerComponent.cs
@@ -7,10 +7,10 @@ namespace Content.Server.Resist;
 public sealed partial class ResistLockerComponent : Component
 {
     /// <summary>
-    /// How long will this locker take to kick open, defaults to 2 minutes
+    /// How long will this locker take to kick open
     /// </summary>
     [DataField("resistTime")]
-    public float ResistTime = 120f;
+    public float ResistTime = 10f;
 
     /// <summary>
     /// For quick exit if the player attempts to move while already resisting

--- a/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.cs
+++ b/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.cs
@@ -86,6 +86,8 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
     public float GetChargePercentage(ESWarpDriveGameRuleComponent component)
     {
         var totalTime = (_timing.CurTime - _ticker.RoundStartTimeSpan) - component.AccumulatedInterruptionTime;
+        if (component.LastInterruptionTime is { } lastInterruption)
+            totalTime -= (_timing.CurTime - lastInterruption);
         return (float) (totalTime / component.BaseChargeTime);
     }
 

--- a/Content.Shared/Cuffs/Components/HandcuffComponent.cs
+++ b/Content.Shared/Cuffs/Components/HandcuffComponent.cs
@@ -18,13 +18,13 @@ public sealed partial class HandcuffComponent : Component
     ///     The time it takes to uncuff an entity.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float UncuffTime = 3.5f;
+    public float UncuffTime = 2f;
 
     /// <summary>
     ///     The time it takes for a cuffed entity to uncuff itself.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float BreakoutTime = 15f;
+    public float BreakoutTime = 4f;
 
     /// <summary>
     ///     If an entity being cuffed is stunned, this amount of time is subtracted from the time it takes to add/remove their cuffs.

--- a/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
+++ b/Content.Shared/Ensnaring/Components/EnsnaringComponent.cs
@@ -12,13 +12,13 @@ public sealed partial class EnsnaringComponent : Component
     /// How long it should take to free someone else.
     /// </summary>
     [DataField]
-    public float FreeTime = 3.5f;
+    public float FreeTime = 1f;
 
     /// <summary>
     /// How long it should take for an entity to free themselves.
     /// </summary>
     [DataField]
-    public float BreakoutTime = 30.0f;
+    public float BreakoutTime = 1.5f;
 
     /// <summary>
     /// How much should this slow down the entities walk?

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs;
-using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
@@ -22,7 +21,6 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
-using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Physics;
@@ -64,9 +62,7 @@ public sealed partial class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullableComponent, MoveInputEvent>(OnPullableMoveInput);
         SubscribeLocalEvent<PullableComponent, CollisionChangeEvent>(OnPullableCollisionChange);
         SubscribeLocalEvent<PullableComponent, JointRemovedEvent>(OnJointRemoved);
-        SubscribeLocalEvent<PullableComponent, GetVerbsEvent<Verb>>(AddPullVerbs);
         SubscribeLocalEvent<PullableComponent, EntGotInsertedIntoContainerMessage>(OnPullableContainerInsert);
-        SubscribeLocalEvent<PullableComponent, ModifyUncuffDurationEvent>(OnModifyUncuffDuration);
         SubscribeLocalEvent<PullableComponent, StopBeingPulledAlertEvent>(OnStopBeingPulledAlert);
         SubscribeLocalEvent<PullableComponent, GetInteractingEntitiesEvent>(OnGetInteractingEntities);
 
@@ -212,18 +208,6 @@ public sealed partial class PullingSystem : EntitySystem
         TryStopPull(ent.Owner, ent.Comp);
     }
 
-    private void OnModifyUncuffDuration(Entity<PullableComponent> ent, ref ModifyUncuffDurationEvent args)
-    {
-        if (!ent.Comp.BeingPulled)
-            return;
-
-        // We don't care if the person is being uncuffed by someone else
-        if (args.User != args.Target)
-            return;
-
-        args.Duration *= 2;
-    }
-
     private void OnStopBeingPulledAlert(Entity<PullableComponent> ent, ref StopBeingPulledAlertEvent args)
     {
         if (args.Handled)
@@ -256,17 +240,6 @@ public sealed partial class PullingSystem : EntitySystem
         {
             TryStopPull(args.BlockingEntity, comp);
         }
-    }
-
-    private void AddPullVerbs(EntityUid uid, PullableComponent component, GetVerbsEvent<Verb> args)
-    {
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        // ES START
-        // No pull verbs
-        return;
-        // ES END
     }
 
     private void OnRefreshMovespeed(EntityUid uid, PullerComponent component, RefreshMovementSpeedModifiersEvent args)
@@ -492,8 +465,10 @@ public sealed partial class PullingSystem : EntitySystem
         return TogglePull((puller.Pulling.Value, pullable), pullerUid);
     }
 
-    public bool TryStartPull(EntityUid pullerUid, EntityUid pullableUid,
-        PullerComponent? pullerComp = null, PullableComponent? pullableComp = null)
+    public bool TryStartPull(EntityUid pullerUid,
+        EntityUid pullableUid,
+        PullerComponent? pullerComp = null,
+        PullableComponent? pullableComp = null)
     {
         if (!Resolve(pullerUid, ref pullerComp, false) ||
             !Resolve(pullableUid, ref pullableComp, false))
@@ -554,9 +529,11 @@ public sealed partial class PullingSystem : EntitySystem
         // joint state handling will manage its own state
         if (!_timing.ApplyingState)
         {
-            var joint = _joints.CreateDistanceJoint(pullableUid, pullerUid,
-                    pullablePhysics.LocalCenter, pullerPhysics.LocalCenter,
-                    id: pullableComp.PullJointId);
+            var joint = _joints.CreateDistanceJoint(pullableUid,
+                pullerUid,
+                pullablePhysics.LocalCenter,
+                pullerPhysics.LocalCenter,
+                id: pullableComp.PullJointId);
             joint.CollideConnected = false;
             // This maximum has to be there because if the object is constrained too closely, the clamping goes backwards and asserts.
             // Internally, the joint length has been set to the distance between the pivots.
@@ -605,8 +582,7 @@ public sealed partial class PullingSystem : EntitySystem
             Loc.GetString("getting-pulled-popup", ("puller", Identity.Entity(pullerUid, EntityManager)));
         _popup.PopupEntity(pullingMessage, pullableUid, pullableUid);
 
-        _adminLogger.Add(LogType.Action, LogImpact.Low,
-            $"{ToPrettyString(pullerUid):user} started pulling {ToPrettyString(pullableUid):target}");
+        _adminLogger.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(pullerUid):user} started pulling {ToPrettyString(pullableUid):target}");
         return true;
     }
 

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Administration.Logs;
 using Content.Shared.Alert;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Cuffs;
+using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.Hands;
 using Content.Shared.Hands.Components;
@@ -69,6 +70,7 @@ public sealed partial class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullerComponent, MobStateChangedEvent>(OnStateChanged, after: [typeof(MobThresholdSystem)]);
         SubscribeLocalEvent<PullerComponent, AfterAutoHandleStateEvent>(OnAfterState);
         SubscribeLocalEvent<PullerComponent, EntGotInsertedIntoContainerMessage>(OnPullerContainerInsert);
+        SubscribeLocalEvent<PullableComponent, ModifyUncuffDurationEvent>(OnModifyUncuffDuration);
         SubscribeLocalEvent<PullerComponent, EntityUnpausedEvent>(OnPullerUnpaused);
         SubscribeLocalEvent<PullerComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
         SubscribeLocalEvent<PullerComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);
@@ -206,6 +208,18 @@ public sealed partial class PullingSystem : EntitySystem
     private void OnPullableContainerInsert(Entity<PullableComponent> ent, ref EntGotInsertedIntoContainerMessage args)
     {
         TryStopPull(ent.Owner, ent.Comp);
+    }
+
+    private void OnModifyUncuffDuration(Entity<PullableComponent> ent, ref ModifyUncuffDurationEvent args)
+    {
+        if (!ent.Comp.BeingPulled)
+            return;
+
+        // We don't care if the person is being uncuffed by someone else
+        if (args.User != args.Target)
+            return;
+
+        args.Duration *= 2;
     }
 
     private void OnStopBeingPulledAlert(Entity<PullableComponent> ent, ref StopBeingPulledAlertEvent args)

--- a/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
+++ b/Content.Shared/Movement/Pulling/Systems/PullingSystem.cs
@@ -64,13 +64,13 @@ public sealed partial class PullingSystem : EntitySystem
         SubscribeLocalEvent<PullableComponent, CollisionChangeEvent>(OnPullableCollisionChange);
         SubscribeLocalEvent<PullableComponent, JointRemovedEvent>(OnJointRemoved);
         SubscribeLocalEvent<PullableComponent, EntGotInsertedIntoContainerMessage>(OnPullableContainerInsert);
+        SubscribeLocalEvent<PullableComponent, ModifyUncuffDurationEvent>(OnModifyUncuffDuration);
         SubscribeLocalEvent<PullableComponent, StopBeingPulledAlertEvent>(OnStopBeingPulledAlert);
         SubscribeLocalEvent<PullableComponent, GetInteractingEntitiesEvent>(OnGetInteractingEntities);
 
         SubscribeLocalEvent<PullerComponent, MobStateChangedEvent>(OnStateChanged, after: [typeof(MobThresholdSystem)]);
         SubscribeLocalEvent<PullerComponent, AfterAutoHandleStateEvent>(OnAfterState);
         SubscribeLocalEvent<PullerComponent, EntGotInsertedIntoContainerMessage>(OnPullerContainerInsert);
-        SubscribeLocalEvent<PullableComponent, ModifyUncuffDurationEvent>(OnModifyUncuffDuration);
         SubscribeLocalEvent<PullerComponent, EntityUnpausedEvent>(OnPullerUnpaused);
         SubscribeLocalEvent<PullerComponent, VirtualItemDeletedEvent>(OnVirtualItemDeleted);
         SubscribeLocalEvent<PullerComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovespeed);

--- a/Content.Shared/_Offbrand/Wounds/CryostasisFactorSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/CryostasisFactorSystem.cs
@@ -29,6 +29,11 @@ public sealed partial class CryostasisFactorSystem : EntitySystem
         if (!TryComp<TemperatureComponent>(ent, out var temp))
             return;
 
+        // es hack
+        // only function when inside cryopods, it feels bad elsewhere
+        if (!HasComp<InsideCryoPodComponent>(ent))
+            return;
+
         args.Multiplier *= Math.Max(ent.Comp.TemperatureCoefficient * temp.CurrentTemperature + ent.Comp.TemperatureConstant, 1);
     }
 }

--- a/Resources/Locale/en-US/_ES/radio/scrambler.ftl
+++ b/Resources/Locale/en-US/_ES/radio/scrambler.ftl
@@ -1,5 +1,5 @@
 es-radio-scrambler-repair-verb = Repair
 es-radio-scrambler-examine = {$hacked ->
-    [true] The processor is [color=crimson]hacked[/color] and need to be repaired!
-    *[false] The processoror is [color=limegreen]operational[/color].
+    [true] The processor is [color=crimson]malfunctioning[/color] and needs to be repaired!
+    *[false] The processor is [color=limegreen]operational[/color].
 }

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -33,7 +33,7 @@
   parent: Handcuffs
   components:
   - type: Handcuff
-    breakoutTime: 3
+    breakoutTime: 2
     cuffedRSI: Objects/Misc/cablecuffs.rsi
     bodyIconState: body-overlay
     color: forestgreen
@@ -147,7 +147,7 @@
     size: Normal
   - type: Handcuff
     cuffedRSI: Clothing/OuterClothing/Misc/straight_jacket.rsi
-    breakoutTime: 100
+    breakoutTime: 20
     cuffTime: 10
     uncuffTime: 10
     stunBonus: 4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -41,7 +41,7 @@
         Blunt: 5
   - type: Ensnaring
     freeTime: 2.0
-    breakoutTime: 3.5 #all bola should generally be fast to remove
+    breakoutTime: 1.5 #all bola should generally be fast to remove
     walkSpeed: 0.5 #makeshift bola shouldn't slow too much
     sprintSpeed: 0.5
     staminaDamage: 0 # anything but this is gamebreaking

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/bola.yml
@@ -40,7 +40,7 @@
       types:
         Blunt: 5
   - type: Ensnaring
-    freeTime: 2.0
+    freeTime: 1
     breakoutTime: 1.5 #all bola should generally be fast to remove
     walkSpeed: 0.5 #makeshift bola shouldn't slow too much
     sprintSpeed: 0.5

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -141,7 +141,7 @@
               amount: 2
           steps:
             - tool: Welding
-              doAfter: 6
+              doAfter: 8
 
     - node: wallChitin
       entity: WallSolidChitin

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -8,7 +8,7 @@
           steps:
             - material: Steel
               amount: 2
-              doAfter: 1
+              doAfter: 5
 
     - node: girder
       entity: Girder
@@ -35,7 +35,7 @@
           steps:
             - material: Steel
               amount: 2
-              doAfter: 2
+              doAfter: 10
 
         - to: reinforcedGirder
           completed:
@@ -141,7 +141,7 @@
               amount: 2
           steps:
             - tool: Welding
-              doAfter: 10
+              doAfter: 6
 
     - node: wallChitin
       entity: WallSolidChitin

--- a/Resources/Prototypes/_ES/Reagents/gases.yml
+++ b/Resources/Prototypes/_ES/Reagents/gases.yml
@@ -33,4 +33,4 @@
           reagent: Smoke
           min: 0.25
         emote: Cough
-        probability: 0.33
+        probability: 0.5

--- a/Resources/Prototypes/_ES/Reagents/gases.yml
+++ b/Resources/Prototypes/_ES/Reagents/gases.yml
@@ -31,6 +31,6 @@
         conditions:
         - !type:ReagentCondition
           reagent: Smoke
-          min: 0.25
+          min: 0.2
         emote: Cough
         probability: 0.5

--- a/Resources/Prototypes/_ES/Reagents/gases.yml
+++ b/Resources/Prototypes/_ES/Reagents/gases.yml
@@ -17,20 +17,20 @@
     Gas:
       effects:
       - !type:HealthChange
-        minScale: 0.25
+        minScale: 0.5
         ignoreResistances: true
         damage:
           types:
             Asphyxiation:
               2
       - !type:ESAddWound
-        minScale: 0.5
+        minScale: 1.5
         wound: ESWoundSmokeInhalation
-        probability: 0.33
+        probability: 0.2
       - !type:Emote
         conditions:
         - !type:ReagentCondition
           reagent: Smoke
-          min: 0.1
+          min: 0.25
         emote: Cough
-        probability: 0.05
+        probability: 0.33


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

fixes #1807 
fixes #1840 
fixes #1810 
fixes #1806 
fixes #1786 
fixes #1804 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Breaking out of cuffs, bolas, and welded/locked lockers is now significantly faster in all cases
- fix: Warp drive charge timer no longer ticks up while interrupted
- fix: Being in space no longer makes you take like 9999 minutes to die because of cryostasis
- tweak: Smoke inhalation now has a higher reagent threshold and you'll more reliably cough as a warning at lower thresholds
- tweak: Regular walls & girders now take longer to construct manually (without an RCD) and take less time to deconstruct