### PR TITLE
Force round end when all players are dead

### DIFF
--- a/Content.Server/_ES/Radstorm/ESRadstormRoundEndRuleSystem.cs
+++ b/Content.Server/_ES/Radstorm/ESRadstormRoundEndRuleSystem.cs
@@ -90,8 +90,6 @@ public sealed partial class ESRadstormRoundEndRuleSystem : GameRuleSystem<ESRads
         {
             component.RadstormNextDamageTickTime = _timing.CurTime + TimeSpan.FromSeconds(1);
 
-            // HELL EVERLASTING! DIE FOREVER!
-            var stillAlive = 0;
             // this should probably not be bounded to mobstate and instead be its own thing but whatever
             var killQuery = EntityQueryEnumerator<MobStateComponent, DamageableComponent, TransformComponent>();
             while (killQuery.MoveNext(out var mob, out var state, out var damageable, out var xform))
@@ -110,18 +108,22 @@ public sealed partial class ESRadstormRoundEndRuleSystem : GameRuleSystem<ESRads
                 if (TryComp<BrainDamageComponent>(mob, out var brainDamage))
                     _brainDamage.TryChangeBrainDamage((mob, brainDamage), brainDamage.MaxDamage / 20);
 
-                // only count mobs which actually end up taking damage from this
-                var dmg = _damage.ChangeDamage((mob, damageable), component.RadstormDamagePerSecond, true, false);
-                if (dmg.GetTotal() > FixedPoint2.Zero && state.CurrentState != MobState.Dead)
-                    stillAlive += 1;
+                _damage.ChangeDamage((mob, damageable), component.RadstormDamagePerSecond, true, false);
             }
+        }
 
-            // show is over
-            // (make sure we only actually do this if after time and not just deadly space)
-            // (i kind of implemented that in a weird way huh)
-            if (stillAlive == 0 && RadstormStarted((uid, component)))
-                _roundEnd.EndRound();
+        // If everyone's dead, end the round
+        var actorQuery = EntityQueryEnumerator<ActorComponent>();
+        var allDead = true;
+        while (actorQuery.MoveNext(out var mob, out _))
+        {
+            if (TryComp<MobStateComponent>(mob, out var state) && state.CurrentState != MobState.Dead)
+                allDead = false;
+        }
 
+        if (allDead)
+        {
+            _roundEnd.EndRound();
             return;
         }
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
If everyone dies the round ends. Yay!

Closes #1742

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The round now ends automatically when all players are dead.
