### PR TITLE
remove scientist from toast temporarily

### DIFF
--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 277.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/09/2026 09:54:51
-  entityCount: 14700
+  time: 05/16/2026 20:42:27
+  entityCount: 14694
 maps:
 - 3
 grids:
@@ -4737,11 +4737,6 @@ entities:
     - type: Transform
       pos: 3.5,-24.5
       parent: 2
-  - uid: 614
-    components:
-    - type: Transform
-      pos: 8.5,-8.5
-      parent: 2
 - proto: AirlockMaintSecLocked
   entities:
   - uid: 3226
@@ -4812,20 +4807,10 @@ entities:
     - type: Transform
       pos: 12.5,-14.5
       parent: 2
-- proto: AirlockScienceGlassLocked
-  entities:
   - uid: 655
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
       pos: 5.5,-14.5
-      parent: 2
-- proto: AirlockScienceLocked
-  entities:
-  - uid: 401
-    components:
-    - type: Transform
-      pos: 5.5,-10.5
       parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
@@ -38655,11 +38640,6 @@ entities:
     - type: Transform
       pos: 27.5,6.5
       parent: 2
-  - uid: 11868
-    components:
-    - type: Transform
-      pos: 6.5,-8.5
-      parent: 2
   - uid: 11869
     components:
     - type: Transform
@@ -39080,18 +39060,6 @@ entities:
       parent: 2
 - proto: ESPoweredLightDepartment
   entities:
-  - uid: 149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-6.5
-      parent: 2
-  - uid: 490
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-6.5
-      parent: 2
   - uid: 580
     components:
     - type: Transform
@@ -41040,6 +41008,12 @@ entities:
       parent: 2
 - proto: ESSpawnerRandomMaintDoorVariant
   entities:
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 2
   - uid: 184
     components:
     - type: Transform
@@ -41251,6 +41225,11 @@ entities:
     components:
     - type: Transform
       pos: 31.5,-4.5
+      parent: 2
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
       parent: 2
   - uid: 1099
     components:
@@ -44054,13 +44033,6 @@ entities:
     - type: Transform
       pos: -15.5,6.5
       parent: 2
-- proto: ESSpawnPointScientist
-  entities:
-  - uid: 598
-    components:
-    - type: Transform
-      pos: 4.5,-6.5
-      parent: 2
 - proto: ESSpawnPointSecurityOfficer
   entities:
   - uid: 7373
@@ -44839,15 +44811,10 @@ entities:
       parent: 2
 - proto: ExosuitFabricator
   entities:
-  - uid: 574
+  - uid: 401
     components:
     - type: Transform
-      pos: 4.5,-20.5
-      parent: 2
-  - uid: 575
-    components:
-    - type: Transform
-      pos: 5.5,-20.5
+      pos: 2.5,-38.5
       parent: 2
 - proto: ExtinguisherCabinetFilled
   entities:
@@ -60690,11 +60657,6 @@ entities:
     - type: Transform
       pos: -26.5,-25.5
       parent: 2
-  - uid: 404
-    components:
-    - type: Transform
-      pos: 4.5,-10.5
-      parent: 2
   - uid: 407
     components:
     - type: Transform
@@ -61254,6 +61216,12 @@ entities:
     components:
     - type: Transform
       pos: -24.5,-20.5
+      parent: 2
+  - uid: 3160
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-14.5
       parent: 2
   - uid: 3787
     components:
@@ -63175,11 +63143,6 @@ entities:
     - type: Transform
       pos: 21.5,-43.5
       parent: 2
-  - uid: 14446
-    components:
-    - type: Transform
-      pos: 4.5,-14.5
-      parent: 2
   - uid: 14549
     components:
     - type: Transform
@@ -64768,23 +64731,6 @@ entities:
     - type: Transform
       pos: -13.5,3.5
       parent: 2
-- proto: LockerScienceFilled
-  entities:
-  - uid: 5121
-    components:
-    - type: Transform
-      pos: 7.5,-5.5
-      parent: 2
-  - uid: 7282
-    components:
-    - type: Transform
-      pos: 7.5,-7.5
-      parent: 2
-  - uid: 7350
-    components:
-    - type: Transform
-      pos: 7.5,-6.5
-      parent: 2
 - proto: LockerSecurityFilled
   entities:
   - uid: 1404
@@ -64914,6 +64860,16 @@ entities:
     components:
     - type: Transform
       pos: 5.5,-23.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 5.5,-20.5
       parent: 2
   - uid: 6725
     components:
@@ -66582,6 +66538,18 @@ entities:
     - type: Transform
       pos: 4.5,-25.5
       parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 2
   - uid: 896
     components:
     - type: Transform
@@ -68020,10 +67988,11 @@ entities:
     - type: Transform
       pos: 6.5,-2.5
       parent: 2
-  - uid: 422
+  - uid: 614
     components:
     - type: Transform
-      pos: 4.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-14.5
       parent: 2
   - uid: 907
     components:
@@ -69149,11 +69118,6 @@ entities:
     components:
     - type: Transform
       pos: -45.5,-47.5
-      parent: 2
-  - uid: 11129
-    components:
-    - type: Transform
-      pos: 4.5,-14.5
       parent: 2
   - uid: 11391
     components:
@@ -72391,13 +72355,6 @@ entities:
     components:
     - type: Transform
       pos: -23.5,-8.5
-      parent: 2
-- proto: SpawnMobSmile
-  entities:
-  - uid: 3160
-    components:
-    - type: Transform
-      pos: 6.5,-7.5
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
@@ -81395,6 +81352,11 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-2.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
       parent: 2
   - uid: 604
     components:

--- a/Resources/Prototypes/_ES/Maps/toast.yml
+++ b/Resources/Prototypes/_ES/Maps/toast.yml
@@ -13,7 +13,7 @@
         nameGenerator:
           !type:ESSimpleNameGenerator
       - type: StationJobs
-        availableJobs: # 23 jobs total
+        availableJobs: # 20 jobs total
           #command (2)
           ESCaptain: [ 1, 1 ]
           ESHeadOfPersonnel: [ 1, 1 ]
@@ -27,8 +27,8 @@
           ESDoctor: [ 2, 2 ]
           ESParamedic: [ 1, 1 ]
           ESCoroner: [ 1, 1 ]
-          #science (3)
-          ESScientist: [ 3, 3 ]
+          #science (3), temporarily disabled
+          # ESScientist: [ 3, 3 ]
           #security (4)
           ESSecurityOfficer: [ 3, 3 ]
           ESDetective: [ 1, 1 ]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
removes scientist from toast temporarily

robotics is still accessible but no longer has the exofab. it has been moved to cargo. the parts vendor is still there cus i didnt know where to put it in cargo

the top room has been hastily converted in to a maintenance room. all of the scientist lockers have been removed and it has dim lighting and smile + the warp point there are kil.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Temporarily removed scientists. 