### PR TITLE
fix: APC sprites stuck in fully drained states on round start (wizden port 42852)

### DIFF
--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -84,7 +84,8 @@ public sealed partial class ApcSystem : EntitySystem
     // Change the APC's state only when the battery state changes, or when it's first created.
     private void OnBatteryChargeChanged(EntityUid uid, ApcComponent component, ref ChargeChangedEvent args)
     {
-        UpdateApcState(uid, component);
+        // Defer until the next tick.
+        component.NeedStateUpdate = true;
     }
 
     private static void OnApcStartup(EntityUid uid, ApcComponent component, ComponentStartup args)


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

* Fix APC incorrect charge state caused by race condition on map startup

* fix: Defer the update from ChargeChangedEvent to next tick

ports this pr because i notice this bug all the time and it annoys me

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

