### PR TITLE
Fix immortal psychids

### DIFF
--- a/Content.Server/_ES/Masks/Psychid/ESPsychidSystem.cs
+++ b/Content.Server/_ES/Masks/Psychid/ESPsychidSystem.cs
@@ -23,11 +23,13 @@ public sealed partial class ESPsychidSystem : EntitySystem
 
     private void OnKillReported(Entity<ESPsychidComponent> ent, ref ESPlayerKilledEvent args)
     {
-        if (!args.ValidKill || !_mind.TryGetMind(args.Killer.Value, out var killerMind))
+        if (!args.ValidKill ||
+            !_mind.TryGetMind(args.Killer.Value, out var killerMind) ||
+            _mask.GetTroupeOrNull(killerMind.Value.AsNullable()) == ent.Comp.IgnoredTroupe)
+        {
+            ent.Comp.KillerMind = null;
             return;
-
-        if (_mask.GetTroupeOrNull(killerMind.Value.AsNullable()) == ent.Comp.IgnoredTroupe)
-            return;
+        }
 
         ent.Comp.KillerMind = killerMind;
 
@@ -58,6 +60,9 @@ public sealed partial class ESPsychidSystem : EntitySystem
 
         _mask.ChangeMask((killerMind, killerMindComp), victimMask.Value);
         _mind.SwapMinds(killerMind, killerBody, ent.Owner, ownedEntity);
+
+        // Reset this so we don't hold a reference
+        ent.Comp.KillerMind = null;
 
         args.Handled = true;
         args.Result = true;


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1847 

ok i didnt test this but im 99% sure this is what caused the weird psychid round.

essentially after one kill, the KillerMind field gets set on the comp and then never gets unset.
This means that every subsequent kill will have a valid KillerMind value regardless of whether or not the kill was valid. since the swapping happens in the ghost attempt rather than the kill reporting, this allowed psychids who were killed once to basically never actually die. oops.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Psychids no longer become immortal after being killed.