### PR TITLE
remove throwing damage from cans

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_base_materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_base_materials.yml
@@ -109,10 +109,6 @@
     damage:
       types:
         Blunt: 1
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 2
   - type: PhysicalComposition
     materialComposition:
       Plastic: 25
@@ -184,10 +180,6 @@
     damage:
       types:
         Blunt: 1
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 1
   - type: PhysicalComposition
     materialComposition:
       Cardboard: 25
@@ -223,10 +215,6 @@
     damage:
       types:
         Blunt: 1
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 5
   - type: PhysicalComposition
     materialComposition:
       Steel: 25


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
title
it really really sucked because people would throw them willy nilly on the shuttle and cause like 50 damage per throw since everyone was bunched up
left it on glass and gold because they break as soon as they're thrown
possibly could just make it do like 1 damage on throw so its still something 
the whole drinks section needs a yml overhaul because the parenting sucks 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: cans no longer deal damage upon being thrown
