### PR TITLE
readd crewmember to masquerades

### DIFF
--- a/Resources/Prototypes/_ES/Masks/crew.yml
+++ b/Resources/Prototypes/_ES/Masks/crew.yml
@@ -21,7 +21,7 @@
   troupe: Crew
   description: es-mask-arsonist-desc
   color: red
-  weight: 0.75
+  weight: 0.33
   objectives:
     id: ESObjectiveArsonistLightFires
 
@@ -39,7 +39,7 @@
   name: es-mask-crewmember-name
   troupe: Crew
   description: es-mask-crewmember-desc
-  weight: 0.33
+  weight: 1
   color: white
 
 - type: esMask

--- a/Resources/Prototypes/_ES/Masks/crew.yml
+++ b/Resources/Prototypes/_ES/Masks/crew.yml
@@ -39,7 +39,7 @@
   name: es-mask-crewmember-name
   troupe: Crew
   description: es-mask-crewmember-desc
-  weight: 1
+  weight: 2
   color: white
 
 - type: esMask


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
crewmember is now 2 weight instead of 0.33, and arsonist is now 0.33 weight instead of 0.75. the game was too chaotic so hopefully this will help

```> mq:sim Traitors 30 1000
Sympathizer (Traitor): μ=1.5970, σ=0.6949,
Infiltrator (Traitor): μ=1.5480, σ=0.6369,
Marauder (Traitor): μ=1.5360, σ=0.6170,
Assassin (Traitor): μ=1.5300, σ=0.6222,
Subverter (Traitor): μ=0.2570, σ=0.4180,
Demolitionist (Traitor): μ=0.1290, σ=0.3313,
Crewmember (Crew): μ=2.9960, σ=1.5039,
Vigilante (Crew): μ=2.4920, σ=1.2437,
Mercenary (Crew): μ=2.2270, σ=1.1925,
Rebel (Crew): μ=2.1260, σ=1.0140,
Hater (Crew): μ=2.0060, σ=1.1257,
Avenger (Crew): μ=1.9290, σ=1.1259,
Pickpocket (Crew): μ=1.9290, σ=1.0538,
Secretary (Crew): μ=1.7580, σ=1.0023,
ArmsDealer (Crew): μ=1.4440, σ=0.9467,
SleeperAgent (Crew): μ=1.4030, σ=0.6582,
VIP (Crew): μ=1.0390, σ=0.5902,
Arsonist (Crew): μ=0.7470, σ=0.6624,
Phantom (Crew): μ=0.7350, σ=0.7066,
Nobleman (Crew): μ=0.3550, σ=0.5127,
Guzzler (Crew): μ=0.2170, σ=0.4288
```

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Crewmember is now more common in masquerades, and arsonist is now less common.
