### PR TITLE
Pickpocket adjustments

### DIFF
--- a/Content.Client/DoAfter/DoAfterOverlay.cs
+++ b/Content.Client/DoAfter/DoAfterOverlay.cs
@@ -78,6 +78,9 @@ public sealed class DoAfterOverlay : Overlay
             if (xform.MapID != args.MapId)
                 continue;
 
+            if (!sprite.Visible)
+                continue;
+
             if (comp.DoAfters.Count == 0)
                 continue;
 

--- a/Content.Server/_ES/Masks/Pickpocket/ESPickpocketMaskSystem.cs
+++ b/Content.Server/_ES/Masks/Pickpocket/ESPickpocketMaskSystem.cs
@@ -31,7 +31,7 @@ public sealed partial class ESPickpocketMaskSystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<ESPickpocketTargetActionEvent>(OnPickpocketTargetAction);
-        SubscribeLocalEvent<DoAfterComponent, ESPickpocketTargetDoAfterEvent>(OnPickpocketTargetDoAfter);
+        SubscribeLocalEvent<ESPickpocketTargetDoAfterEvent>(OnPickpocketTargetDoAfter);
         SubscribeLocalEvent<DoAfterAttemptEvent<ESPickpocketTargetDoAfterEvent>>(OnDoAfterAttempt);
     }
 
@@ -65,17 +65,17 @@ public sealed partial class ESPickpocketMaskSystem : EntitySystem
             args.Performer,
             args.Delay,
             new ESPickpocketTargetDoAfterEvent(),
-            args.Performer,
+            null,
             args.Target)
         {
             AttemptFrequency = AttemptFrequency.EveryTick,
             DuplicateCondition = DuplicateConditions.SameEvent,
             BreakOnMove = true,
-            Hidden = true,
+            Broadcast = true,
         });
     }
 
-    private void OnPickpocketTargetDoAfter(Entity<DoAfterComponent> ent, ref ESPickpocketTargetDoAfterEvent args)
+    private void OnPickpocketTargetDoAfter(ESPickpocketTargetDoAfterEvent args)
     {
         if (args.Cancelled || args.Target is not { } target)
             return;

--- a/Content.Shared/_ES/Masks/Pickpocket/ESPickpocketTargetActionEvent.cs
+++ b/Content.Shared/_ES/Masks/Pickpocket/ESPickpocketTargetActionEvent.cs
@@ -7,7 +7,7 @@ namespace Content.Shared._ES.Masks.Pickpocket;
 public sealed partial class ESPickpocketTargetActionEvent : EntityTargetActionEvent
 {
     [DataField]
-    public TimeSpan Delay = TimeSpan.FromSeconds(2);
+    public TimeSpan Delay = TimeSpan.FromSeconds(3);
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Prototypes/_ES/Actions/Masks/pickpocket.yml
+++ b/Resources/Prototypes/_ES/Actions/Masks/pickpocket.yml
@@ -11,7 +11,6 @@
     iconOn:
       sprite: _ES/Actions/masks/pickpocket.rsi
       state: pickpocket-on
-    useDelay: 30
   - type: TargetAction
   - type: EntityTargetAction
     event: !type:ESPickpocketTargetActionEvent

--- a/Resources/Prototypes/_ES/Actions/Masks/pickpocket.yml
+++ b/Resources/Prototypes/_ES/Actions/Masks/pickpocket.yml
@@ -11,6 +11,7 @@
     iconOn:
       sprite: _ES/Actions/masks/pickpocket.rsi
       state: pickpocket-on
+    useDelay: 30
   - type: TargetAction
   - type: EntityTargetAction
     event: !type:ESPickpocketTargetActionEvent

--- a/Resources/Prototypes/_ES/Objectives/Crew/pickpocket.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/pickpocket.yml
@@ -12,6 +12,5 @@
   - type: ESCounterObjective
     title: es-pickpocket-steal-objective-title
   - type: ESPopulationProportionCounterObjective
-    proportion: 0.5
     minimum: 2
     maximum: 6


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1899 
Closes #1898 

changes:
- Increase pickpocketing doafter from 2 to 3 seconds
- Pickpocket doafter is no longer hidden
- Fixed pickpocketing not cancelling when seen
- Fixed pickpocket objective scaling too aggressively at lowpop
- Fixed doafters being visible when someone is hidden via a viewcone

generally i think pickpocketing is just too easy and thus kinda lame and not really as impactful as it should be. even not considering the bug, it's fairly trivial to just run around and scoop up items when someone is sat down or whatever on the shuttle.

hopefully with this, it'll actually be a bit more challenging to win and get items as a pickpocket

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Pickpocketing now takes slightly longer and can be seen by other players.
- tweak: Reduced pickpocket objective count at lower player counts.
- fix: Fixed being able to see doafters of players hidden outside the viewcone.
