### PR TITLE
Arsonist tweaks

### DIFF
--- a/Content.Server/_ES/Masks/Objectives/Relays/ESTileFireRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESTileFireRelaySystem.cs
@@ -20,7 +20,7 @@ public sealed class ESTileFireRelaySystem : ESBaseMindRelay
         if (!TryGetMind(ent, out var mind))
             return;
 
-        var ev = new ESBodyCreatedTileFireEvent(args.Coordinates, ent, args.Stage);
+        var ev = new ESBodyCreatedTileFireEvent(args.Coordinates, ent);
         RaiseMindEvent(mind.Value, ref ev);
     }
 
@@ -38,7 +38,7 @@ public sealed class ESTileFireRelaySystem : ESBaseMindRelay
 }
 
 [ByRefEvent]
-public readonly record struct ESBodyCreatedTileFireEvent(EntityCoordinates Coordinates, EntityUid User, int Stage = 1);
+public readonly record struct ESBodyCreatedTileFireEvent(EntityCoordinates Coordinates, EntityUid User);
 
 [ByRefEvent]
 public readonly record struct ESBodyExtinguishedTileFireEvent(EntityUid Fire, EntityUid User);

--- a/Content.Server/_ES/TileFires/ESTileFireSystem.cs
+++ b/Content.Server/_ES/TileFires/ESTileFireSystem.cs
@@ -1,4 +1,3 @@
-using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Spreader;
 using Content.Shared._ES.TileFires;
@@ -27,7 +26,7 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private IGameTiming _timing = default!;
 
-    private static EntProtoId _stage1Fire = "ESTileFire";
+    private static readonly EntProtoId Stage1Fire = "ESTileFire";
 
     public override void Initialize()
     {
@@ -137,7 +136,16 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
                 return;
 
             var coords = _random.PickAndTake(weights);
-            Spawn(ent.Comp.Prototype, coords);
+            var fire = Spawn(ent.Comp.Prototype, coords);
+
+            if (ent.Comp.Origin is { } origin)
+            {
+                EnsureComp<ESTileFireComponent>(fire).Origin = origin;
+                EnsureComp<ESTileFireOriginComponent>(origin).Fires.Add(fire);
+
+                var ev = new ESTileFireCreatedEvent(coords, origin);
+                RaiseLocalEvent(origin, ref ev);
+            }
 
             _flammable.AdjustFireStacks(ent, _random.NextFloat(0.25f, 1.25f) * -ent.Comp.FirestacksRemoveOnSpread, flammable);
             args.Updates--;
@@ -160,13 +168,16 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
             return false;
 
         // ESTileFire vs ESTileFireStage2/3/4
-        EntProtoId proto = stage == 1 ? _stage1Fire : $"{_stage1Fire}Stage{stage}";
+        EntProtoId proto = stage == 1 ? Stage1Fire : $"{Stage1Fire}Stage{stage}";
 
-        SpawnAtPosition(proto, coords);
+        var fire = SpawnAtPosition(proto, coords);
 
         if (originatingUser.HasValue)
         {
-            var ev = new ESTileFireCreatedEvent(coords, originatingUser, stage);
+            EnsureComp<ESTileFireComponent>(fire).Origin = originatingUser;
+            EnsureComp<ESTileFireOriginComponent>(originatingUser.Value).Fires.Add(fire);
+
+            var ev = new ESTileFireCreatedEvent(coords, originatingUser);
             RaiseLocalEvent(originatingUser.Value, ref ev);
         }
         return true;

--- a/Content.Shared/_ES/TileFires/ESSharedTileFireSystem.cs
+++ b/Content.Shared/_ES/TileFires/ESSharedTileFireSystem.cs
@@ -2,8 +2,6 @@ using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
-using Robust.Shared.Network;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared._ES.TileFires;
 
@@ -15,7 +13,6 @@ public abstract partial class ESSharedTileFireSystem : EntitySystem
 {
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] protected SharedMapSystem MapSys = default!;
-    [Dependency] protected SharedTransformSystem XformSys = default!;
 
     public override void Initialize()
     {
@@ -23,6 +20,9 @@ public abstract partial class ESSharedTileFireSystem : EntitySystem
 
         // appearance on startup
         SubscribeLocalEvent<FlammableComponent, ComponentStartup>(OnStartup);
+
+        SubscribeLocalEvent<ESTileFireComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<ESTileFireOriginComponent, ComponentShutdown>(OnOriginShutdown);
     }
 
     #region Events
@@ -35,6 +35,21 @@ public abstract partial class ESSharedTileFireSystem : EntitySystem
 
         _appearance.SetData(ent, FireVisuals.OnFire, flammable.OnFire, appearance);
         _appearance.SetData(ent, FireVisuals.FireStacks, (int) MathF.Floor(flammable.FireStacks / flammable.FirestackVisualDivisor), appearance);
+    }
+
+    private void OnShutdown(Entity<ESTileFireComponent> ent, ref ComponentShutdown args)
+    {
+        if (TryComp<ESTileFireOriginComponent>(ent.Comp.Origin, out var comp))
+            comp.Fires.Remove(ent);
+    }
+
+    private void OnOriginShutdown(Entity<ESTileFireOriginComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var fire in ent.Comp.Fires)
+        {
+            if (TryComp<ESTileFireComponent>(fire, out var comp))
+                comp.Origin = null;
+        }
     }
     #endregion
 
@@ -65,5 +80,4 @@ public abstract partial class ESSharedTileFireSystem : EntitySystem
 [ByRefEvent]
 public record struct ESTileFireCreatedEvent(
     EntityCoordinates Coordinates,
-    EntityUid? OriginatingUser = null,
-    int Stage = 1);
+    EntityUid? OriginatingUser = null);

--- a/Content.Shared/_ES/TileFires/ESTileFireComponent.cs
+++ b/Content.Shared/_ES/TileFires/ESTileFireComponent.cs
@@ -1,6 +1,5 @@
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization;
 
 namespace Content.Shared._ES.TileFires;
 
@@ -45,4 +44,7 @@ public sealed partial class ESTileFireComponent : Component
     /// </summary>
     [DataField, AutoPausedField]
     public TimeSpan SmolderTime;
+
+    [DataField]
+    public EntityUid? Origin;
 }

--- a/Content.Shared/_ES/TileFires/ESTileFireOriginComponent.cs
+++ b/Content.Shared/_ES/TileFires/ESTileFireOriginComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared._ES.TileFires;
+
+[RegisterComponent]
+public sealed partial class ESTileFireOriginComponent : Component
+{
+    [DataField]
+    public List<EntityUid> Fires = new();
+}

--- a/Resources/Prototypes/_ES/Objectives/Crew/arsonist.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/arsonist.yml
@@ -11,6 +11,6 @@
   - type: ESCreateTileFireObjective
   - type: ESCounterObjective
     title: es-arsonist-light-fires-objective-title
-    target: 32
-    maxTarget: 52
-    targetIncrement: 2
+    target: 64
+    maxTarget: 112
+    targetIncrement: 8


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1876 

changes:
- objective now ticks for fire spreading
- increased objective limit

arsonist's objective completion is not even remotely proportional to the amount of damage they cause which is stupid. whole damn station on fire and they dont get a win for it what the FUCK.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Arsonists' objective now progresses when their fire spreads. To compensate, they need to create more fires.
