### PR TITLE
Fix facial hair generation

### DIFF
--- a/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.Appearance.cs
+++ b/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.Appearance.cs
@@ -150,7 +150,14 @@ public abstract partial class ESSharedAuditionsSystem
         profile.Appearance.HairStyleId = random.Pick(hairOptions);
 
         if (random.Prob(ShavenChance))
+        {
             profile.Appearance.FacialHairStyleId = HairStyles.DefaultFacialHairStyle;
+        }
+        else if (sex != Sex.Female)
+        {
+            var facialHairStyles = _marking.MarkingsByCategoryAndSpecies(MarkingCategories.FacialHair, speciesId).Keys.ToList();
+            profile.Appearance.FacialHairStyleId = random.Pick(facialHairStyles);
+        }
 
         return profile;
     }

--- a/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.cs
+++ b/Content.Shared/_ES/Auditions/ESSharedAuditionsSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Shared._ES.Auditions.Components;
 using Content.Shared._ES.CCVar;
 using Content.Shared.GameTicking;
+using Content.Shared.Humanoid.Markings;
 using Content.Shared.Mind;
 using Content.Shared.Roles.Jobs;
 using Robust.Shared.Configuration;
@@ -16,6 +17,7 @@ namespace Content.Shared._ES.Auditions;
 public abstract partial class ESSharedAuditionsSystem : EntitySystem
 {
     [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private MarkingManager _marking = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private SharedJobSystem _job = default!;
     [Dependency] private SharedMindSystem _mind = default!;


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Facial hair generation broke in #731 when we stopped using the RandomWithSpecies function and instead individually generated all the visual aspects of the character. Facial hair is apparently one of the things that we don't have custom logic for, so when we removed that, it stopped showing up entirely.

now we just randomly pick some facial hair if the character is male or nonbinary, so hopefully we'll actually see facial hair again.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="678" height="502" alt="image" src="https://github.com/user-attachments/assets/24a991e0-d604-4498-be6f-9c292d0904d0" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Characters now generate with facial hair again.
