### PR TITLE
Correct popup prediction

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Content.Shared.Containers;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Popups;
@@ -36,6 +35,8 @@ namespace Content.Client.Popups
 
         private readonly Dictionary<WorldPopupData, WorldPopupLabel> _aliveWorldLabels = new();
         private readonly Dictionary<CursorPopupData, CursorPopupLabel> _aliveCursorLabels = new();
+
+        private readonly HashSet<IPopupPredictionInstance> _predictionInstances = new();
 
         public const float MinimumPopupLifetime = 0.7f;
         public const float MaximumPopupLifetime = 5f;
@@ -84,9 +85,9 @@ namespace Content.Client.Popups
             if (recordReplay && _replayRecording.IsRecording)
             {
                 if (entity != null)
-                    _replayRecording.RecordClientMessage(new PopupEntityEvent(message, type, GetNetEntity(entity.Value)));
+                    _replayRecording.RecordClientMessage(new PopupEntityEvent(message, type, Timing.CurTick, GetNetEntity(entity.Value)));
                 else
-                    _replayRecording.RecordClientMessage(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)));
+                    _replayRecording.RecordClientMessage(new PopupCoordinatesEvent(message, type, Timing.CurTick, GetNetCoordinates(coordinates)));
             }
 
             var popupData = new WorldPopupData(message, type, coordinates, entity);
@@ -123,19 +124,13 @@ namespace Content.Client.Popups
                 PopupMessage(message, type, coordinates, null, true);
         }
 
-        public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient != null && _timing.IsFirstTimePredicted)
-                PopupCoordinates(message, coordinates, recipient.Value, type);
-        }
-
         private void PopupCursorInternal(string? message, PopupType type, bool recordReplay)
         {
             if (message == null)
                 return;
 
             if (recordReplay && _replayRecording.IsRecording)
-                _replayRecording.RecordClientMessage(new PopupCursorEvent(message, type));
+                _replayRecording.RecordClientMessage(new PopupCursorEvent(message, type, Timing.CurTick));
 
             var popupData = new CursorPopupData(message, type);
             if (_aliveCursorLabels.TryGetValue(popupData, out var existingLabel))
@@ -173,16 +168,6 @@ namespace Content.Client.Popups
                 PopupCursor(message, type);
         }
 
-        public override void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
-        {
-            PopupCursor(message, recipient, type);
-        }
-
-        public override void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
-        {
-            PopupCursor(message, recipient, type);
-        }
-
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, Filter filter, bool replayRecord, PopupType type = PopupType.Small)
         {
             PopupCoordinates(message, coordinates, type);
@@ -208,55 +193,16 @@ namespace Content.Client.Popups
             PopupEntity(message, uid, type);
         }
 
-        public override void PopupClient(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient == null)
-                return;
-
-            if (_timing.IsFirstTimePredicted)
-                PopupCursor(message, recipient.Value, type);
-        }
-
-        public override void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient == null)
-                return;
-
-            if (_timing.IsFirstTimePredicted)
-                PopupEntity(message, uid, recipient.Value, type);
-        }
-
-        public override void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient == null)
-                return;
-
-            if (_timing.IsFirstTimePredicted)
-                PopupCoordinates(message, coordinates, recipient.Value, type);
-        }
-
         public override void PopupEntity(string? message, EntityUid uid, PopupType type = PopupType.Small)
         {
-            if (TryComp(uid, out TransformComponent? transform))
-                PopupMessage(message, type, transform.Coordinates, uid, true);
-        }
+            if (message is null || !Timing.IsFirstTimePredicted)
+                return;
 
-        public override void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient != null && _timing.IsFirstTimePredicted)
-                PopupEntity(message, uid, recipient.Value, type);
-        }
+            if (!TryComp(uid, out TransformComponent? transform))
+                return;
 
-        public override void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, Filter filter, bool recordReplay, PopupType type = PopupType.Small)
-        {
-            if (recipient != null && _timing.IsFirstTimePredicted)
-                PopupEntity(message, uid, recipient.Value, type);
-        }
-
-        public override void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient != null && _timing.IsFirstTimePredicted)
-                PopupEntity(recipientMessage, uid, recipient.Value, type);
+            _predictionInstances.Add(new PopupEntityEvent.PredictionInstance(message, type, Timing.CurTick, GetNetEntity(uid)));
+            PopupMessage(message, type, transform.Coordinates, uid, true);
         }
 
         #endregion
@@ -275,6 +221,10 @@ namespace Content.Client.Popups
 
         private void OnPopupEntityEvent(PopupEntityEvent ev)
         {
+            var instance = new PopupEntityEvent.PredictionInstance(ev.Message, ev.Type, ev.Tick, ev.Uid);
+            if (_predictionInstances.Remove(instance))
+                return;
+
             var entity = GetEntity(ev.Uid);
 
             if (TryComp(entity, out TransformComponent? transform))

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -183,7 +183,7 @@ namespace Content.Client.Popups
             PopupCoordinates(message, coordinates, type);
         }
 
-        public override void PopupEntity(string? message, EntityUid uid, EntityUid recipient, PopupType type = PopupType.Small)
+        public override void PopupEntity(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
         {
             if (_playerManager.LocalEntity == recipient)
                 PopupEntity(message, uid, type);

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -152,7 +152,12 @@ namespace Content.Client.Popups
             _aliveCursorLabels.Add(popupData, label);
         }
 
-        public override void PopupCursor(string? message, PopupType type = PopupType.Small)
+        /// <summary>
+        ///     Shows a popup at the local users' cursor. Does nothing on the server.
+        /// </summary>
+        /// <param name="message">The message to display.</param>
+        /// <param name="type">Used to customize how this popup should appear visually.</param>
+        public void PopupCursor(string? message, PopupType type = PopupType.Small)
         {
             if (!_timing.IsFirstTimePredicted || message is null)
                 return;

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -109,6 +109,10 @@ namespace Content.Client.Popups
         #region Abstract Method Implementations
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, PopupType type = PopupType.Small)
         {
+            if (!Timing.IsFirstTimePredicted || message is null)
+                return;
+
+            _predictionInstances.Add(new PopupCoordinatesEvent.PredictionInstance(message, type, Timing.CurTick, GetNetCoordinates(coordinates)));
             PopupMessage(message, type, coordinates, null, true);
         }
 
@@ -221,6 +225,10 @@ namespace Content.Client.Popups
 
         private void OnPopupCoordinatesEvent(PopupCoordinatesEvent ev)
         {
+            var instance = new PopupCoordinatesEvent.PredictionInstance(ev.Message, ev.Type, ev.Tick, ev.Coordinates);
+            if (_predictionInstances.Remove(instance))
+                return;
+
             PopupMessage(ev.Message, ev.Type, GetCoordinates(ev.Coordinates), null, false);
         }
 

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -150,9 +150,10 @@ namespace Content.Client.Popups
 
         public override void PopupCursor(string? message, PopupType type = PopupType.Small)
         {
-            if (!_timing.IsFirstTimePredicted)
+            if (!_timing.IsFirstTimePredicted || message is null)
                 return;
 
+            _predictionInstances.Add(new PopupCursorEvent.PredictionInstance(message, type, Timing.CurTick));
             PopupCursorInternal(message, type, true);
         }
 
@@ -211,6 +212,10 @@ namespace Content.Client.Popups
 
         private void OnPopupCursorEvent(PopupCursorEvent ev)
         {
+            var instance = new PopupCursorEvent.PredictionInstance(ev.Message, ev.Type, ev.Tick);
+            if (_predictionInstances.Remove(instance))
+                return;
+
             PopupCursorInternal(ev.Message, ev.Type, false);
         }
 

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -172,7 +172,7 @@ namespace Content.Client.Popups
                 PopupCursor(message, type);
         }
 
-        public override void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+        public override void PopupCursor(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
         {
             if (_playerManager.LocalEntity == recipient)
                 PopupCursor(message, type);

--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Client.Popups
         private readonly Dictionary<WorldPopupData, WorldPopupLabel> _aliveWorldLabels = new();
         private readonly Dictionary<CursorPopupData, CursorPopupLabel> _aliveCursorLabels = new();
 
-        private readonly HashSet<IPopupPredictionInstance> _predictionInstances = new();
+        private readonly List<IPopupPredictionInstance> _predictionInstances = new();
 
         public const float MinimumPopupLifetime = 0.7f;
         public const float MaximumPopupLifetime = 5f;
@@ -266,6 +266,11 @@ namespace Content.Client.Popups
 
         public override void FrameUpdate(float frameTime)
         {
+            if (_predictionInstances.Count != 0)
+            {
+                _predictionInstances.RemoveAll(p => (int) Timing.CurTick.Value - (int) p.Tick.Value > 5000);
+            }
+
             if (_aliveWorldLabels.Count == 0 && _aliveCursorLabels.Count == 0)
                 return;
 

--- a/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
+++ b/Content.Client/Power/ActivatableUIRequiresPowerSystem.cs
@@ -19,7 +19,7 @@ public sealed partial class ActivatableUIRequiresPowerSystem : SharedActivatable
         }
 
         if (!args.Silent)
-            _popup.PopupClient(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent.Owner)), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent.Owner)), args.User, args.User);
 
         args.Cancel();
     }

--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -135,7 +135,7 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
 
         // Popup message
         var popup = EntMan.System<PopupSystem>();
-        popup.PopupClient(msg, Owner, _playerManager.LocalSession.AttachedEntity);
+        popup.PopupEntity(msg, Owner, _playerManager.LocalSession.AttachedEntity);
     }
 
     private string GetTooltip(RCDPrototype proto)

--- a/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
+++ b/Content.Client/_ES/Internals/Ui/ESInternalsUIController.cs
@@ -59,7 +59,7 @@ public sealed partial class ESInternalsUIController : UIController, IOnStateChan
         // If they can't connect to a tank, notify them!
         if (internals.BreathTools.Count == 0)
         {
-            _popup.PopupPredictedCursor(Loc.GetString("internals-self-no-breath-tool"), player, PopupType.Medium);
+            _popup.PopupCursor(Loc.GetString("internals-self-no-breath-tool"), player, PopupType.Medium);
             return true;
         }
 
@@ -105,7 +105,7 @@ public sealed partial class ESInternalsUIController : UIController, IOnStateChan
         switch (tanks.Count)
         {
             case 0:
-                _popup.PopupPredictedCursor(Loc.GetString("internals-self-no-tank"), player, PopupType.Medium);
+                _popup.PopupCursor(Loc.GetString("internals-self-no-tank"), player, PopupType.Medium);
                 break;
             case 1:
                 SendToggleMessage(tanks.First().Tank);

--- a/Content.Client/_ES/Lighting/Ui/ESFlashlightUIController.cs
+++ b/Content.Client/_ES/Lighting/Ui/ESFlashlightUIController.cs
@@ -64,7 +64,7 @@ public sealed partial class ESFlashlightUIController : UIController, IOnStateCha
         }
         else
         {
-            _popup.PopupPredictedCursor(Loc.GetString("es-flashlight-popup-no-flashlight"), player, PopupType.Medium);
+            _popup.PopupCursor(Loc.GetString("es-flashlight-popup-no-flashlight"), player, PopupType.Medium);
         }
         return true;
     }

--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -103,10 +103,10 @@ namespace Content.Server.Pointing.EntitySystems
                 // Someone pointing at YOU is slightly more important
                 var popupType = viewerEntity == pointed ? PopupType.Medium : PopupType.Small;
 
-                RaiseNetworkEvent(new PopupEntityEvent(message, popupType, netSource), viewerEntity);
+                RaiseNetworkEvent(new PopupEntityEvent(message, popupType, _gameTiming.CurTick,  netSource), viewerEntity);
             }
 
-            _replay.RecordServerMessage(new PopupEntityEvent(viewerMessage, PopupType.Small, netSource));
+            _replay.RecordServerMessage(new PopupEntityEvent(viewerMessage, PopupType.Small, _gameTiming.CurTick, netSource));
         }
 
         public bool InRange(EntityUid pointer, EntityCoordinates coordinates)

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -20,7 +20,7 @@ namespace Content.Server.Popups
             RaiseNetworkEvent(new PopupCursorEvent(message, type, Timing.CurTick), recipient);
         }
 
-        public override void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+        public override void PopupCursor(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
         {
             if (message == null)
                 return;

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -12,11 +12,6 @@ namespace Content.Server.Popups
         [Dependency] private IConfigurationManager _cfg = default!;
         [Dependency] private SharedTransformSystem _transform = default!;
 
-        public override void PopupCursor(string? message, PopupType type = PopupType.Small)
-        {
-            // No local user.
-        }
-
         public override void PopupCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
         {
             if (message == null)

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -1,5 +1,4 @@
 using Content.Shared.Popups;
-using Robust.Server.GameObjects;
 using Robust.Server.Player;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -23,7 +22,7 @@ namespace Content.Server.Popups
             if (message == null)
                 return;
 
-            RaiseNetworkEvent(new PopupCursorEvent(message, type), recipient);
+            RaiseNetworkEvent(new PopupCursorEvent(message, type, Timing.CurTick), recipient);
         }
 
         public override void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
@@ -32,17 +31,7 @@ namespace Content.Server.Popups
                 return;
 
             if (TryComp(recipient, out ActorComponent? actor))
-                RaiseNetworkEvent(new PopupCursorEvent(message, type), actor.PlayerSession);
-        }
-
-        public override void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
-        {
-            // Do nothing, since the client already predicted the popup.
-        }
-
-        public override void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
-        {
-            // Do nothing, since the client already predicted the popup.
+                RaiseNetworkEvent(new PopupCursorEvent(message, type, Timing.CurTick), actor.PlayerSession);
         }
 
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, Filter filter, bool replayRecord, PopupType type = PopupType.Small)
@@ -50,7 +39,7 @@ namespace Content.Server.Popups
             if (message == null)
                 return;
 
-            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter, replayRecord);
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, Timing.CurTick, GetNetCoordinates(coordinates)), filter, replayRecord);
         }
 
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, PopupType type = PopupType.Small)
@@ -59,7 +48,7 @@ namespace Content.Server.Popups
                 return;
             var mapPos = _transform.ToMapCoordinates(coordinates);
             var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
-            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, Timing.CurTick, GetNetCoordinates(coordinates)), filter);
         }
 
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small)
@@ -67,7 +56,7 @@ namespace Content.Server.Popups
             if (message == null)
                 return;
 
-            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), recipient);
+            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, Timing.CurTick, GetNetCoordinates(coordinates)), recipient);
         }
 
         public override void PopupCoordinates(string? message, EntityCoordinates coordinates, EntityUid recipient, PopupType type = PopupType.Small)
@@ -76,22 +65,7 @@ namespace Content.Server.Popups
                 return;
 
             if (TryComp(recipient, out ActorComponent? actor))
-                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), actor.PlayerSession);
-        }
-
-        public override void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (message == null)
-                return;
-
-            var mapPos = _transform.ToMapCoordinates(coordinates);
-            var filter = Filter.Empty().AddPlayersByPvs(mapPos, entManager: EntityManager, playerMan: _player, cfgMan: _cfg);
-            if (recipient != null)
-            {
-                // Don't send to recipient, since they predicted it locally
-                filter = filter.RemovePlayerByAttachedEntity(recipient.Value);
-            }
-            RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, GetNetCoordinates(coordinates)), filter);
+                RaiseNetworkEvent(new PopupCoordinatesEvent(message, type, Timing.CurTick, GetNetCoordinates(coordinates)), actor.PlayerSession);
         }
 
         public override void PopupEntity(string? message, EntityUid uid, PopupType type = PopupType.Small)
@@ -100,7 +74,7 @@ namespace Content.Server.Popups
                 return;
 
             var filter = Filter.Empty().AddPlayersByPvs(uid, entityManager: EntityManager, playerMan: _player, cfgMan: _cfg);
-            RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), filter);
+            RaiseNetworkEvent(new PopupEntityEvent(message, type, Timing.CurTick, GetNetEntity(uid)), filter);
         }
 
         public override void PopupEntity(string? message, EntityUid uid, EntityUid recipient, PopupType type = PopupType.Small)
@@ -109,20 +83,7 @@ namespace Content.Server.Popups
                 return;
 
             if (TryComp(recipient, out ActorComponent? actor))
-                RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), actor.PlayerSession);
-        }
-
-        public override void PopupClient(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-        }
-
-        public override void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            // do nothing duh its for client only
-        }
-
-        public override void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
+                RaiseNetworkEvent(new PopupEntityEvent(message, type, Timing.CurTick, GetNetEntity(uid)), actor.PlayerSession);
         }
 
         public override void PopupEntity(string? message, EntityUid uid, ICommonSession recipient, PopupType type = PopupType.Small)
@@ -130,7 +91,7 @@ namespace Content.Server.Popups
             if (message == null)
                 return;
 
-            RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), recipient);
+            RaiseNetworkEvent(new PopupEntityEvent(message, type, Timing.CurTick, GetNetEntity(uid)), recipient);
         }
 
         public override void PopupEntity(string? message, EntityUid uid, Filter filter, bool recordReplay, PopupType type = PopupType.Small)
@@ -138,44 +99,7 @@ namespace Content.Server.Popups
             if (message == null)
                 return;
 
-            RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), filter, recordReplay);
-        }
-
-        public override void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (message == null)
-                return;
-
-            if (recipient != null)
-            {
-                // Don't send to recipient, since they predicted it locally
-                var filter = Filter.PvsExcept(recipient.Value, entityManager: EntityManager);
-                RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), filter);
-            }
-            else
-            {
-                // With no recipient, send to everyone (in PVS range)
-                RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)));
-            }
-        }
-
-        public override void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, Filter filter, bool recordReplay, PopupType type = PopupType.Small)
-        {
-            if (message == null)
-                return;
-
-            if (recipient != null)
-            {
-                // Don't send to recipient, since they predicted it locally
-                filter = filter.RemovePlayerByAttachedEntity(recipient.Value);
-            }
-
-            RaiseNetworkEvent(new PopupEntityEvent(message, type, GetNetEntity(uid)), filter, recordReplay);
-        }
-
-        public override void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            PopupPredicted(othersMessage, uid, recipient, type);
+            RaiseNetworkEvent(new PopupEntityEvent(message, type, Timing.CurTick, GetNetEntity(uid)), filter, recordReplay);
         }
     }
 }

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -72,7 +72,7 @@ namespace Content.Server.Popups
             RaiseNetworkEvent(new PopupEntityEvent(message, type, Timing.CurTick, GetNetEntity(uid)), filter);
         }
 
-        public override void PopupEntity(string? message, EntityUid uid, EntityUid recipient, PopupType type = PopupType.Small)
+        public override void PopupEntity(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
         {
             if (message == null)
                 return;

--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -361,7 +361,7 @@ namespace Content.Server.Shuttles.Systems
             if (!TryGetEntity(args.DockEntity, out var dockEnt) ||
                 !TryComp(dockEnt, out DockingComponent? dockComp))
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-undock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-undock-fail"), args.Actor);
                 return;
             }
 
@@ -369,7 +369,7 @@ namespace Content.Server.Shuttles.Systems
 
             if (!CanUndock(dock))
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-undock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-undock-fail"), args.Actor);
                 return;
             }
 
@@ -382,7 +382,7 @@ namespace Content.Server.Shuttles.Systems
 
             if (console == null)
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"), args.Actor);
                 return;
             }
 
@@ -390,7 +390,7 @@ namespace Content.Server.Shuttles.Systems
 
             if (!CanShuttleDock(shuttleUid))
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"), args.Actor);
                 return;
             }
 
@@ -399,7 +399,7 @@ namespace Content.Server.Shuttles.Systems
                 !TryComp(ourDock, out DockingComponent? ourDockComp) ||
                 !TryComp(targetDock, out DockingComponent? targetDockComp))
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"), args.Actor);
                 return;
             }
 
@@ -407,7 +407,7 @@ namespace Content.Server.Shuttles.Systems
             if (!TryComp(ourDock, out TransformComponent? xformA) ||
                 xformA.GridUid != shuttleUid)
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"), args.Actor);
                 return;
             }
 
@@ -415,7 +415,7 @@ namespace Content.Server.Shuttles.Systems
             // Also need to check preventpilot + enabled / dockedwith
             if (!CanDock((ourDock.Value, ourDockComp), (targetDock.Value, targetDockComp)))
             {
-                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"));
+                _popup.PopupCursor(Loc.GetString("shuttle-console-dock-fail"), args.Actor);
                 return;
             }
 

--- a/Content.Shared/Abilities/Goliath/GoliathTentacleSystem.cs
+++ b/Content.Shared/Abilities/Goliath/GoliathTentacleSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class GoliathTentacleSystem : EntitySystem
 
         // TODO: animation
 
-        _popup.PopupPredicted(Loc.GetString("tentacle-ability-use-popup", ("entity", args.Performer)), args.Performer, args.Performer, type: PopupType.SmallCaution);
+        _popup.PopupEntity(Loc.GetString("tentacle-ability-use-popup", ("entity", args.Performer)), args.Performer, type: PopupType.SmallCaution);
         _stun.TryAddStunDuration(args.Performer, TimeSpan.FromSeconds(0.8f));
 
         var coords = args.Target;

--- a/Content.Shared/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Shared/Abilities/Mime/MimePowersSystem.cs
@@ -52,7 +52,7 @@ public sealed partial class MimePowersSystem : EntitySystem
 
             mime.ReadyToRepent = true;
             Dirty(uid, mime);
-            _popupSystem.PopupClient(Loc.GetString("mime-ready-to-repent"), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString("mime-ready-to-repent"), uid, uid);
         }
     }
 
@@ -98,7 +98,7 @@ public sealed partial class MimePowersSystem : EntitySystem
         // Check if the tile is blocked by a wall or mob, and don't create the wall if so
         if (_turf.IsTileBlocked(tile.Value, CollisionGroup.Impassable | CollisionGroup.Opaque))
         {
-            _popupSystem.PopupClient(Loc.GetString("mime-invisible-wall-failed"), ent, ent);
+            _popupSystem.PopupEntity(Loc.GetString("mime-invisible-wall-failed"), ent, ent);
             return;
         }
 
@@ -164,7 +164,7 @@ public sealed partial class MimePowersSystem : EntitySystem
 
         if (!mimePowers.ReadyToRepent)
         {
-            _popupSystem.PopupClient(Loc.GetString("mime-not-ready-repent"), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString("mime-not-ready-repent"), uid, uid);
             return;
         }
 

--- a/Content.Shared/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Shared/Abilities/Mime/MimePowersSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class MimePowersSystem : EntitySystem
 
         var messageSelf = Loc.GetString("mime-invisible-wall-popup-self", ("mime", Identity.Entity(ent.Owner, EntityManager)));
         var messageOthers = Loc.GetString("mime-invisible-wall-popup-others", ("mime", Identity.Entity(ent.Owner, EntityManager)));
-        _popupSystem.PopupPredicted(messageSelf, messageOthers, ent, ent);
+        _popupSystem.PopupEntity(messageSelf, messageOthers, ent, ent);
 
         // Make sure we set the invisible wall to despawn properly
         PredictedSpawnAtPosition(ent.Comp.WallPrototype, _turf.GetTileCenter(tile.Value));

--- a/Content.Shared/Access/Systems/ActivatableUIRequiresAccessSystem.cs
+++ b/Content.Shared/Access/Systems/ActivatableUIRequiresAccessSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class ActivatableUIRequiresAccessSystem : EntitySystem
         {
             args.Cancel();
             if (activatableUI.Comp.PopupMessage != null && !args.Silent)
-                _popup.PopupClient(Loc.GetString(activatableUI.Comp.PopupMessage), activatableUI, args.User);
+                _popup.PopupEntity(Loc.GetString(activatableUI.Comp.PopupMessage), activatableUI, args.User);
         }
     }
 }

--- a/Content.Shared/Actions/ConfirmableActionSystem.cs
+++ b/Content.Shared/Actions/ConfirmableActionSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class ConfirmableActionSystem : EntitySystem
         comp.NextUnprime = comp.NextConfirm + comp.PrimeTime;
         Dirty(uid, comp);
 
-        _popup.PopupClient(Loc.GetString(comp.Popup), user, user, PopupType.LargeCaution);
+        _popup.PopupEntity(Loc.GetString(comp.Popup), user, user, PopupType.LargeCaution);
     }
 
     private void Unprime(Entity<ConfirmableActionComponent> ent)

--- a/Content.Shared/Animals/Systems/SharedParrotMemorySystem.cs
+++ b/Content.Shared/Animals/Systems/SharedParrotMemorySystem.cs
@@ -36,7 +36,7 @@ public abstract partial class SharedParrotMemorySystem : EntitySystem
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/AdminActions/clear-parrot.png")),
             Act = () =>
             {
-                _popup.PopupClient(Loc.GetString("parrot-popup-memory-cleared"), entity.Owner, user);
+                _popup.PopupEntity(Loc.GetString("parrot-popup-memory-cleared"), entity.Owner, user);
 
                 if (_net.IsServer)
                     entity.Comp.SpeechMemories.Clear();

--- a/Content.Shared/Animals/UdderSystem.cs
+++ b/Content.Shared/Animals/UdderSystem.cs
@@ -115,7 +115,7 @@ public sealed partial class UdderSystem : EntitySystem
         var quantity = solution.Volume;
         if (quantity == 0)
         {
-            _popupSystem.PopupClient(Loc.GetString("udder-system-dry"), entity.Owner, args.Args.User);
+            _popupSystem.PopupEntity(Loc.GetString("udder-system-dry"), entity.Owner, args.Args.User);
             return;
         }
 
@@ -125,7 +125,7 @@ public sealed partial class UdderSystem : EntitySystem
         var split = _solutionContainerSystem.SplitSolution(entity.Comp.Solution.Value, quantity);
         _solutionContainerSystem.TryAddSolution(targetSoln.Value, split);
 
-        _popupSystem.PopupClient(Loc.GetString("udder-system-success", ("amount", quantity), ("target", Identity.Entity(args.Args.Used.Value, EntityManager))), entity.Owner,
+        _popupSystem.PopupEntity(Loc.GetString("udder-system-success", ("amount", quantity), ("target", Identity.Entity(args.Args.Used.Value, EntityManager))), entity.Owner,
             args.Args.User, PopupType.Medium);
     }
 

--- a/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
+++ b/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
@@ -168,7 +168,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
         if (ent.Comp.PulseOnConnect)
             _anomaly.DoAnomalyPulse(anomaly, anomaly);
 
-        _popup.PopupPredicted(Loc.GetString("anomaly-sync-connected"), ent, user, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("anomaly-sync-connected"), ent, PopupType.Medium);
         _audio.PlayPredicted(ent.Comp.ConnectedSound, ent, user);
     }
 
@@ -184,7 +184,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
             _anomaly.DoAnomalyPulse(ent.Comp.ConnectedAnomaly.Value, anomaly);
         }
 
-        _popup.PopupPredicted(Loc.GetString("anomaly-sync-disconnected"), ent, user, PopupType.Large);
+        _popup.PopupEntity(Loc.GetString("anomaly-sync-disconnected"), ent, PopupType.Large);
         _audio.PlayPredicted(ent.Comp.DisconnectedSound, ent, user);
 
         ent.Comp.ConnectedAnomaly = null;

--- a/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
+++ b/Content.Shared/Anomaly/AnomalySynchronizerSystem.cs
@@ -89,7 +89,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
     {
         if (!_power.IsPowered(ent.Owner))
         {
-            _popup.PopupClient(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent)), ent, user);
+            _popup.PopupEntity(Loc.GetString("base-computer-ui-component-not-powered", ("machine", ent)), ent, user);
             return false;
         }
 
@@ -98,7 +98,7 @@ public sealed partial class AnomalySynchronizerSystem : EntitySystem
 
         if (anomaly.Owner is { Valid: false }) // no anomaly in range
         {
-            _popup.PopupClient(Loc.GetString("anomaly-sync-no-anomaly"), ent, user);
+            _popup.PopupEntity(Loc.GetString("anomaly-sync-no-anomaly"), ent, user);
             return false;
         }
 

--- a/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalyScannerSystem.cs
@@ -76,7 +76,7 @@ public abstract partial class SharedAnomalyScannerSystem : EntitySystem
             return;
 
         Audio.PlayPredicted(component.CompleteSound, uid, args.User);
-        Popup.PopupPredicted(Loc.GetString("anomaly-scanner-component-scan-complete"), uid, args.User);
+        Popup.PopupEntity(Loc.GetString("anomaly-scanner-component-scan-complete"), uid);
 
         UI.OpenUi(uid, AnomalyScannerUiKey.Key, args.User);
 

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -124,7 +124,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
 
         if (TryComp<SubFloorHideComponent>(ent, out var subFloorHide) && subFloorHide.IsUnderCover)
         {
-            _popup.PopupClient(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
             return;
         }
 
@@ -143,7 +143,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
                 var toolName = Loc.GetString(toolProto.ToolName).ToLower();
                 var message = Loc.GetString("atmos-pipe-layers-component-tool-missing", ("toolName", toolName));
 
-                _popup.PopupClient(message, ent, args.User);
+                _popup.PopupEntity(message, ent, args.User);
             }
 
             return;
@@ -219,7 +219,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
             var layerName = GetPipeLayerName(ent.Comp.CurrentPipeLayer);
             var message = Loc.GetString("atmos-pipe-layers-component-change-layer", ("layerName", layerName));
 
-            _popup.PopupClient(message, ent, user);
+            _popup.PopupEntity(message, ent, user);
         }
     }
 

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -355,7 +355,7 @@ public sealed partial class SleepingSystem : EntitySystem
             if (user != null)
             {
                 _audio.PlayPredicted(ent.Comp.WakeAttemptSound, ent, user);
-                _popupSystem.PopupClient(Loc.GetString("wake-other-failure", ("target", Identity.Entity(ent, EntityManager))), ent, user, PopupType.SmallCaution);
+                _popupSystem.PopupEntity(Loc.GetString("wake-other-failure", ("target", Identity.Entity(ent, EntityManager))), ent, user, PopupType.SmallCaution);
             }
             return false;
         }
@@ -363,7 +363,7 @@ public sealed partial class SleepingSystem : EntitySystem
         if (user != null)
         {
             _audio.PlayPredicted(ent.Comp.WakeAttemptSound, ent, user);
-            _popupSystem.PopupClient(Loc.GetString("wake-other-success", ("target", Identity.Entity(ent, EntityManager))), ent, user);
+            _popupSystem.PopupEntity(Loc.GetString("wake-other-success", ("target", Identity.Entity(ent, EntityManager))), ent, user);
         }
 
         return RemComp<SleepingComponent>(ent);

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -210,13 +210,13 @@ public sealed partial class BlockingSystem : EntitySystem
     private void CantBlockError(EntityUid user)
     {
         var msgError = Loc.GetString("action-popup-blocking-user-cant-block");
-        _popupSystem.PopupClient(msgError, user, user);
+        _popupSystem.PopupEntity(msgError, user, user);
     }
 
     private void TooCloseError(EntityUid user)
     {
         var msgError = Loc.GetString("action-popup-blocking-user-too-close");
-        _popupSystem.PopupClient(msgError, user, user);
+        _popupSystem.PopupEntity(msgError, user, user);
     }
 
     /// <summary>

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -189,7 +189,7 @@ public sealed partial class BlockingSystem : EntitySystem
             return false;
         }
         _actionsSystem.SetToggled(component.BlockingToggleActionEntity, true);
-        _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
+        _popupSystem.PopupEntity(msgUser, msgOther, user, user);
 
         if (TryComp<PhysicsComponent>(user, out var physicsComponent))
         {
@@ -250,7 +250,7 @@ public sealed partial class BlockingSystem : EntitySystem
             _actionsSystem.SetToggled(component.BlockingToggleActionEntity, false);
             _fixtureSystem.DestroyFixture(user, BlockingComponent.BlockFixtureID, body: physicsComponent);
             _physics.SetBodyType(user, blockingUserComponent.OriginalBodyType, body: physicsComponent);
-            _popupSystem.PopupPredicted(msgUser, msgOther, user, user);
+            _popupSystem.PopupEntity(msgUser, msgOther, user, user);
         }
 
         component.IsBlocking = false;

--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -92,7 +92,7 @@ public abstract partial class SharedInternalsSystem : EntitySystem
             }
             else
             {
-                _popupSystem.PopupClient(message, target, user, PopupType.Medium);
+                _popupSystem.PopupEntity(message, target, user, PopupType.Medium);
             }
 // ES END
             return false;
@@ -112,7 +112,7 @@ public abstract partial class SharedInternalsSystem : EntitySystem
             }
             else
             {
-                _popupSystem.PopupClient(message, target, user, PopupType.Medium);
+                _popupSystem.PopupEntity(message, target, user, PopupType.Medium);
             }
 // ES END
             return false;

--- a/Content.Shared/Body/Systems/SharedInternalsSystem.cs
+++ b/Content.Shared/Body/Systems/SharedInternalsSystem.cs
@@ -88,7 +88,7 @@ public abstract partial class SharedInternalsSystem : EntitySystem
             var message = user == target ? Loc.GetString("internals-self-no-breath-tool") : Loc.GetString("internals-other-no-breath-tool", ("ent", Identity.Entity(target, EntityManager, user)));
             if (user == target)
             {
-                _popupSystem.PopupPredictedCursor(message, user, PopupType.Medium);
+                _popupSystem.PopupCursor(message, user, PopupType.Medium);
             }
             else
             {
@@ -108,7 +108,7 @@ public abstract partial class SharedInternalsSystem : EntitySystem
             var message = user == target ? Loc.GetString("internals-self-no-tank") : Loc.GetString("internals-other-no-tank", ("ent", Identity.Entity(target, EntityManager, user)));
             if (user == target)
             {
-                _popupSystem.PopupPredictedCursor(message, user, PopupType.Medium);
+                _popupSystem.PopupCursor(message, user, PopupType.Medium);
             }
             else
             {

--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -238,7 +238,7 @@ public abstract partial class SharedBuckleSystem
             _whitelistSystem.IsWhitelistPass(strapComp.Blacklist, buckleUid))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("buckle-component-cannot-fit-message"), user, PopupType.Medium);
+                _popup.PopupCursor(Loc.GetString("buckle-component-cannot-fit-message"), user, PopupType.Medium);
 
             return false;
         }
@@ -258,7 +258,7 @@ public abstract partial class SharedBuckleSystem
         if (user != null && !HasComp<HandsComponent>(user))
         {
             if (popup)
-                _popup.PopupClient(Loc.GetString("buckle-component-no-hands-message"), user);
+                _popup.PopupCursor(Loc.GetString("buckle-component-no-hands-message"), user);
 
             return false;
         }
@@ -272,7 +272,7 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-already-buckled-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupClient(message, user);
+                _popup.PopupCursor(message, user);
             }
 
             return false;
@@ -295,7 +295,7 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-cannot-buckle-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupClient(message, user);
+                _popup.PopupCursor(message, user);
             }
 
             return false;
@@ -310,7 +310,7 @@ public abstract partial class SharedBuckleSystem
                     : "buckle-component-other-cannot-buckle-message",
                 ("owner", Identity.Entity(buckleUid, EntityManager)));
 
-                _popup.PopupClient(message, user);
+                _popup.PopupCursor(message, user);
             }
 
             return false;

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class BurialSystem : EntitySystem
         }
         else
         {
-            _popupSystem.PopupClient(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
         }
 
         args.Handled = true;
@@ -85,7 +85,7 @@ public sealed partial class BurialSystem : EntitySystem
         if (args.Handled || !args.Complex)
             return;
 
-        _popupSystem.PopupClient(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
+        _popupSystem.PopupEntity(Loc.GetString("grave-digging-requires-tool", ("grave", args.Target)), uid, args.User);
         args.Handled = true;
     }
 
@@ -124,7 +124,7 @@ public sealed partial class BurialSystem : EntitySystem
         }
         else
         {
-            _popupSystem.PopupClient(Loc.GetString("grave-start-digging-user-trapped", ("grave", uid)), user, user, PopupType.Medium);
+            _popupSystem.PopupEntity(Loc.GetString("grave-start-digging-user-trapped", ("grave", uid)), user, user, PopupType.Medium);
         }
     }
 

--- a/Content.Shared/Burial/BurialSystem.cs
+++ b/Content.Shared/Burial/BurialSystem.cs
@@ -118,7 +118,7 @@ public sealed partial class BurialSystem : EntitySystem
         {
             var selfMessage = Loc.GetString("grave-start-digging-user", ("grave", uid), ("tool", used));
             var othersMessage = Loc.GetString("grave-start-digging-others", ("user", user), ("grave", uid), ("tool", used));
-            _popupSystem.PopupPredicted(selfMessage, othersMessage, user, user);
+            _popupSystem.PopupEntity(selfMessage, othersMessage, user, user);
             component.ActiveShovelDigging = true;
             Dirty(uid, component);
         }

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -484,7 +484,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             var userMessage = Loc.GetString("injector-component-blocked-user");
             var otherMessage = Loc.GetString("injector-component-blocked-other", ("target", target), ("user", user));
-            _popup.PopupPredicted(userMessage, otherMessage, target, user, PopupType.SmallCaution);
+            _popup.PopupEntity(userMessage, otherMessage, target, user, PopupType.SmallCaution);
             return true;
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -79,7 +79,7 @@ public sealed partial class InjectorSystem : EntitySystem
             // Are use using an injector capable of targeting a mob?
             if (injector.Comp.IgnoreMobs)
             {
-                _popup.PopupClient(Loc.GetString("injector-component-ignore-mobs"), args.Target.Value, args.User);
+                _popup.PopupEntity(Loc.GetString("injector-component-ignore-mobs"), args.Target.Value, args.User);
                 return;
             }
 
@@ -139,7 +139,7 @@ public sealed partial class InjectorSystem : EntitySystem
                 Act = () =>
                 {
                     injector.Comp.CurrentTransferAmount = toggleAmount;
-                    _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", toggleAmount)), user, user);
+                    _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", toggleAmount)), user, user);
                     Dirty(injector);
                 },
 
@@ -159,7 +159,7 @@ public sealed partial class InjectorSystem : EntitySystem
                     Act = () =>
                     {
                         injector.Comp.CurrentTransferAmount = amount;
-                        _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), user, user);
+                        _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), user, user);
                         Dirty(injector);
                     },
 
@@ -218,7 +218,7 @@ public sealed partial class InjectorSystem : EntitySystem
             return false;
 
         // Create a pop-up for the user.
-        _popup.PopupClient(Loc.GetString(activeMode.PopupUserAttempt), target, user);
+        _popup.PopupEntity(Loc.GetString(activeMode.PopupUserAttempt), target, user);
 
         if (user == target)
         {
@@ -286,7 +286,7 @@ public sealed partial class InjectorSystem : EntitySystem
             // Check if we have anything to inject.
             if (injectorSolution.Volume == 0)
             {
-                _popup.PopupClient(Loc.GetString("injector-component-empty-message", ("injector", injector)), target, user);
+                _popup.PopupEntity(Loc.GetString("injector-component-empty-message", ("injector", injector)), target, user);
                 return false;
             }
 
@@ -349,19 +349,19 @@ public sealed partial class InjectorSystem : EntitySystem
         if (!_solutionContainer.ResolveSolution(injector.Owner, injector.Comp.SolutionName, ref injector.Comp.Solution, out var solution)
             || solution.AvailableVolume == 0)
         {
-            _popup.PopupClient(Loc.GetString("injector-component-cannot-toggle-draw-message"), user, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-cannot-toggle-draw-message"), user, user);
             return false; // If already full, fail drawing.
         }
 
         if (!_solutionContainer.TryGetDrawableSolution(target, out _, out var drawableSol))
         {
-            _popup.PopupClient(Loc.GetString("injector-component-cannot-draw-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-cannot-draw-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
             return false;
         }
 
         if (drawableSol.Volume == 0)
         {
-            _popup.PopupClient(Loc.GetString("injector-component-target-is-empty-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-target-is-empty-message", ("target", Identity.Entity(target, EntityManager))), injector, user);
             return false;
         }
 
@@ -414,7 +414,7 @@ public sealed partial class InjectorSystem : EntitySystem
                     return TryDraw(injector, user, target, drawableSolution.Value);
 
                 msg = target == user ? "injector-component-cannot-draw-message-self" : "injector-component-cannot-draw-message";
-                _popup.PopupClient(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
+                _popup.PopupEntity(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
                 break;
             }
             case InjectorBehavior.Dynamic:
@@ -435,7 +435,7 @@ public sealed partial class InjectorSystem : EntitySystem
                 throw new ArgumentOutOfRangeException();
         }
 
-        _popup.PopupClient(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
+        _popup.PopupEntity(Loc.GetString(msg, ("target", Identity.Entity(target, EntityManager))), injector, user);
         return false;
     }
 
@@ -456,7 +456,7 @@ public sealed partial class InjectorSystem : EntitySystem
                 out var injectorSolution) || injectorSolution.Volume == 0)
         {
             // If empty, show a popup.
-            _popup.PopupClient(Loc.GetString("injector-component-empty-message", ("injector", injector)), user, user);
+            _popup.PopupEntity(Loc.GetString("injector-component-empty-message", ("injector", injector)), user, user);
             return false;
         }
 
@@ -495,7 +495,7 @@ public sealed partial class InjectorSystem : EntitySystem
         if (realTransferAmount <= 0)
         {
             LocId msg = target == user ? "injector-component-target-already-full-message-self" : "injector-component-target-already-full-message";
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString(msg,
                     ("target", Identity.Entity(target, EntityManager))),
                 injector.Owner,
@@ -524,11 +524,11 @@ public sealed partial class InjectorSystem : EntitySystem
         else if (ev.OverrideMessage != null)
             msgSuccess = ev.OverrideMessage;
 
-        _popup.PopupClient(Loc.GetString(msgSuccess, ("amount", removedSolution.Volume), ("target", Identity.Entity(target, EntityManager))), target, user);
+        _popup.PopupEntity(Loc.GetString(msgSuccess, ("amount", removedSolution.Volume), ("target", Identity.Entity(target, EntityManager))), target, user);
 
         // it is IMPERATIVE that when an injector is instant, that it has a pop-up.
         if (activeMode.InjectPopupTarget != null && target != user)
-            _popup.PopupClient(Loc.GetString(activeMode.InjectPopupTarget), target, target);
+            _popup.PopupEntity(Loc.GetString(activeMode.InjectPopupTarget), target, target);
 
         // Some injectors like hyposprays have sound, some like syringes have not.
         if (activeMode.InjectSound != null)
@@ -553,7 +553,7 @@ public sealed partial class InjectorSystem : EntitySystem
     {
         if (!_solutionContainer.ResolveSolution(injector.Owner, injector.Comp.SolutionName, ref injector.Comp.Solution, out var solution) || solution.AvailableVolume == 0)
         {
-            _popup.PopupClient("injector-component-cannot-toggle-draw-message", user, user);
+            _popup.PopupEntity("injector-component-cannot-toggle-draw-message", user, user);
             return false;
         }
 
@@ -576,7 +576,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             LocId msg = target.Owner == user ? "injector-component-target-is-empty-message-self" : "injector-component-target-is-empty-message";
             var targetIdentity = Identity.Entity(target, EntityManager);
-            _popup.PopupClient(Loc.GetString(msg, ("target", targetIdentity)), injector.Owner, user);
+            _popup.PopupEntity(Loc.GetString(msg, ("target", targetIdentity)), injector.Owner, user);
             return false;
         }
 
@@ -600,7 +600,7 @@ public sealed partial class InjectorSystem : EntitySystem
 
         LocId msgSuccess = target.Owner == user ? "injector-component-draw-success-message-self" : "injector-component-draw-success-message";
         var targetIdentitySuccess = Identity.Entity(target, EntityManager);
-        _popup.PopupClient(
+        _popup.PopupEntity(
             Loc.GetString(msgSuccess, ("amount", removedSolution.Volume), ("target", targetIdentitySuccess)),
             target,
             user);
@@ -632,7 +632,7 @@ public sealed partial class InjectorSystem : EntitySystem
         LocId msg = target.Owner == user ? "injector-component-draw-success-message-self" : "injector-component-draw-success-message";
         var targetIdentity = Identity.Entity(target, EntityManager);
         var finalMessage = Loc.GetString(msg, ("amount", transferAmount), ("target", targetIdentity));
-        _popup.PopupClient(finalMessage, target, user);
+        _popup.PopupEntity(finalMessage, target, user);
 
         AfterDraw(injector, user, target);
     }
@@ -723,7 +723,7 @@ public sealed partial class InjectorSystem : EntitySystem
 
         var modeName = Loc.GetString(newMode.Name);
         var message = Loc.GetString("injector-component-mode-changed-text", ("mode", modeName));
-        _popup.PopupClient(message, user, user);
+        _popup.PopupEntity(message, user, user);
         Dirty(injector);
     }
 
@@ -763,7 +763,7 @@ public sealed partial class InjectorSystem : EntitySystem
             return;
         }
         if (errorMessage != null)
-            _popup.PopupClient(Loc.GetString(errorMessage), user, user);
+            _popup.PopupEntity(Loc.GetString(errorMessage), user, user);
     }
     #endregion Mode Toggling
 }

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -470,7 +470,7 @@ public sealed partial class InjectorSystem : EntitySystem
         {
             // Clowns will now also fumble Syringes.
             if (selfEv.OverrideMessage != null)
-                _popup.PopupPredicted(selfEv.OverrideMessage, user, user);
+                _popup.PopupEntity(selfEv.OverrideMessage, user);
             return true;
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/ScoopableSolutionSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/ScoopableSolutionSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class ScoopableSolutionSystem : EntitySystem
         if (scooped == 0)
             return false;
 
-        _popup.PopupClient(Loc.GetString(ent.Comp.Popup, ("scooped", ent.Owner), ("beaker", beaker)), user, user);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.Popup, ("scooped", ent.Owner), ("beaker", beaker)), user, user);
 
         if (srcSolution.Volume == 0 && ent.Comp.Delete)
         {

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerMixerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerMixerSystem.cs
@@ -58,14 +58,14 @@ public abstract partial class SharedSolutionContainerMixerSystem : EntitySystem
         if (!HasPower(entity))
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("solution-container-mixer-no-power"), entity, user.Value);
+                _popup.PopupEntity(Loc.GetString("solution-container-mixer-no-power"), entity, user.Value);
             return;
         }
 
         if (!_container.TryGetContainer(uid, comp.ContainerId, out var container) || container.Count == 0)
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("solution-container-mixer-popup-nothing-to-mix"), entity, user.Value);
+                _popup.PopupEntity(Loc.GetString("solution-container-mixer-popup-nothing-to-mix"), entity, user.Value);
             return;
         }
 

--- a/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionSpikerSystem.cs
@@ -52,14 +52,14 @@ public sealed partial class SolutionSpikerSystem : EntitySystem
 
         if (targetSolution.Volume == 0 && !spikableSource.IgnoreEmpty)
         {
-            _popup.PopupClient(Loc.GetString(spikableSource.PopupEmpty, ("spiked-entity", target), ("spike-entity", source)), user, user);
+            _popup.PopupEntity(Loc.GetString(spikableSource.PopupEmpty, ("spiked-entity", target), ("spike-entity", source)), user, user);
             return false;
         }
 
         if (!_solution.ForceAddSolution(targetSoln.Value, sourceSolution))
             return false;
 
-        _popup.PopupClient(Loc.GetString(spikableSource.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
+        _popup.PopupEntity(Loc.GetString(spikableSource.Popup, ("spiked-entity", target), ("spike-entity", source)), user, user);
         sourceSolution.RemoveAllSolution();
         if (spikableSource.Delete)
             QueueDel(source);

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -80,7 +80,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
             {
                 ent.Comp.TransferAmount = amount;
 
-                _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), ent.Owner, user);
+                _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", amount)), ent.Owner, user);
 
                 Dirty(ent.Owner, ent.Comp);
             };
@@ -99,7 +99,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
         ent.Comp.TransferAmount = newTransferAmount;
 
         if (message.Actor is { Valid: true } user)
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-set-amount", ("amount", newTransferAmount)), ent.Owner, user);
 
         Dirty(ent.Owner, ent.Comp);
     }
@@ -277,7 +277,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
             return;
 
         var message = Loc.GetString("comp-solution-transfer-transfer-solution", ("amount", transferred), ("target", data.TargetEntity));
-        _popup.PopupClient(message, data.SourceEntity, data.User);
+        _popup.PopupEntity(message, data.SourceEntity, data.User);
     }
 
     /// <summary>
@@ -298,7 +298,7 @@ public sealed partial class SolutionTransferSystem : EntitySystem
             ? "comp-solution-transfer-fill-fully"
             : "comp-solution-transfer-fill-normal";
 
-        _popup.PopupClient(Loc.GetString(msg, ("owner", data.SourceEntity), ("amount", transferred), ("target", data.TargetEntity)), data.TargetEntity, data.User);
+        _popup.PopupEntity(Loc.GetString(msg, ("owner", data.SourceEntity), ("amount", transferred), ("target", data.TargetEntity)), data.TargetEntity, data.User);
     }
 
     /// <summary>
@@ -340,14 +340,14 @@ public sealed partial class SolutionTransferSystem : EntitySystem
         RaiseLocalEvent(data.SourceEntity, ref transferAttempt);
         if (transferAttempt.CancelReason is {} reason)
         {
-            _popup.PopupClient(reason, data.SourceEntity, data.User);
+            _popup.PopupEntity(reason, data.SourceEntity, data.User);
             return false;
         }
 
         var sourceSolution = data.Source.Comp.Solution;
         if (sourceSolution.Volume == 0)
         {
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-empty", ("target", data.SourceEntity)), data.SourceEntity, data.User);
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-is-empty", ("target", data.SourceEntity)), data.SourceEntity, data.User);
             return false;
         }
 
@@ -355,14 +355,14 @@ public sealed partial class SolutionTransferSystem : EntitySystem
         RaiseLocalEvent(data.TargetEntity, ref transferAttempt);
         if (transferAttempt.CancelReason is {} targetReason)
         {
-            _popup.PopupClient(targetReason, data.TargetEntity, data.User);
+            _popup.PopupEntity(targetReason, data.TargetEntity, data.User);
             return false;
         }
 
         var targetSolution = data.Target.Comp.Solution;
         if (targetSolution.AvailableVolume == 0)
         {
-            _popup.PopupClient(Loc.GetString("comp-solution-transfer-is-full", ("target", data.TargetEntity)), data.TargetEntity, data.User);
+            _popup.PopupEntity(Loc.GetString("comp-solution-transfer-is-full", ("target", data.TargetEntity)), data.TargetEntity, data.User);
             return false;
         }
 

--- a/Content.Shared/Chemistry/Reaction/ReactionMixerSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionMixerSystem.cs
@@ -93,7 +93,7 @@ public sealed partial class ReactionMixerSystem : EntitySystem
         if (!TryMix(ent.AsNullable(), args.Target.Value))
             return;
 
-        _popup.PopupClient(
+        _popup.PopupEntity(
             Loc.GetString(ent.Comp.MixMessage,
                 ("mixed", Identity.Entity(args.Target.Value, EntityManager)),
                 ("mixer", Identity.Entity(ent.Owner, EntityManager))),

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -342,7 +342,7 @@ public sealed partial class ClimbSystem : VirtualController
                 ("climbable", climbable));
         }
 
-        _popupSystem.PopupPredicted(selfMessage, othersMessage, uid, user);
+        _popupSystem.PopupEntity(selfMessage, othersMessage, uid, user);
     }
 
     /// <summary>

--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -210,7 +210,7 @@ public sealed partial class ClimbSystem : VirtualController
              : CanVault(comp, user, entityToMove, climbable, out reason);
         if (!canVault)
         {
-            _popupSystem.PopupClient(reason, user, user);
+            _popupSystem.PopupEntity(reason, user, user);
             return false;
         }
 

--- a/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MaskSystem.cs
@@ -57,7 +57,7 @@ public sealed partial class MaskSystem : EntitySystem
 
         var dir = mask.IsToggled ? "down" : "up";
         var msg = $"action-mask-pull-{dir}-popup-message";
-        _popupSystem.PopupClient(Loc.GetString(msg, ("mask", uid)), args.Performer, args.Performer);
+        _popupSystem.PopupEntity(Loc.GetString(msg, ("mask", uid)), args.Performer, args.Performer);
     }
 
     private void OnGotUnequipped(EntityUid uid, MaskComponent mask, GotUnequippedEvent args)

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -244,7 +244,7 @@ public sealed partial class ToggleableClothingSystem : EntitySystem
             _inventorySystem.TryUnequip(user, parent, component.Slot, force: true);
         else if (_inventorySystem.TryGetSlotEntity(parent, component.Slot, out var existing))
         {
-            _popupSystem.PopupClient(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
+            _popupSystem.PopupEntity(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
                 user, user);
         }
         else

--- a/Content.Shared/CombatMode/Pacification/PacificationSystem.cs
+++ b/Content.Shared/CombatMode/Pacification/PacificationSystem.cs
@@ -56,7 +56,7 @@ public sealed partial class PacificationSystem : EntitySystem
             return;
 
         var targetName = Identity.Entity(target, EntityManager);
-        _popup.PopupClient(Loc.GetString(reason, ("entity", targetName)), user, user);
+        _popup.PopupEntity(Loc.GetString(reason, ("entity", targetName)), user, user);
         user.Comp.NextPopupTime = _timing.CurTime + user.Comp.PopupCooldown;
         user.Comp.LastAttackedEntity = target;
     }

--- a/Content.Shared/CombatMode/SharedCombatModeSystem.cs
+++ b/Content.Shared/CombatMode/SharedCombatModeSystem.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedCombatModeSystem : EntitySystem
         SetInCombatMode(uid, !component.IsInCombatMode, component);
 
         var msg = component.IsInCombatMode ? "action-popup-combat-enabled" : "action-popup-combat-disabled";
-        _popup.PopupClient(Loc.GetString(msg), args.Performer, args.Performer);
+        _popup.PopupEntity(Loc.GetString(msg), args.Performer, args.Performer);
     }
 
     public void SetCanDisarm(EntityUid entity, bool canDisarm, CombatModeComponent? component = null)

--- a/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/AnchorableSystem.cs
@@ -125,7 +125,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         _transformSystem.Unanchor(uid, xform);
         RaiseLocalEvent(uid, new UserUnanchoredEvent(args.User, used));
 
-        _popup.PopupClient(Loc.GetString("anchorable-unanchored"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("anchorable-unanchored"), uid, args.User);
 
         _adminLogger.Add(
             LogType.Unanchor,
@@ -143,7 +143,7 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (TryComp<PhysicsComponent>(uid, out var anchorBody) &&
             !TileFree(xform.Coordinates, anchorBody))
         {
-            _popup.PopupClient(Loc.GetString("anchorable-occupied"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("anchorable-occupied"), uid, args.User);
             return;
         }
 
@@ -163,7 +163,7 @@ public sealed partial class AnchorableSystem : EntitySystem
 
             if (AnyUnstackable(uid, coordinates))
             {
-                _popup.PopupClient(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, args.User);
+                _popup.PopupEntity(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, args.User);
                 return;
             }
 
@@ -177,7 +177,7 @@ public sealed partial class AnchorableSystem : EntitySystem
 
         RaiseLocalEvent(uid, new UserAnchoredEvent(args.User, used));
 
-        _popup.PopupClient(Loc.GetString("anchorable-anchored"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("anchorable-anchored"), uid, args.User);
 
         _adminLogger.Add(
             LogType.Anchor,
@@ -238,13 +238,13 @@ public sealed partial class AnchorableSystem : EntitySystem
         if (TryComp<PhysicsComponent>(uid, out var anchorBody) &&
             !TileFree(transform.Coordinates, anchorBody))
         {
-            _popup.PopupClient(Loc.GetString("anchorable-occupied"), uid, userUid);
+            _popup.PopupEntity(Loc.GetString("anchorable-occupied"), uid, userUid);
             return;
         }
 
         if (AnyUnstackable(uid, transform.Coordinates))
         {
-            _popup.PopupClient(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, userUid);
+            _popup.PopupEntity(Loc.GetString("construction-step-condition-no-unstackable-in-tile"), uid, userUid);
             return;
         }
 

--- a/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
+++ b/Content.Shared/Construction/EntitySystems/BlockAnchorOnSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class BlockAnchorOnSystem : EntitySystem
         if (!HasOverlap((ent, ent.Comp, Transform(ent))))
             return;
 
-        _popup.PopupPredicted(Loc.GetString("anchored-already-present"), ent, null);
+        _popup.PopupEntity(Loc.GetString("anchored-already-present"), ent);
         _xform.Unanchor(ent, Transform(ent));
     }
 
@@ -51,7 +51,7 @@ public sealed partial class BlockAnchorOnSystem : EntitySystem
         if (!HasOverlap((ent, ent.Comp, Transform(ent))))
             return;
 
-        _popup.PopupPredicted(Loc.GetString("anchored-already-present"), ent, args.User);
+        _popup.PopupEntity(Loc.GetString("anchored-already-present"), ent, args.User);
         args.Cancel();
     }
 

--- a/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
+++ b/Content.Shared/Containers/ItemSlot/ItemSlotsSystem.cs
@@ -248,9 +248,9 @@ namespace Content.Shared.Containers.ItemSlots
                 //
                 // doing a check to make sure that they're all the same or something is probably frivolous
                 if (lockedFailPopup != null)
-                    _popupSystem.PopupClient(Loc.GetString(lockedFailPopup), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString(lockedFailPopup), uid, args.User);
                 else if (whitelistFailPopup != null)
-                    _popupSystem.PopupClient(Loc.GetString(whitelistFailPopup), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString(whitelistFailPopup), uid, args.User);
                 return;
             }
 
@@ -268,7 +268,7 @@ namespace Content.Shared.Containers.ItemSlots
                 Insert(uid, slot, args.Used, args.User, excludeUserAudio: true);
 
                 if (slot.InsertSuccessPopup.HasValue)
-                    _popupSystem.PopupClient(Loc.GetString(slot.InsertSuccessPopup), uid, args.User);
+                    _popupSystem.PopupEntity(Loc.GetString(slot.InsertSuccessPopup), uid, args.User);
 
                 args.Handled = true;
                 return;
@@ -518,7 +518,7 @@ namespace Content.Shared.Containers.ItemSlots
             if (slot.Locked)
             {
                 if (popup.HasValue && slot.LockedFailPopup.HasValue)
-                    _popupSystem.PopupClient(Loc.GetString(slot.LockedFailPopup), uid, popup.Value);
+                    _popupSystem.PopupEntity(Loc.GetString(slot.LockedFailPopup), uid, popup.Value);
                 return false;
             }
 

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -141,7 +141,7 @@ namespace Content.Shared.Cuffs
 
             if (args.Cancelled)
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-cannot-interact-message"), args.Target, args.User);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-cannot-interact-message"), args.Target, args.User);
             }
         }
 
@@ -216,7 +216,7 @@ namespace Content.Shared.Cuffs
                 ? Loc.GetString("handcuff-component-cuff-interrupt-buckled-message")
                 : Loc.GetString("handcuff-component-cuff-interrupt-unbuckled-message");
 
-            _popup.PopupClient(message, ent, user);
+            _popup.PopupEntity(message, ent, user);
         }
 
         private void OnBuckleAttemptEvent(Entity<CuffableComponent> ent, ref BuckleAttemptEvent args)
@@ -303,7 +303,7 @@ namespace Content.Shared.Cuffs
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-fail-message"), user, user);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-fail-message"), user, user);
             }
         }
 
@@ -314,7 +314,7 @@ namespace Content.Shared.Cuffs
 
             if (!args.CanReach)
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-too-far-away-error"), args.User, args.User);
+                _popup.PopupEntity(Loc.GetString("handcuff-component-too-far-away-error"), args.User, args.User);
                 return;
             }
 
@@ -359,15 +359,15 @@ namespace Content.Shared.Cuffs
 
                 if (target == user)
                 {
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-self-success-message"), user, user);
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-self-success-message"), user, user);
                     _adminLog.Add(LogType.Action, LogImpact.Medium,
                         $"{ToPrettyString(user):player} has cuffed himself");
                 }
                 else
                 {
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-other-success-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-other-success-message",
                         ("otherName", Identity.Name(target, EntityManager, user))), user, user);
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-by-other-success-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-by-other-success-message",
                         ("otherName", Identity.Name(user, EntityManager, target))), target, target);
                     _adminLog.Add(LogType.Action, LogImpact.High,
                         $"{ToPrettyString(user):player} has cuffed {ToPrettyString(target):player}");
@@ -377,16 +377,16 @@ namespace Content.Shared.Cuffs
             {
                 if (target == user)
                 {
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-interrupt-self-message"), user, user);
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-interrupt-self-message"), user, user);
                 }
                 else
                 {
                     // TODO Fix popup message wording
                     // This message assumes that the user being handcuffed is the one that caused the handcuff to fail.
 
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-interrupt-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-interrupt-message",
                         ("targetName", Identity.Name(target, EntityManager, user))), user, user);
-                    _popup.PopupClient(Loc.GetString("handcuff-component-cuff-interrupt-other-message",
+                    _popup.PopupEntity(Loc.GetString("handcuff-component-cuff-interrupt-other-message",
                         ("otherName", Identity.Name(user, EntityManager, target)),
                         ("otherEnt", user)), target, target);
                 }
@@ -504,21 +504,21 @@ namespace Content.Shared.Cuffs
 
             if (!TryComp<HandsComponent>(target, out var hands))
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-target-has-no-hands-error",
+                _popup.PopupEntity(Loc.GetString("handcuff-component-target-has-no-hands-error",
                     ("targetName", Identity.Name(target, EntityManager, user))), user, user);
                 return true;
             }
 
             if (cuffable.CuffedHandCount >= hands.Count)
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-target-has-no-free-hands-error",
+                _popup.PopupEntity(Loc.GetString("handcuff-component-target-has-no-free-hands-error",
                     ("targetName", Identity.Name(target, EntityManager, user))), user, user);
                 return true;
             }
 
             if (!_hands.CanDrop(user, handcuff))
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-cannot-drop-cuffs", ("target", Identity.Name(target, EntityManager, user))), user, user);
+                _popup.PopupEntity(Loc.GetString("handcuff-component-cannot-drop-cuffs", ("target", Identity.Name(target, EntityManager, user))), user, user);
                 return false;
             }
 
@@ -552,11 +552,11 @@ namespace Content.Shared.Cuffs
 
             if (target == user)
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-target-self"), user, user);
+                _popup.PopupEntity(Loc.GetString("handcuff-component-target-self"), user, user);
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("handcuff-component-start-cuffing-target-message",
+                _popup.PopupEntity(Loc.GetString("handcuff-component-start-cuffing-target-message",
                     ("targetName", Identity.Name(target, EntityManager, user))), user, user);
                 _popup.PopupEntity(Loc.GetString("handcuff-component-start-cuffing-by-other-message",
                     ("otherName", Identity.Name(user, EntityManager, target))), target, target);
@@ -622,7 +622,7 @@ namespace Content.Shared.Cuffs
 
             if (!isOwner && !_interaction.InRangeUnobstructed(user, target.Owner))
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-cannot-remove-cuffs-too-far-message"), user, user);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-cannot-remove-cuffs-too-far-message"), user, user);
                 return;
             }
 
@@ -670,11 +670,11 @@ namespace Content.Shared.Cuffs
 
             if (isOwner)
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-start-uncuffing-self"), user, user);
+                _popup.PopupEntity(Loc.GetString("cuffable-component-start-uncuffing-self"), user, user);
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("cuffable-component-start-uncuffing-target-message",
+                _popup.PopupEntity(Loc.GetString("cuffable-component-start-uncuffing-target-message",
                     ("targetName", Identity.Name(target, EntityManager, user))),
                     user,
                     user);
@@ -739,14 +739,14 @@ namespace Content.Shared.Cuffs
                 {
                     if (shoved)
                     {
-                        _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-push-success-message",
+                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-push-success-message",
                             ("otherName", Identity.Name(user.Value, EntityManager, user))),
                             user.Value,
                             user.Value);
                     }
                     else
                     {
-                        _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
+                        _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-success-message"), user.Value, user.Value);
                     }
                 }
 
@@ -767,7 +767,7 @@ namespace Content.Shared.Cuffs
             {
                 if (user != target)
                 {
-                    _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
+                    _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
                         ("cuffedHandCount", cuffable.CuffedHandCount),
                         ("otherName", Identity.Name(user.Value, EntityManager, user.Value))), user.Value, user.Value);
                     _popup.PopupEntity(Loc.GetString(
@@ -777,7 +777,7 @@ namespace Content.Shared.Cuffs
                 }
                 else
                 {
-                    _popup.PopupClient(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
+                    _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-partial-success-message",
                         ("cuffedHandCount", cuffable.CuffedHandCount)), user.Value, user.Value);
                 }
             }

--- a/Content.Shared/Damage/Systems/DamageOnAttackedSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageOnAttackedSystem.cs
@@ -81,7 +81,7 @@ public sealed partial class DamageOnAttackedSystem : EntitySystem
             _audioSystem.PlayPredicted(entity.Comp.InteractSound, entity, args.User);
 
             if (entity.Comp.PopupText != null)
-                _popupSystem.PopupClient(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
+                _popupSystem.PopupEntity(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
 
         }
     }

--- a/Content.Shared/Damage/Systems/DamageOnInteractSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageOnInteractSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class DamageOnInteractSystem : EntitySystem
             _audioSystem.PlayPredicted(entity.Comp.InteractSound, args.Target, args.User);
 
             if (entity.Comp.PopupText != null)
-                _popupSystem.PopupClient(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
+                _popupSystem.PopupEntity(Loc.GetString(entity.Comp.PopupText), args.User, args.User);
 
             // Attempt to paralyze the user after they have taken damage
             if (_random.Prob(entity.Comp.StunChance))

--- a/Content.Shared/Damage/Systems/DamagePopupSystem.cs
+++ b/Content.Shared/Damage/Systems/DamagePopupSystem.cs
@@ -32,7 +32,7 @@ public sealed partial class DamagePopupSystem : EntitySystem
             };
 
             // Turn this back into (msg, ent.Owner, args.Origin) when shooting gets predicted.
-            _popupSystem.PopupPredicted(msg, ent.Owner, null);
+            _popupSystem.PopupEntity(msg, ent.Owner);
         }
     }
 
@@ -43,7 +43,7 @@ public sealed partial class DamagePopupSystem : EntitySystem
             var next = (DamagePopupType)(((int)ent.Comp.Type + 1) % Enum.GetValues<DamagePopupType>().Length);
             ent.Comp.Type = next;
             Dirty(ent);
-            _popupSystem.PopupPredicted(Loc.GetString("damage-popup-component-switched", ("setting", ent.Comp.Type)), ent.Owner, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("damage-popup-component-switched", ("setting", ent.Comp.Type)), ent.Owner);
         }
     }
 }

--- a/Content.Shared/Dice/SharedDiceSystem.cs
+++ b/Content.Shared/Dice/SharedDiceSystem.cs
@@ -80,7 +80,7 @@ public abstract partial class SharedDiceSystem : EntitySystem
         var popupString = Loc.GetString("dice-component-on-roll-land",
             ("die", entity),
             ("currentSide", entity.Comp.CurrentValue));
-        _popup.PopupPredicted(popupString, entity, user);
+        _popup.PopupEntity(popupString, entity);
         _audio.PlayPredicted(entity.Comp.Sound, entity, user);
     }
 }

--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -82,14 +82,14 @@ public abstract partial class SharedFirelockSystem : EntitySystem
     {
         if (ent.Comp.Temperature)
         {
-            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-fire-message"),
+            _popupSystem.PopupEntity(Loc.GetString("firelock-component-is-holding-fire-message"),
                 ent.Owner,
                 user,
                 PopupType.MediumCaution);
         }
         else if (ent.Comp.Pressure)
         {
-            _popupSystem.PopupClient(Loc.GetString("firelock-component-is-holding-pressure-message"),
+            _popupSystem.PopupEntity(Loc.GetString("firelock-component-is-holding-pressure-message"),
                 ent.Owner,
                 user,
                 PopupType.MediumCaution);

--- a/Content.Shared/Doors/Systems/SharedTurnstileSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedTurnstileSystem.cs
@@ -73,7 +73,7 @@ public abstract partial class SharedTurnstileSystem : EntitySystem
         {
             if (_timing.CurTime >= ent.Comp.NextResistTime)
             {
-                _popup.PopupClient(Loc.GetString("turnstile-component-popup-resist", ("turnstile", ent.Owner)), ent, args.OtherEntity);
+                _popup.PopupEntity(Loc.GetString("turnstile-component-popup-resist", ("turnstile", ent.Owner)), ent, args.OtherEntity);
                 ent.Comp.NextResistTime = _timing.CurTime + TimeSpan.FromSeconds(0.1);
                 Dirty(ent);
             }

--- a/Content.Shared/Engineering/Systems/InflatableSafeDisassemblySystem.cs
+++ b/Content.Shared/Engineering/Systems/InflatableSafeDisassemblySystem.cs
@@ -28,7 +28,7 @@ public sealed partial class InflatableSafeDisassemblySystem : EntitySystem
         if (!HasComp<BalloonPopperComponent>(args.Used))
             return;
 
-        _popupSystem.PopupPredicted(
+        _popupSystem.PopupEntity(
             Loc.GetString("inflatable-safe-disassembly", ("item", args.Used), ("target", ent.Owner)),
             ent,
             args.User);

--- a/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
+++ b/Content.Shared/Ensnaring/SharedEnsnareableSystem.cs
@@ -75,9 +75,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
         if (args.Cancelled || !Container.Remove(args.Args.Used.Value, component.Container))
         {
             if (args.User == args.Target)
-                Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-fail", ("ensnare", args.Args.Used)), uid, args.User, PopupType.MediumCaution);
+                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail", ("ensnare", args.Args.Used)), uid, args.User, PopupType.MediumCaution);
             else if (args.Target != null)
-                Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-fail-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, args.User, PopupType.MediumCaution);
+                Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-fail-other", ("ensnare", args.Args.Used), ("user", Identity.Entity(args.Target.Value, EntityManager))), uid, args.User, PopupType.MediumCaution);
 
             return;
         }
@@ -89,9 +89,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
         _hands.PickupOrDrop(args.Args.User, args.Args.Used.Value);
 
         if (args.User == args.Target)
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-complete", ("ensnare", args.Args.Used)), uid, args.User, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete", ("ensnare", args.Args.Used)), uid, args.User, PopupType.Medium);
         else if (args.Target != null)
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-complete-other", ("ensnare", args.Args.Used), ("user", args.Target)), uid, args.User, PopupType.Medium);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-complete-other", ("ensnare", args.Args.Used), ("user", Identity.Entity(args.Target.Value, EntityManager))), uid, args.User, PopupType.Medium);
 
         UpdateAlert(args.Args.Target.Value, component);
         var ev = new EnsnareRemoveEvent(ensnaring.WalkSpeed, ensnaring.SprintSpeed);
@@ -169,9 +169,9 @@ public abstract partial class SharedEnsnareableSystem : EntitySystem
             return;
 
         if (user == target)
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free", ("ensnare", ensnare)), target, target);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free", ("ensnare", ensnare)), target, user);
         else
-            Popup.PopupPredicted(Loc.GetString("ensnare-component-try-free-other", ("ensnare", ensnare), ("user", Identity.Entity(target, EntityManager))), user, user);
+            Popup.PopupEntity(Loc.GetString("ensnare-component-try-free-other", ("ensnare", ensnare), ("user", Identity.Entity(target, EntityManager))), user, user);
     }
 
     private void OnStripEnsnareMessage(EntityUid uid, EnsnareableComponent component, StrippingEnsnareButtonPressed args)

--- a/Content.Shared/Eye/Blinding/Systems/ActivatableUIRequiresVisionSystem.cs
+++ b/Content.Shared/Eye/Blinding/Systems/ActivatableUIRequiresVisionSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class ActivatableUIRequiresVisionSystem : EntitySystem
         if (TryComp<BlindableComponent>(args.User, out var blindable) && blindable.IsBlind)
         {
             if (!args.Silent)
-                _popupSystem.PopupClient(Loc.GetString("blindness-fail-attempt"), args.User, Shared.Popups.PopupType.MediumCaution);
+                _popupSystem.PopupCursor(Loc.GetString("blindness-fail-attempt"), args.User, Shared.Popups.PopupType.MediumCaution);
             args.Cancel();
         }
     }

--- a/Content.Shared/FingerprintReader/FingerprintReaderSystem.cs
+++ b/Content.Shared/FingerprintReader/FingerprintReaderSystem.cs
@@ -64,7 +64,7 @@ public sealed partial class FingerprintReaderSystem : EntitySystem
             denyReason = Loc.GetString("fingerprint-reader-fail-gloves", ("blocker", gloves));
 
             if (showPopup)
-                _popup.PopupClient(denyReason, target, user);
+                _popup.PopupEntity(denyReason, target, user);
 
             return false;
         }
@@ -76,7 +76,7 @@ public sealed partial class FingerprintReaderSystem : EntitySystem
             denyReason = Loc.GetString("fingerprint-reader-fail");
 
             if (showPopup)
-                _popup.PopupClient(denyReason, target, user);
+                _popup.PopupEntity(denyReason, target, user);
 
             return false;
         }

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -128,7 +128,7 @@ public abstract partial class SharedFlashSystem : EntitySystem
         {
             _appearance.SetData(ent.Owner, FlashVisuals.Burnt, true);
             _tag.AddTag(ent.Owner, TrashTag);
-            _popup.PopupClient(Loc.GetString("flash-component-becomes-empty"), user);
+            _popup.PopupCursor(Loc.GetString("flash-component-becomes-empty"), user);
         }
 
         return true;

--- a/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
@@ -225,7 +225,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         if (drainSolution.AvailableVolume > 0)
         {
-            _popup.PopupPredicted(Loc.GetString("drain-component-unclog-notapplicable", ("object", args.Target.Value)), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("drain-component-unclog-notapplicable", ("object", args.Target.Value)), args.Target.Value, args.User);
             return;
         }
 
@@ -251,7 +251,7 @@ public sealed partial class DrainSystem : EntitySystem
         var rand = new System.Random(seed);
         if (!rand.Prob(ent.Comp.UnclogProbability))
         {
-            _popup.PopupPredicted(Loc.GetString("drain-component-unclog-fail", ("object", args.Target.Value)), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("drain-component-unclog-fail", ("object", args.Target.Value)), args.Target.Value);
             return;
         }
 
@@ -260,7 +260,7 @@ public sealed partial class DrainSystem : EntitySystem
 
         _solutionContainerSystem.RemoveAllSolution(ent.Comp.Solution.Value);
         _audio.PlayPredicted(ent.Comp.UnclogSound, args.Target.Value, args.User);
-        _popup.PopupPredicted(Loc.GetString("drain-component-unclog-success", ("object", args.Target.Value)), args.Target.Value, args.User);
+        _popup.PopupEntity(Loc.GetString("drain-component-unclog-success", ("object", args.Target.Value)), args.Target.Value);
     }
 
     // Prevent a debug assert.

--- a/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/DrainSystem.cs
@@ -90,7 +90,7 @@ public sealed partial class DrainSystem : EntitySystem
         // Find the solution in the container that is emptied.
         if (!_solutionContainerSystem.TryGetDrainableSolution(container, out var containerSoln, out var containerSolution) || containerSolution.Volume == FixedPoint2.Zero)
         {
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString("drain-component-empty-verb-using-is-empty-message", ("object", container)),
                 ent.Owner,
                 user);
@@ -119,7 +119,7 @@ public sealed partial class DrainSystem : EntitySystem
         {
             var solutionToSpill = _solutionContainerSystem.SplitSolution(containerSoln.Value, amountToSpillOnGround);
             _puddle.TrySpillAt(Transform(ent.Owner).Coordinates, solutionToSpill, out _);
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString("drain-component-empty-verb-target-is-full-message", ("object", ent.Owner)),
                 ent.Owner,
                 user);

--- a/Content.Shared/Fluids/EntitySystems/SolutionDumpingSystem.cs
+++ b/Content.Shared/Fluids/EntitySystems/SolutionDumpingSystem.cs
@@ -123,14 +123,14 @@ public sealed partial class SolutionDumpingSystem : EntitySystem
         sourceSolEnt = null;
         if (!_actionBlocker.CanComplexInteract(user))
         {
-            _popup.PopupClient(Loc.GetString("mopping-system-no-hands"), user, user);
+            _popup.PopupEntity(Loc.GetString("mopping-system-no-hands"), user, user);
             return false;
         }
 
         if (!_solContainer.TryGetSolution(sourceContainer, sourceSolutionName, out sourceSolEnt)
             || sourceSolEnt.Value.Comp.Solution.Volume == FixedPoint2.Zero)
         {
-            _popup.PopupClient(Loc.GetString("mopping-system-empty", ("used", sourceContainer)),
+            _popup.PopupEntity(Loc.GetString("mopping-system-empty", ("used", sourceContainer)),
                 sourceContainer,
                 user);
             return false;
@@ -138,7 +138,7 @@ public sealed partial class SolutionDumpingSystem : EntitySystem
 
         if (checkAvailableVolume && targetSol.AvailableVolume == FixedPoint2.Zero)
         {
-            _popup.PopupClient(Loc.GetString("mopping-system-full", ("used", targetContainer)), targetContainer, user);
+            _popup.PopupEntity(Loc.GetString("mopping-system-full", ("used", targetContainer)), targetContainer, user);
             return false;
         }
 

--- a/Content.Shared/Fluids/SharedAbsorbentSystem.cs
+++ b/Content.Shared/Fluids/SharedAbsorbentSystem.cs
@@ -163,7 +163,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         var absorbentSolution = absorbentSoln.Comp.Solution;
         if (absorbentSolution.Volume <= 0)
         {
-            _popups.PopupClient(Loc.GetString("mopping-system-target-container-empty", ("target", target)), user, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-target-container-empty", ("target", target)), user, user);
             return false;
         }
 
@@ -174,7 +174,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
 
         if (transferAmount <= 0)
         {
-            _popups.PopupClient(Loc.GetString("mopping-system-full", ("used", absorbEnt)), absorbEnt, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", absorbEnt)), absorbEnt, user);
             return false;
         }
 
@@ -209,7 +209,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
             && absorbentSolution.AvailableVolume == FixedPoint2.Zero)
         {
             // Nothing to transfer to refillable and no room to absorb anything extra
-            _popups.PopupClient(Loc.GetString("mopping-system-puddle-space", ("used", absorbEnt)), user, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-puddle-space", ("used", absorbEnt)), user, user);
 
             // We can return cleanly because nothing was split from absorbent solution
             return false;
@@ -228,7 +228,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         if (waterFromRefillable.Volume == FixedPoint2.Zero && contaminantsFromAbsorbent.Volume == FixedPoint2.Zero)
         {
             // Nothing to transfer in either direction
-            _popups.PopupClient(Loc.GetString("mopping-system-target-container-empty-water", ("target", target)),
+            _popups.PopupEntity(Loc.GetString("mopping-system-target-container-empty-water", ("target", target)),
                 user,
                 user);
 
@@ -250,7 +250,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
 
         if (refillableSolution.AvailableVolume <= 0)
         {
-            _popups.PopupClient(Loc.GetString("mopping-system-full", ("used", target)), user, user);
+            _popups.PopupEntity(Loc.GetString("mopping-system-full", ("used", target)), user, user);
         }
         else
         {
@@ -293,7 +293,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
                 puddleSolution.GetTotalPrototypeQuantity(Puddle.GetAbsorbentReagents(puddleSolution));
             if (puddleAbsorberVolume == puddleSolution.Volume)
             {
-                _popups.PopupClient(Loc.GetString("mopping-system-puddle-already-mopped", ("target", target)),
+                _popups.PopupEntity(Loc.GetString("mopping-system-puddle-already-mopped", ("target", target)),
                     target,
                     user);
                 return true;
@@ -306,7 +306,7 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
             // No material
             if (available == FixedPoint2.Zero)
             {
-                _popups.PopupClient(Loc.GetString("mopping-system-no-water", ("used", absorbEnt)), absorbEnt, user);
+                _popups.PopupEntity(Loc.GetString("mopping-system-no-water", ("used", absorbEnt)), absorbEnt, user);
                 return true;
             }
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Spillable.cs
@@ -170,7 +170,7 @@ public abstract partial class SharedPuddleSystem
 
             Reactive.DoEntityReaction(hit, splitSolution, ReactionMethod.Touch, args.User);
 
-            Popups.PopupClient(Loc.GetString("spill-melee-hit-attacker",
+            Popups.PopupEntity(Loc.GetString("spill-melee-hit-attacker",
                     ("amount", totalSplit / hitCount),
                     ("spillable", entity.Owner),
                     ("target", Identity.Entity(hit, EntityManager, args.User))),

--- a/Content.Shared/Foldable/DeployFoldableSystem.cs
+++ b/Content.Shared/Foldable/DeployFoldableSystem.cs
@@ -69,7 +69,7 @@ public sealed partial class DeployFoldableSystem : EntitySystem
         if (!TryComp(ent.Owner, out PhysicsComponent? anchorBody)
             || !_anchorable.TileFree(args.ClickLocation, anchorBody))
         {
-            _popup.PopupPredicted(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("foldable-deploy-fail", ("object", ent)), ent, args.User);
             return;
         }
 

--- a/Content.Shared/Foldable/FoldableSystem.cs
+++ b/Content.Shared/Foldable/FoldableSystem.cs
@@ -101,9 +101,9 @@ public sealed partial class FoldableSystem : EntitySystem
         if (!result && folder != null)
         {
             if (comp.IsFolded)
-                _popup.PopupPredicted(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid, folder.Value);
+                _popup.PopupEntity(Loc.GetString("foldable-unfold-fail", ("object", uid)), uid, folder.Value);
             else
-                _popup.PopupPredicted(Loc.GetString("foldable-fold-fail", ("object", uid)), uid, folder.Value);
+                _popup.PopupEntity(Loc.GetString("foldable-fold-fail", ("object", uid)), uid, folder.Value);
         }
         return result;
     }

--- a/Content.Shared/Friends/Systems/PettableFriendSystem.cs
+++ b/Content.Shared/Friends/Systems/PettableFriendSystem.cs
@@ -39,7 +39,7 @@ public sealed partial class PettableFriendSystem : EntitySystem
         if (!_factionException.IsIgnored(exception, user))
         {
             // you have made a new friend :)
-            _popup.PopupClient(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
+            _popup.PopupEntity(Loc.GetString(comp.SuccessString, ("target", uid)), user, user);
             _factionException.IgnoreEntity(exception, user);
             args.Handled = true;
             return;
@@ -48,7 +48,7 @@ public sealed partial class PettableFriendSystem : EntitySystem
         if (_useDelayQuery.TryComp(uid, out var useDelay) && !_useDelay.TryResetDelay((uid, useDelay), true))
             return;
 
-        _popup.PopupClient(Loc.GetString(comp.FailureString, ("target", uid)), user, user);
+        _popup.PopupEntity(Loc.GetString(comp.FailureString, ("target", uid)), user, user);
     }
 
     private void OnRehydrated(Entity<PettableFriendComponent> ent, ref GotRehydratedEvent args)

--- a/Content.Shared/Glue/GlueSystem.cs
+++ b/Content.Shared/Glue/GlueSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class GlueSystem : EntitySystem
         // This effectively means any unremoveable item could be removed with a bottle of glue.
         if (HasComp<GluedComponent>(target) || !HasComp<ItemComponent>(target) || HasComp<UnremoveableComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
             return false;
         }
 
@@ -84,7 +84,7 @@ public sealed partial class GlueSystem : EntitySystem
             if (quantity > 0)
             {
                 _audio.PlayPredicted(entity.Comp.Squeeze, entity.Owner, actor);
-                _popup.PopupClient(Loc.GetString("glue-success", ("target", target)), actor, actor, PopupType.Medium);
+                _popup.PopupEntity(Loc.GetString("glue-success", ("target", target)), actor, actor, PopupType.Medium);
                 _adminLogger.Add(LogType.Action, LogImpact.Medium, $"{ToPrettyString(actor):actor} glued {ToPrettyString(target):subject} with {ToPrettyString(entity.Owner):tool}");
                 var gluedComp = EnsureComp<GluedComponent>(target);
                 gluedComp.Duration = quantity.Double() * entity.Comp.DurationPerUnit;
@@ -93,7 +93,7 @@ public sealed partial class GlueSystem : EntitySystem
             }
         }
 
-        _popup.PopupClient(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("glue-failure", ("target", target)), actor, actor, PopupType.Medium);
         return false;
     }
 

--- a/Content.Shared/Gravity/SharedGravityGeneratorSystem.cs
+++ b/Content.Shared/Gravity/SharedGravityGeneratorSystem.cs
@@ -22,7 +22,7 @@ public abstract partial class SharedGravityGeneratorSystem : EntitySystem
         if (!ent.Comp.GravityActive)
             return;
 
-        _popupSystem.PopupClient(Loc.GetString("gravity-generator-unanchoring-failed"), ent.Owner, args.User, PopupType.Medium);
+        _popupSystem.PopupEntity(Loc.GetString("gravity-generator-unanchoring-failed"), ent.Owner, args.User, PopupType.Medium);
 
         args.Cancel();
     }

--- a/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
+++ b/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
@@ -57,10 +57,9 @@ public abstract partial class SharedHotPotatoSystem : EntitySystem
 
             if (!_hands.IsHolding((hitEntity, hands), ent.Owner, out _) && _hands.TryForcePickupAnyHand(hitEntity, ent.Owner, handsComp: hands))
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString("hot-potato-passed", ("from", Identity.Entity(args.User, EntityManager)), ("to", Identity.Entity(hitEntity, EntityManager))),
                     ent.Owner,
-                    args.User,
                     PopupType.Medium);
                 break;
             }

--- a/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
+++ b/Content.Shared/HotPotato/SharedHotPotatoSystem.cs
@@ -64,7 +64,7 @@ public abstract partial class SharedHotPotatoSystem : EntitySystem
                 break;
             }
 
-            _popup.PopupClient(
+            _popup.PopupEntity(
                 Loc.GetString("hot-potato-failed", ("to", Identity.Entity(hitEntity, EntityManager))),
                 ent.Owner,
                 args.User,

--- a/Content.Shared/Interaction/InteractionPopupSystem.cs
+++ b/Content.Shared/Interaction/InteractionPopupSystem.cs
@@ -138,7 +138,7 @@ public sealed partial class InteractionPopupSystem : EntitySystem
             return;
         }
 
-        _popupSystem.PopupClient(msg, uid, user);
+        _popupSystem.PopupEntity(msg, uid, user);
 
         if (sfx == null)
             return;

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -871,7 +871,7 @@ namespace Content.Shared.Interaction
             if (!inRange && popup && _gameTiming.IsFirstTimePredicted)
             {
                 var message = Loc.GetString("interaction-system-user-interaction-cannot-reach");
-                _popupSystem.PopupClient(message, origin, origin);
+                _popupSystem.PopupEntity(message, origin, origin);
             }
 
             return inRange;

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -93,14 +93,14 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
         if (!TryComp<InventoryComponent>(uid, out var inventory) || !_inventory.HasSlot(uid, equipmentSlot, inventory))
         {
-            _popup.PopupClient(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", equipmentSlot)), uid, uid);
+            _popup.PopupEntity(Loc.GetString("smart-equip-missing-equipment-slot", ("slotName", equipmentSlot)), uid, uid);
             return;
         }
 
         // early out if we have an item and cant drop it at all
         if (handItem != null && !_hands.CanDropHeld(uid, hands.ActiveHandId))
         {
-            _popup.PopupClient(Loc.GetString("smart-equip-cant-drop"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("smart-equip-cant-drop"), uid, uid);
             return;
         }
 
@@ -129,13 +129,13 @@ public sealed partial class SmartEquipSystem : EntitySystem
         {
             if (handItem == null)
             {
-                _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                _popup.PopupEntity(emptyEquipmentSlotString, uid, uid);
                 return;
             }
 
             if (!_inventory.CanEquip(uid, handItem.Value, equipmentSlot, out var reason))
             {
-                _popup.PopupClient(Loc.GetString(reason), uid, uid);
+                _popup.PopupEntity(Loc.GetString(reason), uid, uid);
                 return;
             }
 
@@ -150,7 +150,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
             switch (handItem)
             {
                 case null when storage.Container.ContainedEntities.Count == 0:
-                    _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                    _popup.PopupEntity(emptyEquipmentSlotString, uid, uid);
                     return;
                 case null:
                     var removing = storage.Container.ContainedEntities[^1];
@@ -162,7 +162,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
             if (!_storage.CanInsert(slotItem, handItem.Value, out var reason))
             {
                 if (reason != null)
-                    _popup.PopupClient(Loc.GetString(reason), uid, uid);
+                    _popup.PopupEntity(Loc.GetString(reason), uid, uid);
 
                 return;
             }
@@ -196,7 +196,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
                 if (toEjectFrom == null)
                 {
-                    _popup.PopupClient(emptyEquipmentSlotString, uid, uid);
+                    _popup.PopupEntity(emptyEquipmentSlotString, uid, uid);
                     return;
                 }
 
@@ -218,7 +218,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
             if (toInsertTo == null)
             {
-                _popup.PopupClient(Loc.GetString("smart-equip-no-valid-item-slot-insert", ("item", handItem.Value)), uid, uid);
+                _popup.PopupEntity(Loc.GetString("smart-equip-no-valid-item-slot-insert", ("item", handItem.Value)), uid, uid);
                 return;
             }
 
@@ -232,7 +232,7 @@ public sealed partial class SmartEquipSystem : EntitySystem
 
         if (!_inventory.CanUnequip(uid, equipmentSlot, out var inventoryReason))
         {
-            _popup.PopupClient(Loc.GetString(inventoryReason), uid, uid);
+            _popup.PopupEntity(Loc.GetString(inventoryReason), uid, uid);
             return;
         }
 

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -467,7 +467,7 @@ public abstract partial class InventorySystem
         // the reason we check for > 1 is because the first item is always the one we are trying to unequip,
         // whereas we only want to notify for extra dropped items.
         if (!silent && firstRun && itemsDropped > 1)
-            _popup.PopupClient(Loc.GetString("inventory-component-dropped-from-unequip", ("items", itemsDropped - 1)), target, target);
+            _popup.PopupEntity(Loc.GetString("inventory-component-dropped-from-unequip", ("items", itemsDropped - 1)), target, target);
 
         // TODO: Inventory needs a hot cleanup hoo boy
         // Check if something else (AKA toggleable) dumped it into a container.

--- a/Content.Shared/Inventory/InventorySystem.Equip.cs
+++ b/Content.Shared/Inventory/InventorySystem.Equip.cs
@@ -109,7 +109,7 @@ public abstract partial class InventorySystem
         // before we drop the item, check that it can be equipped in the first place.
         if (!CanEquip(actor, held.Value, ev.Slot, out var reason))
         {
-            _popup.PopupCursor(Loc.GetString(reason));
+            _popup.PopupCursor(Loc.GetString(reason), actor);
             return;
         }
 
@@ -131,7 +131,7 @@ public abstract partial class InventorySystem
         if (!Resolve(target, ref inventory, false))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
+                _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"), actor);
             return false;
         }
 
@@ -142,14 +142,14 @@ public abstract partial class InventorySystem
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"));
+                _popup.PopupCursor(Loc.GetString("inventory-component-can-equip-cannot"), actor);
             return false;
         }
 
         if (!force && !CanEquip(actor, target, itemUid, slot, out var reason, slotDefinition, inventory, clothing))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString(reason));
+                _popup.PopupCursor(Loc.GetString(reason), actor);
             return false;
         }
 
@@ -179,7 +179,7 @@ public abstract partial class InventorySystem
         if (!_containerSystem.Insert(itemUid, slotContainer))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
+                _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"), actor);
             return false;
         }
 
@@ -398,14 +398,14 @@ public abstract partial class InventorySystem
         if (!Resolve(target, ref inventory, false))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
+                _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"), actor);
             return false;
         }
 
         if (!TryGetSlotContainer(target, slot, out var slotContainer, out var slotDefinition, inventory))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"));
+                _popup.PopupCursor(Loc.GetString("inventory-component-can-unequip-cannot"), actor);
             return false;
         }
 
@@ -417,7 +417,7 @@ public abstract partial class InventorySystem
         if (!force && !CanUnequip(actor, target, slot, out var reason, slotContainer, slotDefinition, inventory))
         {
             if(!silent)
-                _popup.PopupCursor(Loc.GetString(reason));
+                _popup.PopupCursor(Loc.GetString(reason), actor);
             return false;
         }
 

--- a/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
+++ b/Content.Shared/Inventory/VirtualItem/SharedVirtualItemSystem.cs
@@ -130,7 +130,7 @@ public abstract partial class SharedVirtualItemSystem : EntitySystem
                     continue;
 
                 if (!silent && !TerminatingOrDeleted(held))
-                    _popup.PopupClient(Loc.GetString("virtual-item-dropped-other", ("dropped", held)), user, user);
+                    _popup.PopupEntity(Loc.GetString("virtual-item-dropped-other", ("dropped", held)), user, user);
 
                 empty = hand;
                 break;

--- a/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/ItemToggleSystem.cs
@@ -174,7 +174,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
             if (showPopup && attempt.Popup != null && user != null)
             {
                 if (predicted)
-                    _popup.PopupClient(attempt.Popup, uid, user.Value);
+                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
                 else
                     _popup.PopupEntity(attempt.Popup, uid, user.Value);
             }
@@ -216,7 +216,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
             if (showPopup && attempt.Popup != null && user != null)
             {
                 if (predicted)
-                    _popup.PopupClient(attempt.Popup, uid, user.Value);
+                    _popup.PopupEntity(attempt.Popup, uid, user.Value);
                 else
                     _popup.PopupEntity(attempt.Popup, uid, user.Value);
             }
@@ -236,7 +236,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
         {
             _audio.PlayPredicted(soundToPlay, uid, user);
             if (showPopup && ent.Comp.PopupActivate != null && user != null)
-                _popup.PopupClient(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString(ent.Comp.PopupActivate), user.Value, user.Value);
         }
         else
         {
@@ -264,7 +264,7 @@ public sealed partial class ItemToggleSystem : EntitySystem
         {
             _audio.PlayPredicted(soundToPlay, uid, user);
             if (showPopup && ent.Comp.PopupDeactivate != null && user != null)
-                _popup.PopupClient(Loc.GetString(ent.Comp.PopupDeactivate), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString(ent.Comp.PopupDeactivate), user.Value, user.Value);
         }
         else
         {

--- a/Content.Shared/Item/MultiHandedItemSystem.cs
+++ b/Content.Shared/Item/MultiHandedItemSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class MultiHandedItemSystem : EntitySystem
         args.Cancel();
 
         if (args.ShowPopup)
-            _popup.PopupPredictedCursor(
+            _popup.PopupCursor(
                 Loc.GetString("multi-handed-item-pick-up-fail",
                     ("number", ent.Comp.HandsNeeded - 1),
                     ("item", ent.Owner)),

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -50,17 +50,17 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
 
             if (markItem == null)
             {
-                _popups.PopupClient(Loc.GetString("item-recall-item-mark-empty"), args.Performer, args.Performer);
+                _popups.PopupEntity(Loc.GetString("item-recall-item-mark-empty"), args.Performer, args.Performer);
                 return;
             }
 
             if (HasComp<RecallMarkerComponent>(markItem))
             {
-                _popups.PopupClient(Loc.GetString("item-recall-item-already-marked", ("item", markItem)), args.Performer, args.Performer);
+                _popups.PopupEntity(Loc.GetString("item-recall-item-already-marked", ("item", markItem)), args.Performer, args.Performer);
                 return;
             }
 
-            _popups.PopupClient(Loc.GetString("item-recall-item-marked", ("item", markItem.Value)), args.Performer, args.Performer);
+            _popups.PopupEntity(Loc.GetString("item-recall-item-marked", ("item", markItem.Value)), args.Performer, args.Performer);
             TryMarkItem(ent, markItem.Value);
             return;
         }
@@ -131,7 +131,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
             // This line will only do something once that is fixed.
             if (action.Comp.AttachedEntity is {} user)
             {
-                _popups.PopupClient(Loc.GetString("item-recall-item-unmark", ("item", item)), user, user, PopupType.MediumCaution);
+                _popups.PopupEntity(Loc.GetString("item-recall-item-unmark", ("item", item)), user, user, PopupType.MediumCaution);
                 RemoveFromPvsOverride(item, user);
             }
 

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -86,7 +86,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         _popups.PopupPredicted(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
                                Loc.GetString("item-recall-item-summon-others", ("item", ent), ("name", Identity.Entity(user, EntityManager))),
                                user, user);
-        _popups.PopupPredictedCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates, user);
+        _popups.PopupCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates);
 
         _hands.TryForcePickupAnyHand(user, ent);
     }

--- a/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
+++ b/Content.Shared/ItemRecall/SharedItemRecallSystem.cs
@@ -83,7 +83,7 @@ public abstract partial class SharedItemRecallSystem : EntitySystem
         if (TryComp<EmbeddableProjectileComponent>(ent, out var projectile))
             _proj.EmbedDetach(ent, projectile, user);
 
-        _popups.PopupPredicted(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
+        _popups.PopupEntity(Loc.GetString("item-recall-item-summon-self", ("item", ent)),
                                Loc.GetString("item-recall-item-summon-others", ("item", ent), ("name", Identity.Entity(user, EntityManager))),
                                user, user);
         _popups.PopupCoordinates(Loc.GetString("item-recall-item-disappear", ("item", ent)), Transform(ent).Coordinates);

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -128,7 +128,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
         if (args.Handled || !victim.HasValue)
             return;
 
-        _popupSystem.PopupClient(Loc.GetString("butcherable-need-knife",
+        _popupSystem.PopupEntity(Loc.GetString("butcherable-need-knife",
             ("target", Identity.Entity(victim.Value, EntityManager))),
             ent,
             args.User,
@@ -148,7 +148,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
 
         if (!TryComp<SharpComponent>(args.Used, out var sharp))
         {
-            _popupSystem.PopupClient(Loc.GetString("butcherable-need-knife",
+            _popupSystem.PopupEntity(Loc.GetString("butcherable-need-knife",
                     ("target", Identity.Entity(victim.Value, EntityManager))),
                     ent,
                     args.User,
@@ -339,7 +339,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
 
         _audioSystem.PlayPredicted(ent.Comp.ButcherSound, ent, args.User);
 
-        _popupSystem.PopupClient(Loc.GetString("butcherable-knife-butchered-success",
+        _popupSystem.PopupEntity(Loc.GetString("butcherable-knife-butchered-success",
             ("target", Identity.Entity(args.Target.Value, EntityManager)),
             ("knife", args.Used.Value)),
             ent,

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -159,7 +159,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
 
         var victimIdentity = Identity.Entity(victim.Value, EntityManager);
 
-        _popupSystem.PopupPredicted(Loc.GetString("comp-kitchen-spike-begin-butcher-self", ("victim", victimIdentity)),
+        _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-begin-butcher-self", ("victim", victimIdentity)),
             Loc.GetString("comp-kitchen-spike-begin-butcher", ("user", Identity.Entity(args.User, EntityManager)), ("victim", victimIdentity)),
             ent,
             args.User,
@@ -283,7 +283,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
 
         var victimIdentity = Identity.Entity(args.Target.Value, EntityManager);
 
-        _popupSystem.PopupPredicted(Loc.GetString("comp-kitchen-spike-butcher-self", ("victim", victimIdentity)),
+        _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-butcher-self", ("victim", victimIdentity)),
             Loc.GetString("comp-kitchen-spike-butcher", ("user", Identity.Entity(args.User, EntityManager)), ("victim", victimIdentity)),
             ent,
             args.User,
@@ -460,7 +460,7 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
                 ("hook", hook));
         }
 
-        _popupSystem.PopupPredicted(messageSelf, messageOthers, hook, user, PopupType.MediumCaution);
+        _popupSystem.PopupEntity(messageSelf, messageOthers, hook, user, PopupType.MediumCaution);
     }
 
     /// <summary>

--- a/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
+++ b/Content.Shared/Labels/EntitySystems/SharedHandLabelerSystem.cs
@@ -70,7 +70,7 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
         if (_netManager.IsServer)
             _labelSystem.Label(target, ent.Comp.AssignedLabel);
 
-        _popupSystem.PopupClient(Loc.GetString("hand-labeler-successfully-applied"), user, user);
+        _popupSystem.PopupEntity(Loc.GetString("hand-labeler-successfully-applied"), user, user);
 
         // Log labeling
         _adminLogger.Add(LogType.Action, LogImpact.Low,
@@ -82,7 +82,7 @@ public abstract partial class SharedHandLabelerSystem : EntitySystem
         if (_netManager.IsServer)
             _labelSystem.Label(target, null);
 
-        _popupSystem.PopupClient(Loc.GetString("hand-labeler-successfully-removed"), user, user);
+        _popupSystem.PopupEntity(Loc.GetString("hand-labeler-successfully-removed"), user, user);
 
         // Log labeling
         _adminLogger.Add(LogType.Action, LogImpact.Low,

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -106,7 +106,7 @@ public sealed partial class LockSystem : EntitySystem
             return;
 
         if (!args.Silent)
-            _sharedPopupSystem.PopupClient(Loc.GetString("entity-storage-component-locked-message"), uid, args.User);
+            _sharedPopupSystem.PopupEntity(Loc.GetString("entity-storage-component-locked-message"), uid, args.User);
 
         args.Cancelled = true;
     }
@@ -173,7 +173,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (user is { Valid: true })
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-do-lock-success",
+            _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-lock-success",
                 ("entityName", Identity.Name(uid, EntityManager))), uid, user);
         }
 
@@ -206,7 +206,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (user is { Valid: true })
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-do-unlock-success",
+            _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-do-unlock-success",
                 ("entityName", Identity.Name(uid, EntityManager))), uid, user.Value);
         }
 
@@ -349,7 +349,7 @@ public sealed partial class LockSystem : EntitySystem
         if (!quiet)
         {
             var denyReason = accessEv.DenyReason ?? Loc.GetString(_defaultDenyReason);
-            _sharedPopupSystem.PopupClient(denyReason, ent, user);
+            _sharedPopupSystem.PopupEntity(denyReason, ent, user);
         }
 
         return false;
@@ -406,7 +406,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (!args.Silent)
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString("construction-step-condition-wire-panel-close"),
+            _sharedPopupSystem.PopupEntity(Loc.GetString("construction-step-condition-wire-panel-close"),
                 ent,
                 args.User);
         }
@@ -422,7 +422,7 @@ public sealed partial class LockSystem : EntitySystem
         if (!TryComp<LockComponent>(ent, out var lockComp) || !lockComp.Locked)
             return;
 
-        _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-generic-fail",
+        _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-generic-fail",
             ("target", Identity.Entity(ent, EntityManager))),
             ent,
             args.User);
@@ -437,7 +437,7 @@ public sealed partial class LockSystem : EntitySystem
         if (!TryComp<LockComponent>(ent, out var lockComp) || !lockComp.Locked)
             return;
 
-        _sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-generic-fail",
+        _sharedPopupSystem.PopupEntity(Loc.GetString("lock-comp-generic-fail",
                 ("target", Identity.Entity(ent, EntityManager))),
             ent,
             args.User);
@@ -459,7 +459,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (lockComp.Locked && component.Popup != null)
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString(component.Popup), uid, args.User);
+            _sharedPopupSystem.PopupEntity(Loc.GetString(component.Popup), uid, args.User);
         }
 
         _audio.PlayPredicted(component.AccessDeniedSound, uid, args.User);
@@ -494,7 +494,7 @@ public sealed partial class LockSystem : EntitySystem
 
         if (lockComp.Locked && component.LockedPopup != null)
         {
-            _sharedPopupSystem.PopupClient(Loc.GetString(component.LockedPopup,
+            _sharedPopupSystem.PopupEntity(Loc.GetString(component.LockedPopup,
                     ("target", Identity.Entity(uid, EntityManager))),
                 uid,
                 args.User);

--- a/Content.Shared/Lock/LockingWhitelistSystem.cs
+++ b/Content.Shared/Lock/LockingWhitelistSystem.cs
@@ -21,7 +21,7 @@ public sealed partial class LockingWhitelistSystem : EntitySystem
             return;
 
         if (!args.Silent)
-            _popupSystem.PopupClient(Loc.GetString("locking-whitelist-component-lock-toggle-deny"), ent.Owner);
+            _popupSystem.PopupCursor(Loc.GetString("locking-whitelist-component-lock-toggle-deny"), ent.Owner);
 
         args.Cancelled = true;
     }

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -286,7 +286,7 @@ public abstract partial class SharedCryoPodSystem : EntitySystem
 
         if (cryoPodComponent.Locked)
         {
-            _popup.PopupClient(Loc.GetString("cryo-pod-locked"), uid, userId);
+            _popup.PopupEntity(Loc.GetString("cryo-pod-locked"), uid, userId);
             return;
         }
 

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -69,7 +69,7 @@ public sealed partial class HealingSystem : EntitySystem
                 var popup = (args.User == target.Owner)
                     ? Loc.GetString("medical-item-stop-bleeding-self")
                     : Loc.GetString("medical-item-stop-bleeding", ("target", Identity.Entity(target.Owner, EntityManager)));
-                _popupSystem.PopupClient(popup, target, args.User);
+                _popupSystem.PopupEntity(popup, target, args.User);
             }
         }
 
@@ -115,7 +115,7 @@ public sealed partial class HealingSystem : EntitySystem
 
         if (!args.Repeat)
         {
-            _popupSystem.PopupClient(Loc.GetString("medical-item-finished-using", ("item", args.Used)), target.Owner, args.User);
+            _popupSystem.PopupEntity(Loc.GetString("medical-item-finished-using", ("item", args.Used)), target.Owner, args.User);
             return;
         }
 
@@ -194,7 +194,7 @@ public sealed partial class HealingSystem : EntitySystem
 
         if (!HasDamage(healing, target!))
         {
-            _popupSystem.PopupClient(Loc.GetString("medical-item-cant-use", ("item", healing.Owner)), healing, user);
+            _popupSystem.PopupEntity(Loc.GetString("medical-item-cant-use", ("item", healing.Owner)), healing, user);
             return false;
         }
 

--- a/Content.Shared/Medical/SharedDefibrillatorSystem.cs
+++ b/Content.Shared/Medical/SharedDefibrillatorSystem.cs
@@ -90,7 +90,7 @@ public abstract partial class SharedDefibrillatorSystem : EntitySystem
 
         if (!_toggle.IsActivated(ent.Owner))
         {
-            _popup.PopupClient(Loc.GetString("defibrillator-not-on"), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString("defibrillator-not-on"), ent.Owner, user);
             return false;
         }
 

--- a/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
+++ b/Content.Shared/Medical/Stethoscope/StethoscopeSystem.cs
@@ -100,7 +100,7 @@ public sealed partial class StethoscopeSystem : EntitySystem
             _mobState.IsDead(target, mobState)                                           ||
             !damageComp.Damage.DamageDict.TryGetValue(DamageToListenFor, out var asphyxDmg))
         {
-            _popup.PopupPredicted(Loc.GetString("stethoscope-nothing"), target, user);
+            _popup.PopupEntity(Loc.GetString("stethoscope-nothing"), target, user);
             stethoscope.Comp.LastMeasuredDamage = null;
             return;
         }
@@ -110,12 +110,12 @@ public sealed partial class StethoscopeSystem : EntitySystem
         // Don't show the change if this is the first time listening.
         if (stethoscope.Comp.LastMeasuredDamage == null)
         {
-            _popup.PopupPredicted(absString, target, user);
+            _popup.PopupEntity(absString, target, user);
         }
         else
         {
             var deltaString = GetDeltaDamageString(stethoscope.Comp.LastMeasuredDamage.Value, asphyxDmg);
-            _popup.PopupPredicted(Loc.GetString("stethoscope-combined-status", ("absolute", absString), ("delta", deltaString)), target, user);
+            _popup.PopupEntity(Loc.GetString("stethoscope-combined-status", ("absolute", absString), ("delta", deltaString)), target, user);
         }
 
         stethoscope.Comp.LastMeasuredDamage = asphyxDmg;

--- a/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
+++ b/Content.Shared/Medical/SuitSensors/SharedSuitSensorSystem.cs
@@ -325,7 +325,7 @@ public abstract partial class SharedSuitSensorSystem : EntitySystem
         if (userUid != null)
         {
             var msg = Loc.GetString("suit-sensor-mode-state", ("mode", GetModeName(mode)));
-            _popupSystem.PopupClient(msg, sensors, userUid.Value);
+            _popupSystem.PopupEntity(msg, sensors, userUid.Value);
         }
     }
 

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -62,7 +62,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem
             if (transform.GridUid == gridUid && ev.HasGravity &&
                 jetpackQuery.TryGetComponent(user.Jetpack, out var jetpack))
             {
-                _popup.PopupClient(Loc.GetString("jetpack-to-grid"), uid, uid);
+                _popup.PopupEntity(Loc.GetString("jetpack-to-grid"), uid, uid);
 
                 SetEnabled(user.Jetpack, jetpack, false, uid);
             }
@@ -92,7 +92,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem
         {
             SetEnabled(component.Jetpack, jetpack, false, uid);
 
-            _popup.PopupClient(Loc.GetString("jetpack-to-grid"), uid, uid);
+            _popup.PopupEntity(Loc.GetString("jetpack-to-grid"), uid, uid);
         }
     }
 
@@ -132,7 +132,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem
 
         if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
         {
-            _popup.PopupClient(Loc.GetString("jetpack-no-station"), uid, args.Performer);
+            _popup.PopupEntity(Loc.GetString("jetpack-no-station"), uid, args.Performer);
 
             return;
         }

--- a/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -125,7 +125,7 @@ public sealed partial class FoodSequenceSystem : SharedFoodSequenceSystem
         if (start.Comp.FoodLayers.Count >= start.Comp.MaxLayers && !elementIndexed.Final || start.Comp.Finished)
         {
             if (user is not null)
-                _popup.PopupClient(Loc.GetString("food-sequence-no-space"), start, user.Value);
+                _popup.PopupEntity(Loc.GetString("food-sequence-no-space"), start, user.Value);
             return false;
         }
 

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -77,7 +77,7 @@ public sealed partial class IngestionSystem
         if (!_transform.GetMapCoordinates(user).InRange(_transform.GetMapCoordinates(target), MaxFeedDistance))
         {
             var message = Loc.GetString("interaction-system-user-interaction-cannot-reach");
-            _popup.PopupClient(message, user, user);
+            _popup.PopupEntity(message, user, user);
             return false;
         }
 
@@ -88,7 +88,7 @@ public sealed partial class IngestionSystem
             return true;
 
         if (attempt.Blocker != null)
-            _popup.PopupClient(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), target, user);
+            _popup.PopupEntity(Loc.GetString("ingestion-remove-mask", ("entity", attempt.Blocker.Value)), target, user);
 
         return false;
     }
@@ -308,7 +308,7 @@ public sealed partial class IngestionSystem
 
         if (!Resolve(ingested, ref ingested.Comp))
         {
-            _popup.PopupClient(Loc.GetString("ingestion-try-use-is-empty", ("entity", ingested)), ingested, user);
+            _popup.PopupEntity(Loc.GetString("ingestion-try-use-is-empty", ("entity", ingested)), ingested, user);
             return false;
         }
 

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -82,7 +82,7 @@ public sealed partial class IngestionSystem
         {
             args.Cancelled = true;
 
-            _popup.PopupClient(Loc.GetString("ingestion-try-use-is-empty", ("entity", entity)), entity, args.User);
+            _popup.PopupEntity(Loc.GetString("ingestion-try-use-is-empty", ("entity", entity)), entity, args.User);
             return;
         }
 
@@ -100,7 +100,7 @@ public sealed partial class IngestionSystem
 
         args.Cancelled = true;
 
-        _popup.PopupClient(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
+        _popup.PopupEntity(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
     }
 
     private void OnItemSlotsEdible(Entity<ItemSlotsComponent> ent, ref EdibleEvent args)
@@ -113,7 +113,7 @@ public sealed partial class IngestionSystem
 
         args.Cancelled = true;
 
-        _popup.PopupClient(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
+        _popup.PopupEntity(Loc.GetString("edible-has-used-storage", ("food", ent), ("verb", GetEdibleVerb(ent.Owner))), args.User, args.User);
     }
 
     private void OnOpenableEdible(Entity<OpenableComponent> ent, ref EdibleEvent args)

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Utensils.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Utensils.cs
@@ -45,7 +45,7 @@ public sealed partial class IngestionSystem
         //Prevents food usage with a wrong utensil
         if (ev.Types != UtensilType.None && (ev.Types & utensil.Comp.Types) == 0)
         {
-            _popup.PopupClient(Loc.GetString("ingestion-try-use-wrong-utensil", ("verb", GetEdibleVerb(target)), ("food", target), ("utensil", utensil.Owner)), user, user);
+            _popup.PopupEntity(Loc.GetString("ingestion-try-use-wrong-utensil", ("verb", GetEdibleVerb(target)), ("food", target), ("utensil", utensil.Owner)), user, user);
             return true;
         }
 
@@ -126,7 +126,7 @@ public sealed partial class IngestionSystem
         if (!required || (usedTypes & requiredTypes) == requiredTypes)
             return true;
 
-        _popup.PopupClient(Loc.GetString("ingestion-you-need-to-hold-utensil", ("utensil", requiredTypes ^ usedTypes)), entity, entity);
+        _popup.PopupEntity(Loc.GetString("ingestion-you-need-to-hold-utensil", ("utensil", requiredTypes ^ usedTypes)), entity, entity);
         return false;
 
     }

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -481,7 +481,7 @@ public sealed partial class IngestionSystem : EntitySystem
         }
         else
         {
-            _popup.PopupPredicted(Loc.GetString(edible.Message, ("food", entity.Owner), ("flavors", flavors)),
+            _popup.PopupEntity(Loc.GetString(edible.Message, ("food", entity.Owner), ("flavors", flavors)),
                 Loc.GetString(edible.OtherMessage),
                 args.User,
                 args.User);

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -260,9 +260,9 @@ public sealed partial class IngestionSystem : EntitySystem
                 return;
 
             if (forceFed)
-                _popup.PopupClient(Loc.GetString("ingestion-cant-digest-other", ("target", entity), ("entity", food)), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("ingestion-cant-digest-other", ("target", entity), ("entity", food)), entity, args.User);
             else
-                _popup.PopupClient(Loc.GetString("ingestion-cant-digest", ("entity", food)), entity, entity);
+                _popup.PopupEntity(Loc.GetString("ingestion-cant-digest", ("entity", food)), entity, entity);
 
             return;
         }
@@ -342,11 +342,11 @@ public sealed partial class IngestionSystem : EntitySystem
         if (stomachToUse == null)
         {
             // Very long
-            _popup.PopupClient(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
+            _popup.PopupEntity(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
             if (!forceFed)
                 return;
 
-            _popup.PopupClient(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
             return;
         }
 
@@ -357,11 +357,11 @@ public sealed partial class IngestionSystem : EntitySystem
         if (beforeEv.Cancelled || beforeEv.Min > beforeEv.Max)
         {
             // Very long x2
-            _popup.PopupClient(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
+            _popup.PopupEntity(Loc.GetString("ingestion-you-cannot-ingest-any-more", ("verb", GetEdibleVerb(food))), entity, entity);
             if (!forceFed)
                 return;
 
-            _popup.PopupClient(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
+            _popup.PopupEntity(Loc.GetString("ingestion-other-cannot-ingest-any-more", ("target", entity), ("verb", GetEdibleVerb(food))), args.Target.Value, args.User);
             return;
         }
 
@@ -473,7 +473,7 @@ public sealed partial class IngestionSystem : EntitySystem
             var userName = Identity.Entity(args.User, EntityManager);
             _popup.PopupEntity(Loc.GetString("edible-force-feed-success", ("user", userName), ("verb", edible.Verb), ("flavors", flavors)), entity, entity);
 
-            _popup.PopupClient(Loc.GetString("edible-force-feed-success-user", ("target", targetName), ("verb", edible.Verb)), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("edible-force-feed-success-user", ("target", targetName), ("verb", edible.Verb)), args.User, args.User);
 
             // log successful forced feeding
             // TODO: Use correct verb

--- a/Content.Shared/Nutrition/EntitySystems/MessyDrinkerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/MessyDrinkerSystem.cs
@@ -44,7 +44,7 @@ public sealed partial class MessyDrinkerSystem : EntitySystem
             return;
 
         if (ent.Comp.SpillMessagePopup != null)
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.SpillMessagePopup), null, ent, ent, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.SpillMessagePopup), null, ent, ent, PopupType.MediumCaution);
 
         var split = ev.Split.SplitSolution(ent.Comp.SpillAmount);
 

--- a/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/OpenableSystem.cs
@@ -177,7 +177,7 @@ public sealed partial class OpenableSystem : EntitySystem
         if (user != null)
         {
             if (predicted)
-                _popup.PopupClient(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString(comp.ClosedPopup, ("owner", uid)), user.Value, user.Value);
         }

--- a/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
@@ -190,7 +190,7 @@ public sealed partial class PressurizedSolutionSystem : EntitySystem
 
             var selfMessage = Loc.GetString(entity.Comp.SprayHolderMessageSelf, ("victim", victimName), ("drink", drinkName));
             var othersMessage = Loc.GetString(entity.Comp.SprayHolderMessageOthers, ("victim", victimName), ("drink", drinkName));
-            _popup.PopupPredicted(selfMessage, othersMessage, target.Value, target.Value);
+            _popup.PopupEntity(selfMessage, othersMessage, target.Value, target.Value);
         }
         else
         {

--- a/Content.Shared/Nutrition/EntitySystems/ShakeableSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ShakeableSystem.cs
@@ -86,7 +86,7 @@ public sealed partial class ShakeableSystem : EntitySystem
 
         var selfMessage = Loc.GetString(entity.Comp.ShakePopupMessageSelf, ("user", userName), ("shakeable", shakeableName));
         var othersMessage = Loc.GetString(entity.Comp.ShakePopupMessageOthers, ("user", userName), ("shakeable", shakeableName));
-        _popup.PopupPredicted(selfMessage, othersMessage, user, user);
+        _popup.PopupEntity(selfMessage, othersMessage, user, user);
 
         _audio.PlayPredicted(entity.Comp.ShakeSound, entity, user);
 

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -208,9 +208,8 @@ public abstract partial class SharedRingerSystem : EntitySystem
 
         UpdateRingerUi(ent);
 
-        _popup.PopupPredicted(Loc.GetString("comp-ringer-vibration-popup"),
+        _popup.PopupEntity(Loc.GetString("comp-ringer-vibration-popup"),
             ent,
-            ent.Owner,
             Filter.Pvs(ent, 0.05f),
             false,
             PopupType.Medium);

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -122,7 +122,7 @@ public sealed partial class PaperSystem : EntitySystem
                 if (entity.Comp.EditingDisabled)
                 {
                     var paperEditingDisabledMessage = Loc.GetString("paper-tamper-proof-modified-message");
-                    _popupSystem.PopupClient(paperEditingDisabledMessage, entity, args.User);
+                    _popupSystem.PopupEntity(paperEditingDisabledMessage, entity, args.User);
 
                     args.Handled = true;
                     return;
@@ -135,7 +135,7 @@ public sealed partial class PaperSystem : EntitySystem
                     if (ev.FailReason is not null)
                     {
                         var fileWriteMessage = Loc.GetString(ev.FailReason);
-                        _popupSystem.PopupClient(fileWriteMessage, entity.Owner, args.User);
+                        _popupSystem.PopupEntity(fileWriteMessage, entity.Owner, args.User);
                     }
 
                     args.Handled = true;
@@ -166,7 +166,7 @@ public sealed partial class PaperSystem : EntitySystem
             var stampPaperSelfMessage = Loc.GetString("paper-component-action-stamp-paper-self",
                     ("target", args.Target),
                     ("stamp", args.Used));
-            _popupSystem.PopupClient(stampPaperSelfMessage, args.User, args.User);
+            _popupSystem.PopupEntity(stampPaperSelfMessage, args.User, args.User);
 
             _audio.PlayPredicted(stampComp.Sound, entity, args.User);
 

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.ParcelWrap.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.ParcelWrap.cs
@@ -70,7 +70,7 @@ public sealed partial class ParcelWrappingSystem
         if (target == user)
         {
             var selfMsg = Loc.GetString("parcel-wrap-popup-being-wrapped-self");
-            _popup.PopupClient(selfMsg, user, user);
+            _popup.PopupEntity(selfMsg, user, user);
         }
         else
         {

--- a/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.WrappedParcel.cs
+++ b/Content.Shared/ParcelWrap/Systems/ParcelWrappingSystem.WrappedParcel.cs
@@ -71,9 +71,8 @@ public sealed partial class ParcelWrappingSystem
         // Unwrap the package and if something was in it, show a popup describing "wow something came out!"
         if (UnwrapInternal(user: null, parcel) is { } contents)
         {
-            _popup.PopupPredicted(Loc.GetString("parcel-wrap-popup-parcel-destroyed", ("contents", contents)),
+            _popup.PopupEntity(Loc.GetString("parcel-wrap-popup-parcel-destroyed", ("contents", contents)),
                 contents,
-                null,
                 PopupType.MediumCaution);
         }
     }

--- a/Content.Shared/Plunger/Systems/PlungerSystem.cs
+++ b/Content.Shared/Plunger/Systems/PlungerSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class PlungerSystem : EntitySystem
         if (!TryComp(target, out PlungerUseComponent? plunge))
             return;
 
-        _popup.PopupClient(Loc.GetString("plunger-unblock", ("target", target)), args.User, args.User, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("plunger-unblock", ("target", target)), args.User, args.User, PopupType.Medium);
         plunge.Plunged = true;
 
         var spawn = _proto.Index<WeightedRandomEntityPrototype>(plunge.PlungerLoot).Pick(_random);

--- a/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
+++ b/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
@@ -142,13 +142,13 @@ public abstract partial class SharedChameleonProjectorSystem : EntitySystem
     {
         if (_container.IsEntityInContainer(target) || _container.IsEntityInContainer(user))
         {
-            _popup.PopupClient(Loc.GetString("chameleon-projector-inside-container"), target, user);
+            _popup.PopupEntity(Loc.GetString("chameleon-projector-inside-container"), target, user);
             return false;
         }
 
         if (IsInvalid(ent.Comp, target))
         {
-            _popup.PopupClient(Loc.GetString("chameleon-projector-invalid"), target, user);
+            _popup.PopupEntity(Loc.GetString("chameleon-projector-invalid"), target, user);
             return false;
         }
 
@@ -156,7 +156,7 @@ public abstract partial class SharedChameleonProjectorSystem : EntitySystem
         if (TryComp<ItemToggleComponent>(ent.Owner, out var itemToggle) && !_toggle.TryActivate((ent.Owner, itemToggle), user))
             return false;
 
-        _popup.PopupClient(Loc.GetString("chameleon-projector-success"), target, user);
+        _popup.PopupEntity(Loc.GetString("chameleon-projector-success"), target, user);
         Disguise(ent, user, target);
         return true;
     }

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -29,14 +29,6 @@ namespace Content.Shared.Popups
         public abstract void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small);
 
         /// <summary>
-        /// Variant of <see cref="PopupCursor(string?, EntityUid, PopupType)"/> for use with prediction.
-        /// The local client will show the popup to the recipient. Does nothing on the server.
-        /// </summary>
-        [Obsolete]
-        public void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
-            => PopupCursor(message, recipient, type);
-
-        /// <summary>
         ///     Shows a popup at a world location to every entity in PVS range.
         /// </summary>
         /// <param name="message">The message to display.</param>
@@ -61,15 +53,6 @@ namespace Content.Shared.Popups
         ///     Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> that sends a pop-up to a specific player.
         /// </summary>
         public abstract void PopupCoordinates(string? message, EntityCoordinates coordinates, ICommonSession recipient, PopupType type = PopupType.Small);
-
-        /// <summary>
-        ///    Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> for use with prediction. The local client will
-        ///    the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local
-        ///    client will do nothing and the server will show the message to every player in PVS range.
-        /// </summary>
-        [Obsolete]
-        public void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
-            => PopupCoordinates(message, coordinates, type);
 
         /// <summary>
         ///     Shows a popup above an entity for every player in pvs range.

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -17,7 +17,7 @@ namespace Content.Shared.Popups
         /// </summary>
         /// <param name="message">The message to display.</param>
         /// <param name="type">Used to customize how this popup should appear visually.</param>
-        [Obsolete]
+        [Obsolete] // TODO: this method should only be on the client
         public abstract void PopupCursor(string? message, PopupType type = PopupType.Small);
 
         /// <summary>
@@ -194,7 +194,10 @@ namespace Content.Shared.Popups
         }
     }
 
-    public interface IPopupPredictionInstance;
+    public interface IPopupPredictionInstance
+    {
+        GameTick Tick { get; }
+    }
 
     /// <summary>
     ///     Network event for displaying a popup on the user's cursor.
@@ -206,7 +209,7 @@ namespace Content.Shared.Popups
         {
         }
 
-        public record struct PredictionInstance(string Message, PopupType Type, GameTick Tick) : IPopupPredictionInstance;
+        public readonly record struct PredictionInstance(string Message, PopupType Type, GameTick Tick) : IPopupPredictionInstance;
     }
 
     /// <summary>
@@ -222,7 +225,7 @@ namespace Content.Shared.Popups
             Coordinates = coordinates;
         }
 
-        public record struct PredictionInstance(string Message, PopupType Type, GameTick Tick, NetCoordinates Coordinates) : IPopupPredictionInstance;
+        public readonly record struct PredictionInstance(string Message, PopupType Type, GameTick Tick, NetCoordinates Coordinates) : IPopupPredictionInstance;
     }
 
     /// <summary>
@@ -238,7 +241,7 @@ namespace Content.Shared.Popups
             Uid = uid;
         }
 
-        public record struct PredictionInstance(string Message, PopupType Type, GameTick Tick, NetEntity Uid) : IPopupPredictionInstance;
+        public readonly record struct PredictionInstance(string Message, PopupType Type, GameTick Tick, NetEntity Uid) : IPopupPredictionInstance;
     }
 
     /// <summary>

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -65,7 +65,7 @@ namespace Content.Shared.Popups
         /// <summary>
         ///     Variant of <see cref="PopupEntity(string, EntityUid, PopupType)"/> that shows the popup only to some specific client.
         /// </summary>
-        public abstract void PopupEntity(string? message, EntityUid uid, EntityUid recipient, PopupType type = PopupType.Small);
+        public abstract void PopupEntity(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
 
         /// <summary>
         ///     Variant of <see cref="PopupEntity(string, EntityUid, PopupType)"/> that shows the popup only to some specific client.
@@ -77,14 +77,6 @@ namespace Content.Shared.Popups
         ///     if the filtering has to be more specific than simply PVS range based.
         /// </summary>
         public abstract void PopupEntity(string? message, EntityUid uid, Filter filter, bool recordReplay, PopupType type = PopupType.Small);
-
-        /// <summary>
-        /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> that only runs on the client, outside of prediction.
-        /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
-        /// </summary>
-        [Obsolete]
-        public void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-            => PopupEntity(message, uid, type);
 
         /// <summary>
         /// Variant of <see cref="PopupEntity(string?, EntityUid, PopupType)"/> that displays <paramref name="recipientMessage"/>

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -87,16 +87,7 @@ namespace Content.Shared.Popups
             => PopupEntity(message, uid, type);
 
         /// <summary>
-        /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> for use with prediction. The local client will show
-        /// the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local client
-        /// will do nothing and the server will show the message to every player in PVS range.
-        /// </summary>
-        [Obsolete]
-        public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
-            => PopupEntity(message, uid, type);
-
-        /// <summary>
-        /// Variant of <see cref="PopupPredicted(string?, EntityUid, EntityUid?, PopupType)"/> that displays <paramref name="recipientMessage"/>
+        /// Variant of <see cref="PopupEntity(string?, EntityUid, PopupType)"/> that displays <paramref name="recipientMessage"/>
         /// to the recipient and <paramref name="othersMessage"/> to everyone else in PVS range.
         /// </summary>
         public void PopupEntity(string? recipientMessage,

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -87,14 +87,6 @@ namespace Content.Shared.Popups
             => PopupEntity(message, uid, type);
 
         /// <summary>
-        /// Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> that only runs on the client, outside of prediction.
-        /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
-        /// </summary>
-        [Obsolete]
-        public void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
-            => PopupCoordinates(message, coordinates, type);
-
-        /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> for use with prediction. The local client will show
         /// the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local client
         /// will do nothing and the server will show the message to every player in PVS range.
@@ -102,21 +94,6 @@ namespace Content.Shared.Popups
         [Obsolete]
         public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
             => PopupEntity(message, uid, type);
-
-        /// <summary>
-        /// Variant of <see cref="PopupEntity(string, EntityUid, Filter, bool, PopupType)"/> for use with prediction.
-        /// The local client will show the popup to the recipient, and the server will show it to players in the filter.
-        /// If recipient is null, the local client will do nothing and the server will show the message to players in the filter.
-        /// </summary>
-        /// <param name="message">The message to display.</param>
-        /// <param name="uid">The entity to display the popup above.</param>
-        /// <param name="recipient">The client that will see this popup locally during prediction.</param>
-        /// <param name="filter">Filter for players that will see the popup from the server.</param>
-        /// <param name="recordReplay">If true, this pop-up will be considered as a globally visible pop-up that gets shown during replays.</param>
-        /// <param name="type">Used to customize how this popup should appear visually. See: <see cref="PopupType"/>.</param>
-        [Obsolete]
-        public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, Filter filter, bool recordReplay, PopupType type = PopupType.Small)
-            => PopupEntity(message, uid, filter, recordReplay, type);
 
         /// <summary>
         /// Variant of <see cref="PopupPredicted(string?, EntityUid, EntityUid?, PopupType)"/> that displays <paramref name="recipientMessage"/>

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -122,8 +122,7 @@ namespace Content.Shared.Popups
         /// Variant of <see cref="PopupPredicted(string?, EntityUid, EntityUid?, PopupType)"/> that displays <paramref name="recipientMessage"/>
         /// to the recipient and <paramref name="othersMessage"/> to everyone else in PVS range.
         /// </summary>
-        // TODO: this method should be renamed
-        public void PopupPredicted(string? recipientMessage,
+        public void PopupEntity(string? recipientMessage,
             string? othersMessage,
             EntityUid uid,
             EntityUid? recipient,

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -13,14 +13,6 @@ namespace Content.Shared.Popups
         [Dependency] protected IGameTiming Timing = default!;
 
         /// <summary>
-        ///     Shows a popup at the local users' cursor. Does nothing on the server.
-        /// </summary>
-        /// <param name="message">The message to display.</param>
-        /// <param name="type">Used to customize how this popup should appear visually.</param>
-        [Obsolete] // TODO: this method should only be on the client
-        public abstract void PopupCursor(string? message, PopupType type = PopupType.Small);
-
-        /// <summary>
         ///     Shows a popup at a users' cursor.
         /// </summary>
         /// <param name="message">The message to display.</param>
@@ -35,14 +27,6 @@ namespace Content.Shared.Popups
         /// <param name="recipient">Client that will see this popup.</param>
         /// <param name="type">Used to customize how this popup should appear visually.</param>
         public abstract void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small);
-
-        /// <summary>
-        /// Variant of <see cref="PopupCursor(string?, ICommonSession, PopupType)"/> for use with prediction.
-        /// The local client will show the popup to the recipient. Does nothing on the server.
-        /// </summary>
-        [Obsolete]
-        public void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
-            => PopupCursor(message, recipient, type);
 
         /// <summary>
         /// Variant of <see cref="PopupCursor(string?, EntityUid, PopupType)"/> for use with prediction.
@@ -117,7 +101,10 @@ namespace Content.Shared.Popups
         /// </summary>
         [Obsolete]
         public void PopupClient(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
-            => PopupCursor(message, type); // TODO: add API for entityUid? recipient
+        {
+            if (recipient.HasValue)
+                PopupCursor(message, recipient.Value, type);
+        }
 
         /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> that only runs on the client, outside of prediction.
@@ -163,7 +150,7 @@ namespace Content.Shared.Popups
         /// Variant of <see cref="PopupPredicted(string?, EntityUid, EntityUid?, PopupType)"/> that displays <paramref name="recipientMessage"/>
         /// to the recipient and <paramref name="othersMessage"/> to everyone else in PVS range.
         /// </summary>
-        [Obsolete]
+        // TODO: this method should be renamed
         public void PopupPredicted(string? recipientMessage,
             string? othersMessage,
             EntityUid uid,

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -26,7 +26,7 @@ namespace Content.Shared.Popups
         /// <param name="message">The message to display.</param>
         /// <param name="recipient">Client that will see this popup.</param>
         /// <param name="type">Used to customize how this popup should appear visually.</param>
-        public abstract void PopupCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small);
+        public abstract void PopupCursor(string? message, EntityUid? recipient, PopupType type = PopupType.Small);
 
         /// <summary>
         ///     Shows a popup at a world location to every entity in PVS range.
@@ -77,17 +77,6 @@ namespace Content.Shared.Popups
         ///     if the filtering has to be more specific than simply PVS range based.
         /// </summary>
         public abstract void PopupEntity(string? message, EntityUid uid, Filter filter, bool recordReplay, PopupType type = PopupType.Small);
-
-        /// <summary>
-        /// Variant of <see cref="PopupCursor(string, EntityUid, PopupType)"/> that only runs on the client, outside of prediction.
-        /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
-        /// </summary>
-        [Obsolete]
-        public void PopupClient(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
-        {
-            if (recipient.HasValue)
-                PopupCursor(message, recipient.Value, type);
-        }
 
         /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> that only runs on the client, outside of prediction.

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -170,7 +170,15 @@ namespace Content.Shared.Popups
             EntityUid? recipient,
             PopupType type = PopupType.Small)
         {
-            // TODO: figure this thing out
+            if (recipient.HasValue)
+            {
+                PopupEntity(othersMessage, uid, Filter.PvsExcept(recipient.Value), true, type);
+                PopupEntity(recipientMessage, uid, recipient.Value, type);
+            }
+            else
+            {
+                PopupEntity(othersMessage, uid, type);
+            }
         }
     }
 

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -1,19 +1,23 @@
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Popups
 {
     /// <summary>
     ///     System for displaying small text popups on users' screens.
     /// </summary>
-    public abstract class SharedPopupSystem : EntitySystem
+    public abstract partial class SharedPopupSystem : EntitySystem
     {
+        [Dependency] protected IGameTiming Timing = default!;
+
         /// <summary>
         ///     Shows a popup at the local users' cursor. Does nothing on the server.
         /// </summary>
         /// <param name="message">The message to display.</param>
         /// <param name="type">Used to customize how this popup should appear visually.</param>
+        [Obsolete]
         public abstract void PopupCursor(string? message, PopupType type = PopupType.Small);
 
         /// <summary>
@@ -36,13 +40,17 @@ namespace Content.Shared.Popups
         /// Variant of <see cref="PopupCursor(string?, ICommonSession, PopupType)"/> for use with prediction.
         /// The local client will show the popup to the recipient. Does nothing on the server.
         /// </summary>
-        public abstract void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupPredictedCursor(string? message, ICommonSession recipient, PopupType type = PopupType.Small)
+            => PopupCursor(message, recipient, type);
 
         /// <summary>
         /// Variant of <see cref="PopupCursor(string?, EntityUid, PopupType)"/> for use with prediction.
         /// The local client will show the popup to the recipient. Does nothing on the server.
         /// </summary>
-        public abstract void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupPredictedCursor(string? message, EntityUid recipient, PopupType type = PopupType.Small)
+            => PopupCursor(message, recipient, type);
 
         /// <summary>
         ///     Shows a popup at a world location to every entity in PVS range.
@@ -75,7 +83,9 @@ namespace Content.Shared.Popups
         ///    the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local
         ///    client will do nothing and the server will show the message to every player in PVS range.
         /// </summary>
-        public abstract void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupPredictedCoordinates(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
+            => PopupCoordinates(message, coordinates, type);
 
         /// <summary>
         ///     Shows a popup above an entity for every player in pvs range.
@@ -105,26 +115,34 @@ namespace Content.Shared.Popups
         /// Variant of <see cref="PopupCursor(string, EntityUid, PopupType)"/> that only runs on the client, outside of prediction.
         /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
         /// </summary>
-        public abstract void PopupClient(string? message, EntityUid? recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupClient(string? message, EntityUid? recipient, PopupType type = PopupType.Small)
+            => PopupCursor(message, type); // TODO: add API for entityUid? recipient
 
         /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> that only runs on the client, outside of prediction.
         /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
         /// </summary>
-        public abstract void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
+            => PopupEntity(message, uid, type);
 
         /// <summary>
         /// Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> that only runs on the client, outside of prediction.
         /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
         /// </summary>
-        public abstract void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
+            => PopupCoordinates(message, coordinates, type);
 
         /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> for use with prediction. The local client will show
         /// the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local client
         /// will do nothing and the server will show the message to every player in PVS range.
         /// </summary>
-        public abstract void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small)
+            => PopupEntity(message, uid, type);
 
         /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, Filter, bool, PopupType)"/> for use with prediction.
@@ -137,13 +155,23 @@ namespace Content.Shared.Popups
         /// <param name="filter">Filter for players that will see the popup from the server.</param>
         /// <param name="recordReplay">If true, this pop-up will be considered as a globally visible pop-up that gets shown during replays.</param>
         /// <param name="type">Used to customize how this popup should appear visually. See: <see cref="PopupType"/>.</param>
-        public abstract void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, Filter filter, bool recordReplay, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupPredicted(string? message, EntityUid uid, EntityUid? recipient, Filter filter, bool recordReplay, PopupType type = PopupType.Small)
+            => PopupEntity(message, uid, filter, recordReplay, type);
 
         /// <summary>
         /// Variant of <see cref="PopupPredicted(string?, EntityUid, EntityUid?, PopupType)"/> that displays <paramref name="recipientMessage"/>
         /// to the recipient and <paramref name="othersMessage"/> to everyone else in PVS range.
         /// </summary>
-        public abstract void PopupPredicted(string? recipientMessage, string? othersMessage, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
+        [Obsolete]
+        public void PopupPredicted(string? recipientMessage,
+            string? othersMessage,
+            EntityUid uid,
+            EntityUid? recipient,
+            PopupType type = PopupType.Small)
+        {
+            // TODO: figure this thing out
+        }
     }
 
     /// <summary>
@@ -156,12 +184,17 @@ namespace Content.Shared.Popups
 
         public PopupType Type { get; }
 
-        protected PopupEvent(string message, PopupType type)
+        public GameTick Tick { get; }
+
+        protected PopupEvent(string message, PopupType type, GameTick tick)
         {
             Message = message;
             Type = type;
+            Tick = tick;
         }
     }
+
+    public interface IPopupPredictionInstance;
 
     /// <summary>
     ///     Network event for displaying a popup on the user's cursor.
@@ -169,9 +202,11 @@ namespace Content.Shared.Popups
     [Serializable, NetSerializable]
     public sealed class PopupCursorEvent : PopupEvent
     {
-        public PopupCursorEvent(string message, PopupType type) : base(message, type)
+        public PopupCursorEvent(string message, PopupType type, GameTick tick) : base(message, type, tick)
         {
         }
+
+        public record struct PredictionInstance(string Message, PopupType Type, GameTick Tick) : IPopupPredictionInstance;
     }
 
     /// <summary>
@@ -182,10 +217,12 @@ namespace Content.Shared.Popups
     {
         public NetCoordinates Coordinates { get; }
 
-        public PopupCoordinatesEvent(string message, PopupType type, NetCoordinates coordinates) : base(message, type)
+        public PopupCoordinatesEvent(string message, PopupType type, GameTick tick, NetCoordinates coordinates) : base(message, type, tick)
         {
             Coordinates = coordinates;
         }
+
+        public record struct PredictionInstance(string Message, PopupType Type, GameTick Tick, NetCoordinates Coordinates) : IPopupPredictionInstance;
     }
 
     /// <summary>
@@ -196,10 +233,12 @@ namespace Content.Shared.Popups
     {
         public NetEntity Uid { get; }
 
-        public PopupEntityEvent(string message, PopupType type, NetEntity uid) : base(message, type)
+        public PopupEntityEvent(string message, PopupType type, GameTick tick, NetEntity uid) : base(message, type, tick)
         {
             Uid = uid;
         }
+
+        public record struct PredictionInstance(string Message, PopupType Type, GameTick Tick, NetEntity Uid) : IPopupPredictionInstance;
     }
 
     /// <summary>

--- a/Content.Shared/PowerCell/PowerCellSystem.API.cs
+++ b/Content.Shared/PowerCell/PowerCellSystem.API.cs
@@ -139,7 +139,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
 
@@ -152,7 +152,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
 
@@ -178,7 +178,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-no-battery"), ent.Owner, user.Value);
 
@@ -191,7 +191,7 @@ public sealed partial class PowerCellSystem
                 return false;
 
             if (predicted)
-                _popup.PopupClient(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
+                _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
             else
                 _popup.PopupEntity(Loc.GetString("power-cell-insufficient"), ent.Owner, user.Value);
 

--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class PryingSystem : EntitySystem
         if (!CanPry(target, user, out var message, comp))
         {
             if (!string.IsNullOrWhiteSpace(message))
-                _popup.PopupClient(Loc.GetString(message), target, user);
+                _popup.PopupEntity(Loc.GetString(message), target, user);
             // If we have reached this point we want the event that caused this
             // to be marked as handled.
             return true;
@@ -164,7 +164,7 @@ public sealed partial class PryingSystem : EntitySystem
         if (!CanPry(uid, args.User, out var message, comp))
         {
             if (!string.IsNullOrWhiteSpace(message))
-                _popup.PopupClient(Loc.GetString(message), uid, args.User);
+                _popup.PopupEntity(Loc.GetString(message), uid, args.User);
             return;
         }
 

--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -47,11 +47,11 @@ public sealed partial class RCDAmmoSystem : EntitySystem
         var count = Math.Min(charges.MaxCharges - current, comp.Charges);
         if (count <= 0)
         {
-            _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-full"), target, user);
+            _popup.PopupEntity(Loc.GetString("rcd-ammo-component-after-interact-full"), target, user);
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-refilled"), target, user);
+        _popup.PopupEntity(Loc.GetString("rcd-ammo-component-after-interact-refilled"), target, user);
         _sharedCharges.AddCharges(target, count);
         comp.Charges -= count;
         Dirty(uid, comp);

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -148,7 +148,7 @@ public sealed partial class RCDSystem : EntitySystem
 
         if (!TryComp<MapGridComponent>(gridUid, out var mapGrid))
         {
-            _popup.PopupClient(Loc.GetString("rcd-component-no-valid-grid"), uid, user);
+            _popup.PopupEntity(Loc.GetString("rcd-component-no-valid-grid"), uid, user);
             return;
         }
         var tile = _mapSystem.GetTileRef(gridUid.Value, mapGrid, location);
@@ -337,7 +337,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (charges == 0)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-no-ammo-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-no-ammo-message"), uid, user);
 
             return false;
         }
@@ -345,7 +345,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.Cost > charges)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-insufficient-ammo-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-insufficient-ammo-message"), uid, user);
 
             return false;
         }
@@ -379,7 +379,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.ConstructionRules.Contains(RcdConstructionRule.MustBuildOnEmptyTile) && !tile.Tile.IsEmpty)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-must-build-on-empty-tile-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-must-build-on-empty-tile-message"), uid, user);
 
             return false;
         }
@@ -388,7 +388,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (!prototype.ConstructionRules.Contains(RcdConstructionRule.CanBuildOnEmptyTile) && tile.Tile.IsEmpty)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-empty-tile-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-empty-tile-message"), uid, user);
 
             return false;
         }
@@ -397,7 +397,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.ConstructionRules.Contains(RcdConstructionRule.MustBuildOnSubfloor) && !_turf.GetContentTileDefinition(tile).IsSubFloor)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-must-build-on-subfloor-message"), uid, user);
+                _popup.PopupEntity(Loc.GetString("rcd-component-must-build-on-subfloor-message"), uid, user);
 
             return false;
         }
@@ -409,7 +409,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (!_floors.CanPlaceTile(gridUid, mapGrid, tile.GridIndices, out var reason))
             {
                 if (popMsgs)
-                    _popup.PopupClient(reason, uid, user);
+                    _popup.PopupEntity(reason, uid, user);
 
                 return false;
             }
@@ -418,7 +418,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (_turf.GetContentTileDefinition(tile).ID == prototype.Prototype)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-identical-tile"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-identical-tile"), uid, user);
 
                 return false;
             }
@@ -444,7 +444,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (isCatwalk && _tags.HasTag(ent, CatwalkTag))
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
 
                 return false;
             }
@@ -464,7 +464,7 @@ public sealed partial class RCDSystem : EntitySystem
 
                     // Collision was detected
                     if (popMsgs)
-                        _popup.PopupClient(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
+                        _popup.PopupEntity(Loc.GetString("rcd-component-cannot-build-on-occupied-tile-message"), uid, user);
 
                     return false;
                 }
@@ -483,7 +483,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (tile.Tile.IsEmpty)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-nothing-to-deconstruct-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-nothing-to-deconstruct-message"), uid, user);
 
                 return false;
             }
@@ -492,7 +492,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (_turf.IsTileBlocked(tile, CollisionGroup.MobMask))
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-tile-obstructed-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-tile-obstructed-message"), uid, user);
 
                 return false;
             }
@@ -503,7 +503,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (tileDef.Indestructible)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-tile-indestructible-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-tile-indestructible-message"), uid, user);
 
                 return false;
             }
@@ -516,7 +516,7 @@ public sealed partial class RCDSystem : EntitySystem
             if (!TryComp<RCDDeconstructableComponent>(target, out var deconstructible) || !deconstructible.Deconstructable)
             {
                 if (popMsgs)
-                    _popup.PopupClient(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
+                    _popup.PopupEntity(Loc.GetString("rcd-component-deconstruct-target-not-on-whitelist-message"), uid, user);
 
                 return false;
             }

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -109,25 +109,25 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     {
         if (!component.KeysUnlocked)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
             return;
         }
 
         if (TryComp<WiresPanelComponent>(uid, out var panel) && !panel.Open)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
             return;
         }
 
         if (component.KeySlots <= component.KeyContainer.ContainedEntities.Count)
         {
-            _popup.PopupClient(Loc.GetString("encryption-key-slots-already-full"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-key-slots-already-full"), uid, args.User);
             return;
         }
 
         if (_container.Insert(args.Used, component.KeyContainer))
         {
-            _popup.PopupClient(Loc.GetString("encryption-key-successfully-installed"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-key-successfully-installed"), uid, args.User);
             _audio.PlayPredicted(component.KeyInsertionSound, args.Target, args.User);
             args.Handled = true;
             return;
@@ -139,19 +139,19 @@ public sealed partial class EncryptionKeySystem : EntitySystem
     {
         if (!component.KeysUnlocked)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-are-locked"), uid, args.User);
             return;
         }
 
         if (!_wires.IsPanelOpen(uid))
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-panel-locked"), uid, args.User);
             return;
         }
 
         if (component.KeyContainer.ContainedEntities.Count == 0)
         {
-            _popup.PopupClient(Loc.GetString("encryption-keys-no-keys"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("encryption-keys-no-keys"), uid, args.User);
             return;
         }
 

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -56,7 +56,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
             _hands.PickupOrDrop(args.User, ent, dropNear: true);
         }
 
-        _popup.PopupPredicted(Loc.GetString("encryption-keys-all-extracted"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("encryption-keys-all-extracted"), uid, args.User);
         _audio.PlayPredicted(component.KeyExtractionSound, uid, args.User);
     }
 

--- a/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedJammerSystem.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedJammerSystem : EntitySystem
                     // The range should be updated when it turns on again!
                     _jammer.TrySetRange(entity.Owner, GetCurrentRange(entity));
 
-                    Popup.PopupClient(Loc.GetString(setting.Message), user, user);
+                    Popup.PopupEntity(Loc.GetString(setting.Message), user, user);
                 },
                 Text = Loc.GetString(setting.Name),
             };

--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -65,7 +65,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
 
         if (!_powerReceiver.IsPowered(args.Target.Value))
         {
-            _popup.PopupClient(Loc.GetString("door-remote-no-power"), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("door-remote-no-power"), args.User, args.User);
             return;
         }
 
@@ -83,7 +83,7 @@ public abstract partial class SharedDoorRemoteSystem : EntitySystem
             if (isAirlock)
                 _doorSystem.Deny(args.Target.Value, doorComp, user: args.User, predicted: true);
 
-            _popup.PopupClient(Loc.GetString("door-remote-denied"), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("door-remote-denied"), args.User, args.User);
             return;
         }
 

--- a/Content.Shared/Repairable/RepairableSystem.cs
+++ b/Content.Shared/Repairable/RepairableSystem.cs
@@ -45,7 +45,7 @@ public sealed partial class RepairableSystem : EntitySystem
         if (!args.Repeat)
         {
             var str = Loc.GetString("comp-repairable-repair", ("target", ent.Owner), ("tool", args.Used!));
-            _popup.PopupClient(str, ent.Owner, args.User);
+            _popup.PopupEntity(str, ent.Owner, args.User);
 
             var ev = new RepairedEvent(ent, args.User);
             RaiseLocalEvent(ent.Owner, ref ev);

--- a/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
+++ b/Content.Shared/RetractableItemAction/RetractableItemActionSystem.cs
@@ -58,7 +58,7 @@ public sealed partial class RetractableItemActionSystem : EntitySystem
             && !_hands.IsHolding(args.Performer, ent.Comp.ActionItemUid)
             && !_hands.CanDropHeld(args.Performer, activeHand, false))
         {
-            _popups.PopupClient(Loc.GetString("retractable-item-hand-cannot-drop"), args.Performer, args.Performer);
+            _popups.PopupEntity(Loc.GetString("retractable-item-hand-cannot-drop"), args.Performer, args.Performer);
             return;
         }
 

--- a/Content.Shared/Rotatable/RotatableSystem.cs
+++ b/Content.Shared/Rotatable/RotatableSystem.cs
@@ -138,7 +138,7 @@ public sealed partial class RotatableSystem : EntitySystem
         if (!rotatableComp.RotateWhileAnchored && TryComp<PhysicsComponent>(entity, out var physics) &&
             physics.BodyType == BodyType.Static)
         {
-            _popup.PopupClient(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
+            _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
             return false;
         }
 
@@ -163,7 +163,7 @@ public sealed partial class RotatableSystem : EntitySystem
         if (!rotatableComp.RotateWhileAnchored && TryComp<PhysicsComponent>(entity, out var physics) &&
             physics.BodyType == BodyType.Static)
         {
-            _popup.PopupClient(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
+            _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
             return false;
         }
 
@@ -187,7 +187,7 @@ public sealed partial class RotatableSystem : EntitySystem
         // Check if the object is anchored.
         if (TryComp<PhysicsComponent>(entity, out var physics) && physics.BodyType == BodyType.Static)
         {
-            _popup.PopupClient(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
+            _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
             return false;
         }
 

--- a/Content.Shared/Security/Systems/SharedGenpopSystem.cs
+++ b/Content.Shared/Security/Systems/SharedGenpopSystem.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedGenpopSystem : EntitySystem
 
         if (!_accessReader.IsAllowed(user, ent))
         {
-            _popup.PopupClient(Loc.GetString("lock-comp-has-user-access-fail"), user);
+            _popup.PopupCursor(Loc.GetString("lock-comp-has-user-access-fail"), user);
             return;
         }
 

--- a/Content.Shared/Security/Systems/SharedGenpopSystem.cs
+++ b/Content.Shared/Security/Systems/SharedGenpopSystem.cs
@@ -106,7 +106,7 @@ public abstract partial class SharedGenpopSystem : EntitySystem
         if (!_accessReader.FindPotentialAccessItems(args.User).Contains(ent.Comp.LinkedId.Value))
         {
             if (!args.Silent)
-                _popup.PopupClient(Loc.GetString("lock-comp-has-user-access-fail"), ent, args.User);
+                _popup.PopupEntity(Loc.GetString("lock-comp-has-user-access-fail"), ent, args.User);
             args.Cancelled = true;
             return;
         }
@@ -115,7 +115,7 @@ public abstract partial class SharedGenpopSystem : EntitySystem
             !expireIdCard.Expired)
         {
             if (!args.Silent)
-                _popup.PopupClient(Loc.GetString("genpop-prisoner-id-popup-not-served"), ent, args.User);
+                _popup.PopupEntity(Loc.GetString("genpop-prisoner-id-popup-not-served"), ent, args.User);
             args.Cancelled = true;
         }
     }

--- a/Content.Shared/SelectableComponentAdder/SelectableComponentAdderSystem.cs
+++ b/Content.Shared/SelectableComponentAdder/SelectableComponentAdderSystem.cs
@@ -39,7 +39,7 @@ public sealed partial class SelectableComponentAdderSystem : EntitySystem
                     if (entry.Popup == null)
                         return;
                     var message = Loc.GetString(entry.Popup.Value, ("target", target));
-                    _popup.PopupClient(message, target, user);
+                    _popup.PopupEntity(message, target, user);
                 },
                 Text = Loc.GetString(entry.VerbName),
             };

--- a/Content.Shared/Sericulture/SericultureSystem.cs
+++ b/Content.Shared/Sericulture/SericultureSystem.cs
@@ -74,7 +74,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
                 _hungerSystem.GetHunger(hungerComp) - comp.HungerCost,
                 hungerComp))
         {
-            _popupSystem.PopupClient(Loc.GetString(comp.PopupText), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString(comp.PopupText), uid, uid);
             return;
         }
 
@@ -102,7 +102,7 @@ public abstract partial class SharedSericultureSystem : EntitySystem
                 _hungerSystem.GetHunger(hungerComp) - comp.HungerCost,
                 hungerComp))
         {
-            _popupSystem.PopupClient(Loc.GetString(comp.PopupText), uid, uid);
+            _popupSystem.PopupEntity(Loc.GetString(comp.PopupText), uid, uid);
             return;
         }
 

--- a/Content.Shared/Shuttles/Systems/SharedEmergencyShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedEmergencyShuttleSystem.cs
@@ -31,6 +31,6 @@ public abstract partial class SharedEmergencyShuttleSystem : EntitySystem
         args.Cancel();
 
         if (!args.Silent)
-            Popup.PopupClient(Loc.GetString("emergency-shuttle-console-no-early-launches"), ent, args.User);
+            Popup.PopupEntity(Loc.GetString("emergency-shuttle-console-no-early-launches"), ent, args.User);
     }
 }

--- a/Content.Shared/Silicons/Bots/MedibotSystem.cs
+++ b/Content.Shared/Silicons/Bots/MedibotSystem.cs
@@ -70,7 +70,7 @@ public sealed partial class MedibotSystem : EntitySystem
 
         if (HasComp<NPCRecentlyInjectedComponent>(target))
         {
-            _popup.PopupClient(Loc.GetString("medibot-recently-injected"), medibot, medibot);
+            _popup.PopupEntity(Loc.GetString("medibot-recently-injected"), medibot, medibot);
             return false;
         }
 
@@ -80,14 +80,14 @@ public sealed partial class MedibotSystem : EntitySystem
 
         if (mobState.CurrentState != MobState.Alive && mobState.CurrentState != MobState.Critical)
         {
-            _popup.PopupClient(Loc.GetString("medibot-target-dead"), medibot, medibot);
+            _popup.PopupEntity(Loc.GetString("medibot-target-dead"), medibot, medibot);
             return false;
         }
 
         var total = damageable.TotalDamage;
         if (total == 0)
         {
-            _popup.PopupClient(Loc.GetString("medibot-target-healthy"), medibot, medibot);
+            _popup.PopupEntity(Loc.GetString("medibot-target-healthy"), medibot, medibot);
             return false;
         }
 
@@ -113,7 +113,7 @@ public sealed partial class MedibotSystem : EntitySystem
         _solutionContainer.TryAddReagent(injectable.Value, treatment.Reagent, treatment.Quantity, out _);
 
         _popup.PopupEntity(Loc.GetString("injector-component-feel-prick-message"), target, target);
-        _popup.PopupClient(Loc.GetString("medibot-target-injected"), medibot, medibot);
+        _popup.PopupEntity(Loc.GetString("medibot-target-injected"), medibot, medibot);
 
         _audio.PlayPredicted(medibot.Comp.InjectSound, medibot, medibot);
 

--- a/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
+++ b/Content.Shared/Singularity/EntitySystems/SharedEmitterSystem.cs
@@ -48,7 +48,7 @@ public abstract partial class SharedEmitterSystem : EntitySystem
                 {
                     ent.Comp.BoltType = type;
                     Dirty(ent);
-                    _popup.PopupClient(Loc.GetString("emitter-component-type-set", ("type", proto.Name)), ent.Owner);
+                    _popup.PopupCursor(Loc.GetString("emitter-component-type-set", ("type", proto.Name)), ent.Owner);
                 },
             };
             args.Verbs.Add(v);

--- a/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
+++ b/Content.Shared/SmartFridge/SharedSmartFridgeSystem.cs
@@ -115,7 +115,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         if (_accessReader.IsAllowed(user, machine))
             return true;
 
-        _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-access-denied"), machine, user);
+        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-access-denied"), machine);
         _audio.PlayPredicted(machine.Comp.SoundDeny, machine, user);
         return false;
     }
@@ -131,7 +131,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         if (!ent.Comp.ContainedEntries.TryGetValue(args.Entry, out var contained))
         {
             _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
-            _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-unknown-entry"), ent, args.Actor);
+            _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-unknown-entry"), ent);
             return;
         }
 
@@ -148,7 +148,7 @@ public abstract partial class SharedSmartFridgeSystem : EntitySystem
         }
 
         _audio.PlayPredicted(ent.Comp.SoundDeny, ent, args.Actor);
-        _popup.PopupPredicted(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent, args.Actor);
+        _popup.PopupEntity(Loc.GetString("smart-fridge-component-try-eject-out-of-stock"), ent);
     }
 
     private void OnGetAltVerb(Entity<SmartFridgeComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)

--- a/Content.Shared/Species/Systems/GibActionSystem.cs
+++ b/Content.Shared/Species/Systems/GibActionSystem.cs
@@ -52,7 +52,7 @@ public sealed partial class GibActionSystem : EntitySystem
     private void OnGibAction(EntityUid uid, GibActionComponent comp, GibActionEvent args)
     {
         // When they use the action, gib them.
-        _popupSystem.PopupClient(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
+        _popupSystem.PopupEntity(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
         _gibbing.Gib(uid, user: args.Performer);
     }
 

--- a/Content.Shared/Species/Systems/ReformSystem.cs
+++ b/Content.Shared/Species/Systems/ReformSystem.cs
@@ -61,7 +61,7 @@ public sealed partial class ReformSystem : EntitySystem
         // Stun them when they use the action for the amount of reform time.
         if (comp.ShouldStun)
             _stunSystem.TryUpdateStunDuration(uid, TimeSpan.FromSeconds(comp.ReformTime));
-        _popupSystem.PopupClient(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
+        _popupSystem.PopupEntity(Loc.GetString(comp.PopupText, ("name", uid)), uid, uid);
 
         // Create a doafter & start it
         var doAfter = new DoAfterArgs(EntityManager, uid, comp.ReformTime, new ReformDoAfterEvent(), uid)

--- a/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
+++ b/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
@@ -192,14 +192,14 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
             && Charges.GetCurrentCharges((args.Used, charges)) < targetGroup.Cost)
         {
             var msg = Loc.GetString("spray-painter-interact-no-charges");
-            _popup.PopupClient(msg, args.User, args.User);
+            _popup.PopupEntity(msg, args.User, args.User);
             return;
         }
 
         if (!targetGroup.Styles.TryGetValue(selectedStyle, out var proto))
         {
             var msg = Loc.GetString("spray-painter-style-not-available");
-            _popup.PopupClient(msg, args.User, args.User);
+            _popup.PopupEntity(msg, args.User, args.User);
             return;
         }
 

--- a/Content.Shared/SprayPainter/SprayPainterAmmoSystem.cs
+++ b/Content.Shared/SprayPainter/SprayPainterAmmoSystem.cs
@@ -38,11 +38,11 @@ public sealed partial class SprayPainterAmmoSystem : EntitySystem
         var count = Math.Min(charges.MaxCharges - charges.LastCharges, ent.Comp.Charges);
         if (count <= 0)
         {
-            _popup.PopupClient(Loc.GetString("spray-painter-ammo-after-interact-full"), target, user);
+            _popup.PopupEntity(Loc.GetString("spray-painter-ammo-after-interact-full"), target, user);
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("spray-painter-ammo-after-interact-refilled"), target, user);
+        _popup.PopupEntity(Loc.GetString("spray-painter-ammo-after-interact-refilled"), target, user);
         _charges.AddCharges(target, count);
         ent.Comp.Charges -= count;
         Dirty(ent, ent.Comp);

--- a/Content.Shared/Stacks/SharedStackSystem.cs
+++ b/Content.Shared/Stacks/SharedStackSystem.cs
@@ -87,19 +87,18 @@ public abstract partial class SharedStackSystem : EntitySystem
         switch (transferred)
         {
             case > 0:
-                Popup.PopupClient($"+{transferred}", popupPos, args.User);
+                Popup.PopupCoordinates($"+{transferred}", popupPos);
 
                 if (GetAvailableSpace(recipientStack) == 0)
                 {
-                    Popup.PopupClient(Loc.GetString("comp-stack-becomes-full"),
-                        popupPos.Offset(new Vector2(0, -0.5f)),
-                        args.User);
+                    Popup.PopupCoordinates(Loc.GetString("comp-stack-becomes-full"),
+                        popupPos.Offset(new Vector2(0, -0.5f)));
                 }
 
                 break;
 
             case 0 when GetAvailableSpace(recipientStack) == 0:
-                Popup.PopupClient(Loc.GetString("comp-stack-already-full"), popupPos, args.User);
+                Popup.PopupCoordinates(Loc.GetString("comp-stack-already-full"), popupPos);
                 break;
         }
 

--- a/Content.Shared/Sticky/Systems/StickySystem.cs
+++ b/Content.Shared/Sticky/Systems/StickySystem.cs
@@ -87,7 +87,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.StickPopupStart != null)
         {
             var msg = Loc.GetString(comp.StickPopupStart);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         // start sticking object to target
@@ -137,7 +137,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.UnstickPopupStart != null)
         {
             var msg = Loc.GetString(comp.UnstickPopupStart);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         // start unsticking object
@@ -166,7 +166,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.StickPopupSuccess != null)
         {
             var msg = Loc.GetString(comp.StickPopupSuccess);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         // send information to appearance that entity is stuck
@@ -208,7 +208,7 @@ public sealed partial class StickySystem : EntitySystem
         if (comp.UnstickPopupSuccess != null)
         {
             var msg = Loc.GetString(comp.UnstickPopupSuccess);
-            _popup.PopupClient(msg, user, user);
+            _popup.PopupEntity(msg, user, user);
         }
 
         comp.StuckTo = null;

--- a/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
@@ -101,7 +101,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         if (HasItemInside(entity))
         {
             var popup = Loc.GetString("comp-secret-stash-action-hide-container-not-empty");
-            _popupSystem.PopupClient(popup, entity, userUid);
+            _popupSystem.PopupEntity(popup, entity, userUid);
             return false;
         }
 
@@ -111,7 +111,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         {
             var msg = Loc.GetString("comp-secret-stash-action-hide-item-too-big",
                 ("item", itemToHideUid), ("stashname", GetStashName(entity)));
-            _popupSystem.PopupClient(msg, entity, userUid);
+            _popupSystem.PopupEntity(msg, entity, userUid);
             return false;
         }
 
@@ -122,7 +122,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         // all done, show success message
         var successMsg = Loc.GetString("comp-secret-stash-action-hide-success",
             ("item", itemToHideUid), ("stashname", GetStashName(entity)));
-        _popupSystem.PopupClient(successMsg, entity, userUid);
+        _popupSystem.PopupEntity(successMsg, entity, userUid);
         return true;
     }
 
@@ -148,7 +148,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         // show success message
         var successMsg = Loc.GetString("comp-secret-stash-action-get-item-found-something",
             ("stashname", GetStashName(entity)));
-        _popupSystem.PopupClient(successMsg, entity, userUid);
+        _popupSystem.PopupEntity(successMsg, entity, userUid);
 
         return true;
     }

--- a/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SecretStashSystem.cs
@@ -234,7 +234,7 @@ public sealed partial class SecretStashSystem : EntitySystem
         if (storedInside != null && storedInside.Count >= 1)
         {
             var popup = Loc.GetString("comp-secret-stash-on-destroyed-popup", ("stashname", GetStashName(entity)));
-            _popupSystem.PopupPredicted(popup, storedInside[0], null, PopupType.MediumCaution);
+            _popupSystem.PopupEntity(popup, storedInside[0], PopupType.MediumCaution);
         }
     }
 

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -426,7 +426,7 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         if (_weldable.IsWelded(target))
         {
             if (!silent && !component.Contents.Contains(user))
-                Popup.PopupClient(Loc.GetString("entity-storage-component-welded-shut-message"), target, user);
+                Popup.PopupEntity(Loc.GetString("entity-storage-component-welded-shut-message"), target, user);
 
             return false;
         }

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1259,13 +1259,13 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         if (!CanInsert(ent, toInsert.Value, out var reason, ent.Comp))
         {
-            _popupSystem.PopupClient(Loc.GetString(reason ?? "comp-storage-cant-insert"), ent, player);
+            _popupSystem.PopupEntity(Loc.GetString(reason ?? "comp-storage-cant-insert"), ent, player);
             return false;
         }
 
         if (!_sharedHandsSystem.CanDrop(player, toInsert.Value))
         {
-            _popupSystem.PopupClient(Loc.GetString("comp-storage-cant-drop", ("entity", toInsert.Value)), ent, player);
+            _popupSystem.PopupEntity(Loc.GetString("comp-storage-cant-drop", ("entity", toInsert.Value)), ent, player);
             return false;
         }
 
@@ -1287,7 +1287,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         if (!Insert(uid, toInsert, out _, user: player, uid.Comp, playSound: playSound))
         {
-            _popupSystem.PopupClient(Loc.GetString("comp-storage-cant-insert"), uid, player);
+            _popupSystem.PopupEntity(Loc.GetString("comp-storage-cant-insert"), uid, player);
             return false;
         }
         return true;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -158,7 +158,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!_handsSystem.CanDropHeld(user, user.Comp.ActiveHandId!))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop"));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop"), user);
             return false;
         }
 
@@ -166,13 +166,13 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (_inventorySystem.TryGetSlotEntity(target, slot, out _))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-item-slot-occupied", ("owner", targetIdentity)));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-item-slot-occupied", ("owner", targetIdentity)), user);
             return false;
         }
 
         if (!_inventorySystem.CanEquip(user, target, held, slot, out _))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-equip-message", ("owner", targetIdentity)));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-equip-message", ("owner", targetIdentity)), user);
             return false;
         }
 
@@ -261,7 +261,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
     {
         if (!_inventorySystem.TryGetSlotEntity(target, slot, out var slotItem))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-item-slot-free-message", ("owner", Identity.Entity(target, EntityManager))));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-item-slot-free-message", ("owner", Identity.Entity(target, EntityManager))), user);
             return false;
         }
 
@@ -270,7 +270,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!_inventorySystem.CanUnequip(user, target, slot, out var reason))
         {
-            _popupSystem.PopupCursor(Loc.GetString(reason));
+            _popupSystem.PopupCursor(Loc.GetString(reason), user);
             return false;
         }
 
@@ -375,13 +375,13 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!_handsSystem.CanDropHeld(user, user.Comp.ActiveHandId!))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop"));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop"), user);
             return false;
         }
 
         if (!_handsSystem.CanPickupToHand(target, activeItem.Value, handName, checkActionBlocker: false, handsComp: target.Comp))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-put-message", ("owner", Identity.Entity(target, EntityManager))));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-put-message", ("owner", Identity.Entity(target, EntityManager))), user);
             return false;
         }
 
@@ -476,7 +476,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!_handsSystem.TryGetHand(target, handName, out _))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-item-slot-free-message", ("owner", Identity.Entity(target, EntityManager))));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-item-slot-free-message", ("owner", Identity.Entity(target, EntityManager))), user);
             return false;
         }
 
@@ -491,7 +491,7 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!_handsSystem.CanDropHeld(target, handName, false))
         {
-            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop-message", ("owner", Identity.Entity(target, EntityManager))));
+            _popupSystem.PopupCursor(Loc.GetString("strippable-component-cannot-drop-message", ("owner", Identity.Entity(target, EntityManager))), user);
             return false;
         }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -350,7 +350,7 @@ public abstract partial class SharedStunSystem
 
         if (ev.Message != null)
         {
-            _popup.PopupClient(ev.Message.Value.Item1, entity, entity, ev.Message.Value.Item2);
+            _popup.PopupEntity(ev.Message.Value.Item1, entity, entity, ev.Message.Value.Item2);
         }
 
         return !ev.Cancelled;
@@ -380,7 +380,7 @@ public abstract partial class SharedStunSystem
         if (!IntersectingStandingColliders(entity.Owner))
             return false;
 
-        _popup.PopupClient(Loc.GetString("knockdown-component-stand-no-room"), entity, entity, PopupType.SmallCaution);
+        _popup.PopupEntity(Loc.GetString("knockdown-component-stand-no-room"), entity, entity, PopupType.SmallCaution);
         SetAutoStand(entity.Owner);
         return true;
 
@@ -442,11 +442,11 @@ public abstract partial class SharedStunSystem
 
         if (!Stamina.TryTakeStamina(entity, ev.Stamina, entity.Comp, visual: true))
         {
-            _popup.PopupClient(Loc.GetString("knockdown-component-pushup-failure"), entity, entity, PopupType.MediumCaution);
+            _popup.PopupEntity(Loc.GetString("knockdown-component-pushup-failure"), entity, entity, PopupType.MediumCaution);
             return false;
         }
 
-        _popup.PopupClient(Loc.GetString("knockdown-component-pushup-success"), entity, entity);
+        _popup.PopupEntity(Loc.GetString("knockdown-component-pushup-success"), entity, entity);
         _audio.PlayPredicted(entity.Comp.ForceStandSuccessSound, entity.Owner, entity.Owner, AudioParams.Default.WithVariation(0.025f).WithVolume(5f));
 
         return true;

--- a/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
+++ b/Content.Shared/SubFloor/SharedSubFloorHideSystem.cs
@@ -54,7 +54,7 @@ namespace Content.Shared.SubFloor
             if (TryComp<MapGridComponent>(xform.GridUid, out var grid)
                 && HasFloorCover(xform.GridUid.Value, grid, Map.TileIndicesFor(xform.GridUid.Value, grid, xform.Coordinates)))
             {
-                _popup.PopupClient(Loc.GetString("subfloor-anchor-failure", ("entity", uid)), args.User);
+                _popup.PopupCursor(Loc.GetString("subfloor-anchor-failure", ("entity", uid)), args.User);
                 args.Cancel();
             }
         }
@@ -65,7 +65,7 @@ namespace Content.Shared.SubFloor
             // despite being partially under the floor.
             if (component.IsUnderCover)
             {
-                _popup.PopupClient(Loc.GetString("subfloor-unanchor-failure", ("entity", uid)), args.User);
+                _popup.PopupCursor(Loc.GetString("subfloor-unanchor-failure", ("entity", uid)), args.User);
                 args.Cancel();
             }
         }

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -63,13 +63,13 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
 
         if (comp.LinkedEnt != null)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-fail-already"), uid, args.User);
             return;
         }
 
         if (targetComp.LinkedEnt != null)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already-other"), uid, args.User);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-fail-already-other"), uid, args.User);
             return;
         }
 
@@ -79,7 +79,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
         Dirty(target, targetComp);
         _appearance.SetData(uid, SwapTeleporterVisuals.Linked, true);
         _appearance.SetData(target, SwapTeleporterVisuals.Linked, true);
-        _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-create"), uid, args.User);
+        _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-create"), uid, args.User);
     }
 
     private void OnGetAltVerb(Entity<SwapTeleporterComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -115,7 +115,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
 
         if (comp.LinkedEnt == null)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-cancel-link"), ent, user);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-cancel-link"), ent, user);
             return;
         }
 
@@ -128,7 +128,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
 
         if (_timing.CurTime < comp.NextTeleportUse)
         {
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-cancel-time"), ent, user);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-cancel-time"), ent, user);
             return;
         }
 
@@ -166,7 +166,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-other",
+        _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-teleport-other",
             ("entity", Identity.Entity(linkedEnt, EntityManager))),
             teleEnt,
             otherTeleEnt,
@@ -209,7 +209,7 @@ public sealed partial class SwapTeleporterSystem : EntitySystem
         Dirty(ent, ent.Comp);
 
         if (user != null)
-            _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user.Value);
+            _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user.Value);
         else
             _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent);
 

--- a/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
+++ b/Content.Shared/Temperature/Systems/SharedEntityHeaterSystem.cs
@@ -69,7 +69,7 @@ public abstract partial class SharedEntityHeaterSystem : EntitySystem
         // Still allow changing the setting without power
         ent.Comp.Setting = setting;
         _audio.PlayPredicted(ent.Comp.SettingSound, ent, user);
-        _popup.PopupClient(Loc.GetString("entity-heater-switched-setting", ("setting", setting)), ent, user);
+        _popup.PopupEntity(Loc.GetString("entity-heater-switched-setting", ("setting", setting)), ent, user);
         Dirty(ent);
 
         // Only show the glowing heating element layer if there's power

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -136,7 +136,7 @@ public sealed partial class FloorTileSystem : EntitySystem
 
                 if (!CanPlaceTile(gridUid, mapGrid, tile.GridIndices, out var reason))
                 {
-                    _popup.PopupClient(reason, args.User, args.User);
+                    _popup.PopupEntity(reason, args.User, args.User);
                     return;
                 }
 

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Welder.cs
@@ -125,15 +125,15 @@ public abstract partial class SharedToolSystem
                 var drained = SolutionContainerSystem.Drain(target, targetSoln.Value, trans);
                 SolutionContainerSystem.TryAddSolution(solutionComp.Value, drained);
                 _audioSystem.PlayPredicted(entity.Comp.WelderRefill, entity, user: args.User);
-                _popup.PopupClient(Loc.GetString("welder-component-after-interact-refueled-message"), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("welder-component-after-interact-refueled-message"), entity, args.User);
             }
             else if (welderSolution.AvailableVolume <= 0)
             {
-                _popup.PopupClient(Loc.GetString("welder-component-already-full"), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("welder-component-already-full"), entity, args.User);
             }
             else
             {
-                _popup.PopupClient(Loc.GetString("welder-component-no-fuel-in-tank", ("owner", args.Target)), entity, args.User);
+                _popup.PopupEntity(Loc.GetString("welder-component-no-fuel-in-tank", ("owner", args.Target)), entity, args.User);
             }
 
             args.Handled = true;
@@ -144,7 +144,7 @@ public abstract partial class SharedToolSystem
     {
         if (!ItemToggle.IsActivated(entity.Owner))
         {
-            _popup.PopupClient(Loc.GetString("welder-component-welder-not-lit-message"), entity, user);
+            _popup.PopupEntity(Loc.GetString("welder-component-welder-not-lit-message"), entity, user);
             ev.Cancel();
         }
 
@@ -152,7 +152,7 @@ public abstract partial class SharedToolSystem
 
         if (requiredFuel > currentFuel)
         {
-            _popup.PopupClient(Loc.GetString("welder-component-cannot-weld-message"), entity, user);
+            _popup.PopupEntity(Loc.GetString("welder-component-cannot-weld-message"), entity, user);
             ev.Cancel();
         }
     }

--- a/Content.Shared/Trigger/Systems/DnaScrambleOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/DnaScrambleOnTriggerSystem.cs
@@ -41,7 +41,7 @@ public sealed partial class DnaScrambleOnTriggerSystem : XOnTriggerSystem<DnaScr
         RemComp<DetailExaminableComponent>(target); // remove MRP+ custom description if one exists
         _identity.QueueIdentityUpdate(target); // manually queue identity update since we don't raise the event
 
-        // Can't use PopupClient or PopupPredicted because the trigger might be unpredicted.
+        // Can't use PopupEntity or PopupPredicted because the trigger might be unpredicted.
         _popup.PopupEntity(Loc.GetString("scramble-on-trigger-popup"), target, target);
 
         var ev = new DnaScrambledEvent(target);

--- a/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class PopupOnTriggerSystem : XOnTriggerSystem<PopupOnTrigg
         // Popups play for all entities
         if (ent.Comp.Predicted)
         {
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
+            _popup.PopupEntity(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
                 Loc.GetString(ent.Comp.OtherText ?? ent.Comp.Text, ("entity", ent), ("user", user)),
                 target,
                 ent.Comp.UserIsRecipient ? args.User : ent.Owner,

--- a/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/PopupOnTriggerSystem.cs
@@ -20,7 +20,7 @@ public sealed partial class PopupOnTriggerSystem : XOnTriggerSystem<PopupOnTrigg
         {
             if (ent.Comp.Predicted)
             {
-                _popup.PopupClient(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
+                _popup.PopupEntity(Loc.GetString(ent.Comp.Text, ("entity", ent), ("user", user)),
                     target,
                     ent.Comp.UserIsRecipient ? args.User : ent.Owner,
                     ent.Comp.PopupType);

--- a/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerOnMobstateChangeSystem.cs
@@ -50,7 +50,7 @@ public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
         if (!component.PreventSuicide)
             return;
 
-        _popup.PopupClient(Loc.GetString("suicide-prevented"), args.Victim);
+        _popup.PopupCursor(Loc.GetString("suicide-prevented"), args.Victim);
         args.Handled = true;
     }
 
@@ -62,7 +62,7 @@ public sealed partial class TriggerOnMobstateChangeSystem : TriggerOnXSystem
         if (!component.PreventSuicide)
             return;
 
-        _popup.PopupClient(Loc.GetString("suicide-prevented"), args.Event.Victim);
+        _popup.PopupCursor(Loc.GetString("suicide-prevented"), args.Event.Victim);
         args.Event.Handled = true;
     }
 }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Condition.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Condition.cs
@@ -59,7 +59,7 @@ public sealed partial class TriggerSystem
     private void Toggle(Entity<ToggleTriggerConditionComponent> ent, EntityUid user)
     {
         var msg = ent.Comp.Enabled ? ent.Comp.ToggleOff : ent.Comp.ToggleOn;
-        _popup.PopupPredicted(Loc.GetString(msg), ent.Owner, user);
+        _popup.PopupEntity(Loc.GetString(msg), ent.Owner);
         ent.Comp.Enabled = !ent.Comp.Enabled;
         Dirty(ent);
     }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Timer.cs
@@ -100,7 +100,7 @@ public sealed partial class TriggerSystem
                     {
                         ent.Comp.Delay = option;
                         Dirty(ent);
-                        _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", option.TotalSeconds)), user, user);
+                        _popup.PopupEntity(Loc.GetString("timer-trigger-popup-set", ("time", option.TotalSeconds)), user, user);
                     }
                 });
             }
@@ -125,7 +125,7 @@ public sealed partial class TriggerSystem
         if (ent.Comp.DelayOptions[^1] <= ent.Comp.Delay)
         {
             ent.Comp.Delay = ent.Comp.DelayOptions[0];
-            _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", ent.Comp.Delay)), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString("timer-trigger-popup-set", ("time", ent.Comp.Delay)), ent.Owner, user);
             return;
         }
 
@@ -134,7 +134,7 @@ public sealed partial class TriggerSystem
             if (option > ent.Comp.Delay)
             {
                 ent.Comp.Delay = option;
-                _popup.PopupClient(Loc.GetString("timer-trigger-popup-set", ("time", option)), ent.Owner, user);
+                _popup.PopupEntity(Loc.GetString("timer-trigger-popup-set", ("time", option)), ent.Owner, user);
                 return;
             }
         }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.Voice.cs
@@ -148,7 +148,7 @@ public sealed partial class TriggerSystem
         else
             _adminLogger.Add(LogType.Trigger, LogImpact.Low, $"A voice-trigger on {ToPrettyString(ent):entity} has started recording. User: {ToPrettyString(user.Value):user}");
 
-        _popup.PopupPredicted(Loc.GetString("trigger-on-voice-start-recording"), ent, user);
+        _popup.PopupEntity(Loc.GetString("trigger-on-voice-start-recording"), ent);
     }
 
     /// <summary>
@@ -161,7 +161,7 @@ public sealed partial class TriggerSystem
         if (string.IsNullOrWhiteSpace(ent.Comp.KeyPhrase))
             RemComp<ActiveListenerComponent>(ent);
 
-        _popup.PopupPredicted(Loc.GetString("trigger-on-voice-stop-recording"), ent, user);
+        _popup.PopupEntity(Loc.GetString("trigger-on-voice-stop-recording"), ent);
     }
 
 
@@ -207,6 +207,6 @@ public sealed partial class TriggerSystem
         _adminLogger.Add(LogType.Trigger, LogImpact.Low,
             $"A voice-trigger on {ToPrettyString(ent):entity} has been reset to default keyphrase: '{ent.Comp.KeyPhrase}'. User: {ToPrettyString(user):speaker}");
 
-        _popup.PopupPredicted(Loc.GetString("trigger-on-voice-set-default", ("keyphrase", ent.Comp.KeyPhrase)), ent, user);
+        _popup.PopupEntity(Loc.GetString("trigger-on-voice-set-default", ("keyphrase", ent.Comp.KeyPhrase)), ent);
     }
 }

--- a/Content.Shared/Trigger/Systems/TriggerSystem.cs
+++ b/Content.Shared/Trigger/Systems/TriggerSystem.cs
@@ -107,7 +107,7 @@ public sealed partial class TriggerSystem : EntitySystem
         }
 
         if (ent.Comp.Popup != null)
-            _popup.PopupPredicted(Loc.GetString(ent.Comp.Popup.Value, ("device", ent.Owner)), ent.Owner, user);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.Popup.Value, ("device", ent.Owner)), ent.Owner);
 
         AddComp<ActiveTimerTriggerComponent>(ent);
         var curTime = _timing.CurTime;

--- a/Content.Shared/TurretController/SharedDeployableTurretControllerSystem.cs
+++ b/Content.Shared/TurretController/SharedDeployableTurretControllerSystem.cs
@@ -88,7 +88,7 @@ public abstract partial class SharedDeployableTurretControllerSystem : EntitySys
         if (_accessreader.IsAllowed(user, ent))
             return true;
 
-        _popup.PopupClient(Loc.GetString("turret-controls-access-denied"), ent, user);
+        _popup.PopupEntity(Loc.GetString("turret-controls-access-denied"), ent, user);
         _audio.PlayPredicted(ent.Comp.AccessDeniedSound, ent, user);
 
         return false;

--- a/Content.Shared/Turrets/SharedDeployableTurretSystem.cs
+++ b/Content.Shared/Turrets/SharedDeployableTurretSystem.cs
@@ -66,7 +66,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
 
         if (!_accessReader.IsAllowed(args.User, ent))
         {
-            _popup.PopupClient(Loc.GetString("deployable-turret-component-access-denied"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("deployable-turret-component-access-denied"), ent, args.User);
             _audio.PlayPredicted(ent.Comp.AccessDeniedSound, ent, args.User);
 
             return;
@@ -80,7 +80,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
         if (!ent.Comp.Enabled || args.Cancelled)
             return;
 
-        _popup.PopupClient(Loc.GetString("deployable-turret-component-cannot-access-wires"), ent, args.User);
+        _popup.PopupEntity(Loc.GetString("deployable-turret-component-cannot-access-wires"), ent, args.User);
 
         args.Cancelled = true;
     }
@@ -95,7 +95,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
         if (enabled && ent.Comp.CurrentState == DeployableTurretState.Broken)
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("deployable-turret-component-is-broken"), ent, user.Value);
+                _popup.PopupEntity(Loc.GetString("deployable-turret-component-is-broken"), ent, user.Value);
 
             return false;
         }
@@ -103,7 +103,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
         if (enabled && !HasAmmo(ent))
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("deployable-turret-component-no-ammo"), ent, user.Value);
+                _popup.PopupEntity(Loc.GetString("deployable-turret-component-no-ammo"), ent, user.Value);
 
             return false;
         }
@@ -150,7 +150,7 @@ public abstract partial class SharedDeployableTurretSystem : EntitySystem
 
         // Play pop up message
         var msg = enabled ? "deployable-turret-component-activating" : "deployable-turret-component-deactivating";
-        _popup.PopupClient(Loc.GetString(msg), ent, user);
+        _popup.PopupEntity(Loc.GetString(msg), ent, user);
 
         // Update enabled state
         ent.Comp.Enabled = enabled;

--- a/Content.Shared/UserInterface/ActivatableUIRequiresAnchorSystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUIRequiresAnchorSystem.cs
@@ -37,7 +37,7 @@ public sealed partial class ActivatableUIRequiresAnchorSystem : EntitySystem
 
         if (ent.Comp.Popup != null && !args.Silent)
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.Popup), args.User);
+            _popup.PopupCursor(Loc.GetString(ent.Comp.Popup), args.User);
         }
 
         args.Cancel();

--- a/Content.Shared/UserInterface/ActivatableUISystem.cs
+++ b/Content.Shared/UserInterface/ActivatableUISystem.cs
@@ -218,7 +218,7 @@ public sealed partial class ActivatableUISystem : EntitySystem
         if (aui.SingleUser && aui.CurrentSingleUser != null && user != aui.CurrentSingleUser)
         {
             var message = Loc.GetString("machine-already-in-use", ("machine", uiEntity));
-            _popupSystem.PopupClient(message, uiEntity, user);
+            _popupSystem.PopupEntity(message, uiEntity, user);
 
             if (_uiSystem.IsUiOpen(uiEntity, aui.Key))
                 return true;

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -95,7 +95,7 @@ public abstract partial class SharedVendingMachineSystem
         var othersMessage = Loc.GetString("vending-machine-restock-start-others",
             ("user", Identity.Entity(args.User, EntityManager)),
             ("target", target));
-        Popup.PopupPredicted(selfMessage, othersMessage, target, args.User, PopupType.Medium);
+        Popup.PopupEntity(selfMessage, othersMessage, target, args.User, PopupType.Medium);
 
 
         if (!Timing.IsFirstTimePredicted)
@@ -130,7 +130,7 @@ public abstract partial class SharedVendingMachineSystem
         var othersMessage = Loc.GetString("vending-machine-restock-done-others",
             ("user", Identity.Entity(args.User, EntityManager)),
             ("target", ent));
-        Popup.PopupPredicted(userMessage, othersMessage, ent, args.User, PopupType.Medium);
+        Popup.PopupEntity(userMessage, othersMessage, ent, args.User, PopupType.Medium);
 
         Audio.PlayPredicted(restockComponent.SoundRestockDone, ent, args.User);
 

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.Restock.cs
@@ -16,7 +16,7 @@ public abstract partial class SharedVendingMachineSystem
     {
         if (!TryComp<WiresPanelComponent>(target, out var panel) || !panel.Open)
         {
-            Popup.PopupPredictedCursor(Loc.GetString("vending-machine-restock-needs-panel-open",
+            Popup.PopupCursor(Loc.GetString("vending-machine-restock-needs-panel-open",
                     ("this", uid),
                     ("user", user),
                     ("target", target)),
@@ -39,7 +39,7 @@ public abstract partial class SharedVendingMachineSystem
 
         if (!component.CanRestock.Contains(machineComponent.PackPrototypeId))
         {
-            Popup.PopupPredictedCursor(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
+            Popup.PopupCursor(Loc.GetString("vending-machine-restock-invalid-inventory", ("this", uid), ("user", user),
                 ("target", target)), user);
 
             return false;

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -176,7 +176,7 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
         if (_accessReader.IsAllowed(sender, uid, accessReader))
             return true;
 
-        Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-access-denied"), uid, sender);
+        Popup.PopupEntity(Loc.GetString("vending-machine-component-try-eject-access-denied"), uid, sender);
         Deny((uid, vendComponent), sender);
         return false;
     }

--- a/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
+++ b/Content.Shared/VendingMachines/SharedVendingMachineSystem.cs
@@ -215,14 +215,14 @@ public abstract partial class SharedVendingMachineSystem : EntitySystem
 
         if (string.IsNullOrEmpty(entry?.ID))
         {
-            Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-invalid-item"), uid);
+            Popup.PopupCursor(Loc.GetString("vending-machine-component-try-eject-invalid-item"), uid);
             Deny((uid, vendComponent));
             return;
         }
 
         if (entry.Amount <= 0)
         {
-            Popup.PopupClient(Loc.GetString("vending-machine-component-try-eject-out-of-stock"), uid);
+            Popup.PopupCursor(Loc.GetString("vending-machine-component-try-eject-out-of-stock"), uid);
             Deny((uid, vendComponent));
             return;
         }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -460,7 +460,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         {
             if (ev.Message != null)
             {
-                PopupSystem.PopupClient(ev.Message, weaponUid, user);
+                PopupSystem.PopupEntity(ev.Message, weaponUid, user);
             }
 
             return false;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -915,7 +915,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
             {
                 // Notify disarmable
                 if (HasComp<MobStateComponent>(target.Value))
-                    PopupSystem.PopupClient(Loc.GetString("disarm-action-disarmable", ("targetName", target.Value)), target.Value);
+                    PopupSystem.PopupCursor(Loc.GetString("disarm-action-disarmable", ("targetName", target.Value)), target.Value);
 
                 return false;
             }

--- a/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/BatteryWeaponFireModesSystem.cs
@@ -149,7 +149,7 @@ public sealed partial class BatteryWeaponFireModesSystem : EntitySystem
                 _appearanceSystem.SetData(ent, BatteryWeaponFireModeVisuals.State, prototype.ID, appearance);
 
             if (user != null)
-                _popupSystem.PopupClient(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user.Value);
+                _popupSystem.PopupEntity(Loc.GetString("gun-set-fire-mode-popup", ("mode", prototype.Name)), ent, user.Value);
         }
 
         if (TryComp(ent, out BatteryAmmoProviderComponent? batteryAmmoProviderComponent))

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.ChamberMagazine.cs
@@ -159,7 +159,7 @@ public abstract partial class SharedGunSystem
             CycleCartridge(uid, component, user, appearance);
 
             if (user != null)
-                PopupSystem.PopupClient(Loc.GetString("gun-chamber-bolt-closed"), uid, user.Value);
+                PopupSystem.PopupEntity(Loc.GetString("gun-chamber-bolt-closed"), uid, user.Value);
 
             if (slots != null)
             {
@@ -189,7 +189,7 @@ public abstract partial class SharedGunSystem
             }
 
             if (user != null)
-                PopupSystem.PopupClient(Loc.GetString("gun-chamber-bolt-opened"), uid, user.Value);
+                PopupSystem.PopupEntity(Loc.GetString("gun-chamber-bolt-opened"), uid, user.Value);
 
             if (slots != null)
             {

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -339,7 +339,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         {
             if (attemptEv.Message != null)
             {
-                PopupSystem.PopupClient(attemptEv.Message, gun, user);
+                PopupSystem.PopupEntity(attemptEv.Message, gun, user);
             }
             gun.Comp.BurstActivated = false;
             gun.Comp.BurstShotsCount = 0;

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -378,7 +378,7 @@ public abstract partial class SharedGunSystem : EntitySystem
             // If they're firing an existing clip then don't play anything.
             if (shots > 0)
             {
-                PopupSystem.PopupCursor(ev.Reason ?? Loc.GetString("gun-magazine-fired-empty"));
+                PopupSystem.PopupCursor(ev.Reason ?? Loc.GetString("gun-magazine-fired-empty"), user);
 
                 // Don't spam safety sounds at gun fire rate, play it at a reduced rate.
                 // May cause prediction issues? Needs more tweaking

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         if (GetCurrentUpgrades(ent).Count >= ent.Comp.MaxUpgradeCount)
         {
-            _popup.PopupPredicted(Loc.GetString("upgradeable-gun-popup-upgrade-limit"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-upgrade-limit"), ent, args.User);
             return;
         }
 
@@ -80,7 +80,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
 
         if (GetCurrentUpgradeTags(ent).ToHashSet().IsSupersetOf(upgradeComponent.Tags))
         {
-            _popup.PopupPredicted(Loc.GetString("upgradeable-gun-popup-already-present"), ent, args.User);
+            _popup.PopupEntity(Loc.GetString("upgradeable-gun-popup-already-present"), ent);
             return;
         }
 

--- a/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Upgrades/GunUpgradeSystem.cs
@@ -85,7 +85,7 @@ public sealed partial class GunUpgradeSystem : EntitySystem
         }
 
         _audio.PlayPredicted(ent.Comp.InsertSound, ent, args.User);
-        _popup.PopupClient(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User);
+        _popup.PopupCursor(Loc.GetString("gun-upgrade-popup-insert", ("upgrade", args.Used),("gun", ent.Owner)), args.User);
         _gun.RefreshModifiers(ent.Owner);
         args.Handled = _container.Insert(args.Used, _container.GetContainer(ent, ent.Comp.UpgradesContainerId));
 

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -95,7 +95,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
             {
                 component.LastPopup = time;
                 var message = Loc.GetString("wieldable-component-requires", ("item", uid));
-                _popup.PopupClient(message, args.Used, args.User);
+                _popup.PopupEntity(message, args.Used, args.User);
             }
         }
     }
@@ -247,7 +247,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
         if (!TryComp<HandsComponent>(user, out var hands))
         {
             if (!quiet)
-                _popup.PopupClient(Loc.GetString("wieldable-component-no-hands"), user, user);
+                _popup.PopupEntity(Loc.GetString("wieldable-component-no-hands"), user, user);
             return false;
         }
 
@@ -255,7 +255,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
         if (!_hands.IsHolding((user, hands), uid, out _))
         {
             if (!quiet)
-                _popup.PopupClient(Loc.GetString("wieldable-component-not-in-hands", ("item", uid)), user, user);
+                _popup.PopupEntity(Loc.GetString("wieldable-component-not-in-hands", ("item", uid)), user, user);
             return false;
         }
 
@@ -265,7 +265,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
             {
                 var message = Loc.GetString("wieldable-component-not-enough-free-hands",
                     ("number", component.FreeHandsRequired), ("item", uid));
-                _popup.PopupClient(message, user, user);
+                _popup.PopupEntity(message, user, user);
             }
             return false;
         }
@@ -295,7 +295,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
         if (attemptEv.Cancelled)
         {
             if (attemptEv.Message != null)
-                _popup.PopupClient(attemptEv.Message, user, user);
+                _popup.PopupEntity(attemptEv.Message, user, user);
             return false;
         }
 
@@ -356,7 +356,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
             if (attemptEv.Cancelled)
             {
                 if (attemptEv.Message != null)
-                    _popup.PopupClient(attemptEv.Message, user, user);
+                    _popup.PopupEntity(attemptEv.Message, user, user);
                 return false;
             }
         }

--- a/Content.Shared/Wieldable/SharedWieldableSystem.cs
+++ b/Content.Shared/Wieldable/SharedWieldableSystem.cs
@@ -331,7 +331,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
 
         var selfMessage = Loc.GetString("wieldable-component-successful-wield", ("item", used));
         var othersMessage = Loc.GetString("wieldable-component-successful-wield-other", ("user", Identity.Entity(user, EntityManager)), ("item", used));
-        _popup.PopupPredicted(selfMessage, othersMessage, user, user);
+        _popup.PopupEntity(selfMessage, othersMessage, user, user);
 
         var ev = new ItemWieldedEvent(user);
         RaiseLocalEvent(used, ref ev);
@@ -405,7 +405,7 @@ public abstract partial class SharedWieldableSystem : EntitySystem
 
             var selfMessage = Loc.GetString("wieldable-component-failed-wield", ("item", uid));
             var othersMessage = Loc.GetString("wieldable-component-failed-wield-other", ("user", Identity.Entity(args.User, EntityManager)), ("item", uid));
-            _popup.PopupPredicted(selfMessage, othersMessage, user, user);
+            _popup.PopupEntity(selfMessage, othersMessage, user, user);
         }
     }
 

--- a/Content.Shared/_ES/Coroner/ESSharedCoronerSystem.cs
+++ b/Content.Shared/_ES/Coroner/ESSharedCoronerSystem.cs
@@ -46,7 +46,7 @@ public abstract partial class ESSharedCoronerSystem : EntitySystem
         if (!CanUseCoronerTool(ent.AsNullable(), args.User, target, out _))
             return;
 
-        _popup.PopupClient(Loc.GetString("es-coroner-report-complete-popup"), target, args.User, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("es-coroner-report-complete-popup"), target, args.User, PopupType.Medium);
         _audio.PlayPredicted(ent.Comp.AutopsySound, target, args.User);
         var paper = PredictedSpawnNextToOrDrop(ent.Comp.ReportPrototype, target);
         _paper.SetContent(paper, GetReport(target).ToMarkup());
@@ -59,7 +59,7 @@ public abstract partial class ESSharedCoronerSystem : EntitySystem
         if (!CanUseCoronerTool(tool, user, target, out var reason))
         {
             if (!string.IsNullOrEmpty(reason))
-                _popup.PopupClient(reason, target, user, PopupType.SmallCaution);
+                _popup.PopupEntity(reason, target, user, PopupType.SmallCaution);
 
             return false;
         }

--- a/Content.Shared/_ES/Emag/ESEmagSystem.cs
+++ b/Content.Shared/_ES/Emag/ESEmagSystem.cs
@@ -93,10 +93,9 @@ public sealed partial class ESEmagSystem : EntitySystem
         _charges.TryUseCharge(used.Owner);
         if (user.HasValue)
         {
-            _popup.PopupPredicted(
+            _popup.PopupEntity(
                 Loc.GetString("emag-success", ("target", Identity.Entity(target, EntityManager))),
                 user.Value,
-                user,
                 PopupType.Medium);
         }
 

--- a/Content.Shared/_ES/Emag/ESEmagSystem.cs
+++ b/Content.Shared/_ES/Emag/ESEmagSystem.cs
@@ -80,7 +80,7 @@ public sealed partial class ESEmagSystem : EntitySystem
         if (_charges.IsEmpty(used.Owner))
         {
             if (user != null)
-                _popup.PopupClient(Loc.GetString("emag-no-charges"), user.Value, user.Value);
+                _popup.PopupEntity(Loc.GetString("emag-no-charges"), user.Value, user.Value);
             return false;
         }
 

--- a/Content.Shared/_ES/Keypad/ESSharedKeypadSystem.cs
+++ b/Content.Shared/_ES/Keypad/ESSharedKeypadSystem.cs
@@ -173,7 +173,7 @@ public abstract partial class ESSharedKeypadSystem : EntitySystem
             ent.Comp.Passcode = ent.Comp.CodeInput;
             ent.Comp.CodeInput = string.Empty;
             _audio.PlayPredicted(ent.Comp.RightCodeSound, ent, user, ent.Comp.RightCodeSound.Params.WithPitchScale(1.15f));
-            _popup.PopupPredicted(Loc.GetString("es-keypad-popup-code-changed"), ent, user);
+            _popup.PopupEntity(Loc.GetString("es-keypad-popup-code-changed"), ent);
             Dirty(ent);
             return;
         }

--- a/Content.Shared/_ES/Masks/ChemicalInjector/ChemicalInjectorSystem.cs
+++ b/Content.Shared/_ES/Masks/ChemicalInjector/ChemicalInjectorSystem.cs
@@ -25,7 +25,7 @@ public sealed partial class ChemicalInjectorSystem : EntitySystem
 
         if (!_health.IsCritical(args.Performer) && args.OnlyUsableWhileCrit)
         {
-            _popupSystem.PopupPredicted(Loc.GetString(args.FailMessage), args.Performer, args.Performer, PopupType.Medium);
+            _popupSystem.PopupEntity(Loc.GetString(args.FailMessage), args.Performer, args.Performer, PopupType.Medium);
             return;
         }
 

--- a/Content.Shared/_ES/Masks/Phantom/ESPhantomSystem.cs
+++ b/Content.Shared/_ES/Masks/Phantom/ESPhantomSystem.cs
@@ -40,7 +40,7 @@ public sealed partial class ESPhantomSystem : EntitySystem
     {
         if (_physics.GetEntitiesIntersectingBody(ent, (int) CollisionGroup.Impassable).Count > 0)
         {
-            _popup.PopupPredicted(Loc.GetString("es-phantom-materialize-fail"), ent, ent, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString("es-phantom-materialize-fail"), ent, ent, PopupType.Medium);
             return;
         }
 

--- a/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
@@ -74,7 +74,7 @@ public sealed partial class ESAddMaskOnUseSystem : EntitySystem
 
         _doafter.TryStartDoAfter(doAfterArgs);
 
-        _popup.PopupPredicted(Loc.GetString(ent.Comp.UsingMessage), ent, ent, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.UsingMessage), ent, PopupType.MediumCaution);
     }
 
     private void OnDoAfter(Entity<ESAddMaskOnUseComponent> ent, ref ESAddMaskOnUseDoAfterEvent args)

--- a/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESAddMaskOnUseSystem.cs
@@ -44,7 +44,7 @@ public sealed partial class ESAddMaskOnUseSystem : EntitySystem
 
         if (ent.Comp.MindshieldPrevent && HasComp<MindShieldComponent>(args.Target))
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.MindshieldedMessage), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.MindshieldedMessage), args.User, args.User);
             return;
         }
 
@@ -52,13 +52,13 @@ public sealed partial class ESAddMaskOnUseSystem : EntitySystem
             !_health.IsCritical(args.Target.Value) &&
             _actionBlocker.CanInteract(args.Target.Value, null))
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.NotIncapacitatedMessage), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.NotIncapacitatedMessage), args.User, args.User);
             return;
         }
 
         if (ent.Comp.Used)
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.UsedMessage), args.User, args.User, PopupType.Medium);
+            _popup.PopupEntity(Loc.GetString(ent.Comp.UsedMessage), args.User, args.User, PopupType.Medium);
             return;
         }
 

--- a/Content.Shared/_ES/Masks/Traitor/ESSabotageSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESSabotageSystem.cs
@@ -85,7 +85,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
                     }))
                     return;
 
-                _popup.PopupPredicted(Loc.GetString("es-sabotage-popup-starting"), ent, user, PopupType.SmallCaution);
+                _popup.PopupEntity(Loc.GetString("es-sabotage-popup-starting"), ent, PopupType.SmallCaution);
             },
         });
     }

--- a/Content.Shared/_ES/Masks/Traitor/ESSharedMaskCacheSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESSharedMaskCacheSystem.cs
@@ -137,7 +137,7 @@ public abstract partial class ESSharedMaskCacheSystem : EntitySystem
         var pos = Transform(ent).Coordinates;
         var cache = PredictedSpawnAtPosition(ent.Comp.CacheLoot, pos);
         PredictedQueueDel(ent);
-        _popup.PopupPredicted(Loc.GetString("es-ceiling-cache-popup"), cache, user);
+        _popup.PopupEntity(Loc.GetString("es-ceiling-cache-popup"), cache);
         _audio.PlayPredicted(ent.Comp.RevealSound, pos, user);
 
         if (ent.Comp.MindId.HasValue)

--- a/Content.Shared/_ES/Telesci/Anomaly/ESSharedAnomalySystem.cs
+++ b/Content.Shared/_ES/Telesci/Anomaly/ESSharedAnomalySystem.cs
@@ -80,7 +80,7 @@ public abstract partial class ESSharedAnomalySystem : EntitySystem
                 {
                     SetProbeSignal(ent, signal);
                     _sparks.DoSparks(ent.Owner, 1, user: user);
-                    _popup.PopupPredicted(Loc.GetString("es-anomaly-probe-popup-freq-set", ("type", GetSignalString(Loc, signal))), ent, user);
+                    _popup.PopupEntity(Loc.GetString("es-anomaly-probe-popup-freq-set", ("type", GetSignalString(Loc, signal))), ent);
                 },
             };
             args.Verbs.Add(v);
@@ -141,7 +141,7 @@ public abstract partial class ESSharedAnomalySystem : EntitySystem
 
         _sparks.DoSparks(ent, user: args.User);
         _audio.PlayPredicted(ent.Comp.CompleteSound, ent, args.User);
-        _popup.PopupPredicted(Loc.GetString("es-anomaly-probe-completed-probe"), target, args.User, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("es-anomaly-probe-completed-probe"), target, PopupType.Medium);
         var query = EntityQueryEnumerator<ESAnomalyConsoleComponent>();
         while (query.MoveNext(out var comp))
         {
@@ -196,7 +196,7 @@ public abstract partial class ESSharedAnomalySystem : EntitySystem
         Dirty(ent);
         UpdateConsolesUi();
 
-        _popup.PopupPredicted(Loc.GetString("anomaly-popup-correct"), ent, user, PopupType.Medium);
+        _popup.PopupEntity(Loc.GetString("anomaly-popup-correct"), ent, PopupType.Medium);
 
         if (ent.Comp.CodeIndex >= ent.Comp.CodeLength)
         {
@@ -228,7 +228,7 @@ public abstract partial class ESSharedAnomalySystem : EntitySystem
     public void PulseAnomalyRadiation(Entity<ESPortalAnomalyComponent> ent, EntityUid? user)
     {
         _audio.PlayPredicted(ent.Comp.RadPulseSound, ent, user);
-        _popup.PopupPredicted(Loc.GetString("anomaly-popup-fail"), ent, user, PopupType.MediumCaution);
+        _popup.PopupEntity(Loc.GetString("anomaly-popup-fail"), ent, PopupType.MediumCaution);
         PredictedSpawnAttachedTo(ent.Comp.RadiationEntity, Transform(ent).Coordinates);
         ent.Comp.NextSignalTime = _timing.CurTime + TimeSpan.FromSeconds(3);
         RaiseNetworkEvent(new ESAnomalyRadiationAnimationEvent

--- a/Content.Shared/_Offbrand/IV/IVSystem.cs
+++ b/Content.Shared/_Offbrand/IV/IVSystem.cs
@@ -214,7 +214,7 @@ public sealed partial class IVSystem : EntitySystem
 
         if (_itemSlots.GetItemOrNull(source, source.Comp.SlotName) is not { } contained)
         {
-            _popup.PopupPredictedCursor(Loc.GetString(source.Comp.NoBagInserted), user);
+            _popup.PopupCursor(Loc.GetString(source.Comp.NoBagInserted), user);
             return;
         }
 

--- a/Content.Shared/_Offbrand/IV/IVSystem.cs
+++ b/Content.Shared/_Offbrand/IV/IVSystem.cs
@@ -154,7 +154,7 @@ public sealed partial class IVSystem : EntitySystem
         if (!TryComp<PhysicsComponent>(target, out var targetPhysics))
             return;
 
-        _popup.PopupPredicted(
+        _popup.PopupEntity(
             Loc.GetString(source.Comp.ConnectedUser, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             Loc.GetString(source.Comp.ConnectedOthers, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             target,
@@ -187,7 +187,7 @@ public sealed partial class IVSystem : EntitySystem
         if (!Resolve(source, ref source.Comp) || !Resolve(target, ref target.Comp))
             return;
 
-        _popup.PopupPredicted(
+        _popup.PopupEntity(
             Loc.GetString(source.Comp.DisconnectedUser, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             Loc.GetString(source.Comp.DisconnectedOthers, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             target,
@@ -218,7 +218,7 @@ public sealed partial class IVSystem : EntitySystem
             return;
         }
 
-        _popup.PopupPredicted(
+        _popup.PopupEntity(
             Loc.GetString(source.Comp.StartConnectionUser, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             Loc.GetString(source.Comp.StartConnectionOthers, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             target,
@@ -241,7 +241,7 @@ public sealed partial class IVSystem : EntitySystem
         if (!Resolve(source, ref source.Comp) || !Resolve(target, ref target.Comp) || source.Comp.IVTarget is null || target.Comp.IVSource is null || source.Comp.IVTarget != target || target.Comp.IVSource != source)
             return;
 
-        _popup.PopupPredicted(
+        _popup.PopupEntity(
             Loc.GetString(source.Comp.StartDisconnectionUser, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             Loc.GetString(source.Comp.StartDisconnectionOthers, ("target", Identity.Entity(target, EntityManager)), ("source", Identity.Entity(source, EntityManager)), ("user", Identity.Entity(user, EntityManager))),
             target,

--- a/Content.Shared/_Offbrand/StatusEffects/PopupOnAppliedStatusEffectSystem.cs
+++ b/Content.Shared/_Offbrand/StatusEffects/PopupOnAppliedStatusEffectSystem.cs
@@ -16,6 +16,6 @@ public sealed partial class PopupOnAppliedStatusEffectSystem : EntitySystem
 
     private void OnStatusEffectApplied(Entity<PopupOnAppliedStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
     {
-        _popup.PopupClient(Loc.GetString(ent.Comp.Message), args.Target, args.Target, ent.Comp.VisualType);
+        _popup.PopupEntity(Loc.GetString(ent.Comp.Message), args.Target, args.Target, ent.Comp.VisualType);
     }
 }

--- a/Content.Shared/_Offbrand/StatusEffects/RemovableStatusEffectSystem.cs
+++ b/Content.Shared/_Offbrand/StatusEffects/RemovableStatusEffectSystem.cs
@@ -49,7 +49,7 @@ public sealed partial class RemovableStatusEffectSystem : EntitySystem
         {
             if (ent.Comp.UserStarted is { } userStarted && ent.Comp.OtherStarted is { } otherStarted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(userStarted, ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     Loc.GetString(otherStarted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     target,
@@ -61,7 +61,7 @@ public sealed partial class RemovableStatusEffectSystem : EntitySystem
         {
             if (ent.Comp.SelfUserStarted is { } selfUserStarted && ent.Comp.SelfOtherStarted is { } selfOtherStarted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(selfUserStarted, ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     Loc.GetString(selfOtherStarted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     target,
@@ -93,7 +93,7 @@ public sealed partial class RemovableStatusEffectSystem : EntitySystem
         {
             if (ent.Comp.UserCompleted is { } userCompleted && ent.Comp.OtherCompleted is { } otherCompleted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(userCompleted, ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     Loc.GetString(otherCompleted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     target,
@@ -105,7 +105,7 @@ public sealed partial class RemovableStatusEffectSystem : EntitySystem
         {
             if (ent.Comp.SelfUserCompleted is { } selfUserCompleted && ent.Comp.SelfOtherCompleted is { } selfOtherCompleted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(selfUserCompleted, ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     Loc.GetString(selfOtherCompleted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("effect", ent)),
                     target,

--- a/Content.Shared/_Offbrand/Surgery/SharedSurgeryGuideTargetSystem.cs
+++ b/Content.Shared/_Offbrand/Surgery/SharedSurgeryGuideTargetSystem.cs
@@ -42,12 +42,12 @@ public abstract partial class SharedSurgeryGuideTargetSystem : EntitySystem
     protected virtual void OnStartSurgery(Entity<SurgeryGuideTargetComponent> ent, ref SurgeryGuideStartSurgeryMessage args)
     {
         _userInterface.CloseUi(ent.Owner, SurgeryGuideUiKey.Key, args.Actor);
-        _popup.PopupPredictedCursor(Loc.GetString("surgery-examine-for-instructions"), args.Actor);
+        _popup.PopupCursor(Loc.GetString("surgery-examine-for-instructions"), args.Actor);
     }
 
     protected virtual void OnStartCleanup(Entity<SurgeryGuideTargetComponent> ent, ref SurgeryGuideStartCleanupMessage args)
     {
         _userInterface.CloseUi(ent.Owner, SurgeryGuideUiKey.Key, args.Actor);
-        _popup.PopupPredictedCursor(Loc.GetString("surgery-examine-for-instructions"), args.Actor);
+        _popup.PopupCursor(Loc.GetString("surgery-examine-for-instructions"), args.Actor);
     }
 }

--- a/Content.Shared/_Offbrand/Triggers/TriggerOnDoAfterSystem.cs
+++ b/Content.Shared/_Offbrand/Triggers/TriggerOnDoAfterSystem.cs
@@ -114,7 +114,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
             if (attemptTriggerEvent.Cancelled)
             {
                 if (trigger.Comp.ConditionFailedRepeat is { } conditionFailedRepeat)
-                    _popup.PopupClient(Loc.GetString(conditionFailedRepeat, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)), args.User);
+                    _popup.PopupCursor(Loc.GetString(conditionFailedRepeat, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)), args.User);
             }
             else
                 args.Repeat = true;
@@ -122,7 +122,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
         else
         {
             if (trigger.Comp.ItemsUsedUp is { } usedUp)
-                _popup.PopupClient(Loc.GetString(usedUp, ("trigger", args.Used.Value)), args.Args.User);
+                _popup.PopupCursor(Loc.GetString(usedUp, ("trigger", args.Used.Value)), args.Args.User);
         }
     }
 
@@ -137,7 +137,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
         if (attemptTriggerEvent.Cancelled)
         {
             if (trigger.Comp.ConditionFailed is { } conditionFailed)
-                _popup.PopupClient(Loc.GetString(conditionFailed, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)), user);
+                _popup.PopupCursor(Loc.GetString(conditionFailed, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)), user);
 
             return true;
         }

--- a/Content.Shared/_Offbrand/Triggers/TriggerOnDoAfterSystem.cs
+++ b/Content.Shared/_Offbrand/Triggers/TriggerOnDoAfterSystem.cs
@@ -62,7 +62,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
         {
             if (trigger.Comp.UserCompleted is { } userCompleted && trigger.Comp.OtherCompleted is { } otherCompleted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(userCompleted, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     Loc.GetString(otherCompleted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     target,
@@ -74,7 +74,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
         {
             if (trigger.Comp.SelfUserCompleted is { } selfUserCompleted && trigger.Comp.SelfOtherCompleted is { } selfOtherCompleted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(selfUserCompleted, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     Loc.GetString(selfOtherCompleted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     target,
@@ -157,7 +157,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
         {
             if (trigger.Comp.UserStarted is { } userStarted && trigger.Comp.OtherStarted is { } otherStarted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(userStarted, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     Loc.GetString(otherStarted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     target,
@@ -169,7 +169,7 @@ public sealed partial class TriggerOnDoAfterSystem : EntitySystem
         {
             if (trigger.Comp.SelfUserStarted is { } selfUserStarted && trigger.Comp.SelfOtherStarted is { } selfOtherStarted)
             {
-                _popup.PopupPredicted(
+                _popup.PopupEntity(
                     Loc.GetString(selfUserStarted, ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     Loc.GetString(selfOtherStarted, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("trigger", trigger)),
                     target,

--- a/Content.Shared/_Offbrand/Wounds/CprSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/CprSystem.cs
@@ -31,7 +31,7 @@ public sealed partial class CprSystem : EntitySystem
 
     private void TryStartCpr(Entity<CprTargetComponent> ent, EntityUid user)
     {
-        _popup.PopupPredicted(
+        _popup.PopupEntity(
             Loc.GetString(ent.Comp.UserPopup, ("target", Identity.Entity(ent, EntityManager))),
             Loc.GetString(ent.Comp.OtherPopup, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(ent, EntityManager))),
             ent,

--- a/Content.Shared/_Offbrand/Wounds/CprSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/CprSystem.cs
@@ -61,7 +61,7 @@ public sealed partial class CprSystem : EntitySystem
         {
             if (_woundable.TryWound((ent, woundable), ent.Comp.Wound, unique: true, refreshDamage: true))
             {
-                _popup.PopupClient(
+                _popup.PopupEntity(
                     Loc.GetString(ent.Comp.WoundPopup, ("target", Identity.Entity(ent, EntityManager))),
                     ent.Owner,
                     args.User,

--- a/Content.Shared/_Offbrand/Wounds/TendingSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/TendingSystem.cs
@@ -81,9 +81,9 @@ public sealed partial class TendingSystem : EntitySystem
         if (woundToTend is not { } foundWound)
         {
             if (isRepeat)
-                _popup.PopupClient(Loc.GetString(ent.Comp.NothingToTendRepeat, ("target", Identity.Entity(target, EntityManager)), ("tending", ent)), user);
+                _popup.PopupCursor(Loc.GetString(ent.Comp.NothingToTendRepeat, ("target", Identity.Entity(target, EntityManager)), ("tending", ent)), user);
             else
-                _popup.PopupClient(Loc.GetString(ent.Comp.NothingToTend, ("target", Identity.Entity(target, EntityManager)), ("tending", ent)), user);
+                _popup.PopupCursor(Loc.GetString(ent.Comp.NothingToTend, ("target", Identity.Entity(target, EntityManager)), ("tending", ent)), user);
 
             return true;
         }
@@ -113,7 +113,7 @@ public sealed partial class TendingSystem : EntitySystem
         }
         else
         {
-            _popup.PopupClient(Loc.GetString(ent.Comp.SelfPopup, ("tending", ent), ("wound", foundWound)), user);
+            _popup.PopupCursor(Loc.GetString(ent.Comp.SelfPopup, ("tending", ent), ("wound", foundWound)), user);
         }
 
         var args =
@@ -160,7 +160,7 @@ public sealed partial class TendingSystem : EntitySystem
         }
         else
         {
-            _popup.PopupClient(Loc.GetString(tending.UsedUp, ("tending", args.Used.Value)), args.Args.User);
+            _popup.PopupCursor(Loc.GetString(tending.UsedUp, ("tending", args.Used.Value)), args.Args.User);
         }
     }
 }

--- a/Content.Shared/_Offbrand/Wounds/TendingSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/TendingSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class TendingSystem : EntitySystem
 
         if (differentTarget)
         {
-            _popup.PopupPredicted(
+            _popup.PopupEntity(
                 Loc.GetString(ent.Comp.UserPopup, ("target", Identity.Entity(target, EntityManager)), ("tending", ent), ("wound", foundWound)),
                 Loc.GetString(ent.Comp.OtherPopup, ("user", Identity.Entity(user, EntityManager)), ("target", Identity.Entity(target, EntityManager)), ("tending", ent), ("wound", foundWound)),
                 target,


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Popups are plagued with a ton of confusing overload methods designed to handle cases when prediction causes duplicate popups to be shown. This leads to what can only be described as an incredibly confusing architecture where each caller has to individually consider whether they are currently operating in a predicted environment (impossible to know). As such, it's fairly common to see double popups or have missing popups in situations where the incorrect method is getting called in the wrong environment.

This PR corrects this by adding proper prediction collision resolution to popups. Using a similar system as Pain Flashes, the client now creates tokens for each popup, which it uses to resolve collisions by not showing popups coming from the server with matching tokens.

Tested to the best of my ability (there were like 500 popup usages i had to redo) so if you want to run around in this beautiful world let me know if anything is broken.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
