### PR TITLE
Fix caches playing double popups

### DIFF
--- a/Content.Shared/_ES/Masks/Traitor/ESSharedMaskCacheSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESSharedMaskCacheSystem.cs
@@ -137,7 +137,7 @@ public abstract partial class ESSharedMaskCacheSystem : EntitySystem
         var pos = Transform(ent).Coordinates;
         var cache = PredictedSpawnAtPosition(ent.Comp.CacheLoot, pos);
         PredictedQueueDel(ent);
-        _popup.PopupEntity(Loc.GetString("es-ceiling-cache-popup"), cache);
+        _popup.PopupEntity(Loc.GetString("es-ceiling-cache-popup"), ent);
         _audio.PlayPredicted(ent.Comp.RevealSound, pos, user);
 
         if (ent.Comp.MindId.HasValue)


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1935 

the predicted spawn gives two unique entityuids which means trying to do a popup on that will register as trying to do two unique popups. fml.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

