### PR TITLE
Make parasite "do not kill" more strict

### DIFF
--- a/Content.Server/_ES/Masks/Objectives/Relays/Components/ESDamageDealerRelayComponent.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/Components/ESDamageDealerRelayComponent.cs
@@ -1,0 +1,5 @@
+﻿namespace Content.Server._ES.Masks.Objectives.Relays.Components;
+
+[RegisterComponent]
+[Access(typeof(ESDamageDealerRelaySystem))]
+public sealed partial class ESDamageDealerRelayComponent : Component;

--- a/Content.Server/_ES/Masks/Objectives/Relays/ESDamageDealerRelaySystem.cs
+++ b/Content.Server/_ES/Masks/Objectives/Relays/ESDamageDealerRelaySystem.cs
@@ -1,0 +1,28 @@
+using Content.Server._ES.Masks.Objectives.Relays.Components;
+using Content.Server.Mind;
+using Content.Shared._ES.Mind;
+using Content.Shared.Damage.Systems;
+
+namespace Content.Server._ES.Masks.Objectives.Relays;
+
+/// <summary>
+///     This handles relaying <see cref="DamageChangedEvent"/> to the mind, allowing other objectives to listen to it.
+/// </summary>
+public sealed partial class ESDamageDealerRelaySystem : ESBaseMindRelay
+{
+    [Dependency] private MindSystem _mind = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ESDamageDealerRelayComponent, ESCausedDamageChanged>(OnCausedDamageChanged);
+    }
+
+    private void OnCausedDamageChanged(Entity<ESDamageDealerRelayComponent> ent, ref ESCausedDamageChanged args)
+    {
+        if (!_mind.TryGetMind(ent, out var mind))
+            return;
+
+        RaiseMindEvent(mind.Value, ref args);
+    }
+}

--- a/Content.Server/_ES/Masks/Parasite/Components/ESParasiteDamageObjectiveComponent.cs
+++ b/Content.Server/_ES/Masks/Parasite/Components/ESParasiteDamageObjectiveComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server._ES.Masks.Parasite.Components;
+
+[RegisterComponent]
+[Access(typeof(ESParasiteDamageObjectiveSystem))]
+public sealed partial class ESParasiteDamageObjectiveComponent : Component
+{
+    [DataField]
+    public bool Failed;
+
+    [DataField]
+    public TimeSpan KillDelay = TimeSpan.FromMinutes(1);
+}

--- a/Content.Server/_ES/Masks/Parasite/ESParasiteDamageObjectiveSystem.cs
+++ b/Content.Server/_ES/Masks/Parasite/ESParasiteDamageObjectiveSystem.cs
@@ -1,0 +1,51 @@
+using Content.Server._ES.Masks.Nobleman.Components;
+using Content.Server._ES.Masks.Objectives.Relays.Components;
+using Content.Server._ES.Masks.Parasite.Components;
+using Content.Server.Administration;
+using Content.Shared._ES.Core.Timer;
+using Content.Shared._ES.Objectives;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Systems;
+using Robust.Shared.Player;
+
+namespace Content.Server._ES.Masks.Parasite;
+
+public sealed partial class ESParasiteDamageObjectiveSystem : ESBaseObjectiveSystem<ESParasiteDamageObjectiveComponent>
+{
+    [Dependency] private ESEntityTimerSystem _timer = default!;
+    [Dependency] private QuickDialogSystem _quickDialog = default!;
+
+    public override Type[] RelayComponents { get; } = [typeof(ESDamageDealerRelayComponent)];
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ESParasiteDamageObjectiveComponent, ESCausedDamageChanged>(OnCausedDamageChanged);
+    }
+
+    private void OnCausedDamageChanged(Entity<ESParasiteDamageObjectiveComponent> ent, ref ESCausedDamageChanged args)
+    {
+        if (args.DamageDelta is null || !MindSys.TryGetMind(args.Entity, out _))
+            return;
+
+        var damageDealt = DamageSpecifier.GetPositive(args.DamageDelta).GetTotal();
+        ObjectivesSys.AdjustObjectiveCounter(ent.Owner, damageDealt.Float());
+
+        if (!ent.Comp.Failed && ObjectivesSys.GetProgress(ent.Owner) <= 0)
+        {
+            ent.Comp.Failed = true;
+
+            _timer.SpawnTimer(args.Origin, ent.Comp.KillDelay, new ESTimedDemiseOnKillEvent());
+
+            if (!TryComp<ActorComponent>(args.Origin, out var actor))
+                return;
+
+            var title = Loc.GetString("es-parasite-killer-quickdialog-title");
+            var msg = Loc.GetString("es-parasite-killer-quickdialog-msg");
+
+            _quickDialog.OpenDialog<string>(actor.PlayerSession, title, msg, _ => {});
+        }
+    }
+}

--- a/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.Events.cs
@@ -331,3 +331,11 @@ public sealed class DamageChangedEvent : EntityEventArgs
         InterruptsDoAfters = interruptsDoAfters && DamageIncreased;
     }
 }
+
+[ByRefEvent]
+public readonly record struct ESCausedDamageChanged(
+    Entity<DamageableComponent> Entity,
+    DamageSpecifier? DamageDelta,
+    EntityUid Origin,
+    EntityUid? Source,
+    EntityUid? Weapon);

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -71,9 +71,13 @@ public sealed partial class DamageableSystem : EntitySystem
 
         // TODO DAMAGE
         // byref struct event.
-// ES START
         RaiseLocalEvent(ent, new DamageChangedEvent(ent.Comp, damageDelta, interruptsDoAfters, origin, forceRefresh, source, weapon));
-// ES END
+
+        if (origin.HasValue)
+        {
+            var originEv = new ESCausedDamageChanged(ent, damageDelta, origin.Value, source, weapon);
+            RaiseLocalEvent(origin.Value, ref originEv);
+        }
     }
 
     private void DamageableGetState(Entity<DamageableComponent> ent, ref ComponentGetState args)

--- a/Resources/Prototypes/_ES/Objectives/parasite.yml
+++ b/Resources/Prototypes/_ES/Objectives/parasite.yml
@@ -28,14 +28,14 @@
 - type: entity
   parent: ESBaseMaskObjective
   id: ESObjectiveParasiteDoNotKill
-  name: Don't kill anyone
-  description: The parasite in your head is extremely sensitive to hormonal changes caused by taking the life of another. Any influx could send it on a frenzy, eating your brain and killing you.
+  name: Don't harm others
+  description: The parasite in your head is extremely sensitive to hormonal changes caused by harming. A small amount would be fine, but too much will send it into a frenzy, killing you.
   components:
   - type: ESObjective
     icon:
-      sprite: _ES/Interface/Objectives/parasite.rsi
-      state: icon
-  - type: ESTimedDemiseOnKillObjective
-    killDelay: 1m
-    notificationTitle: es-parasite-killer-quickdialog-title
-    notificationBody: es-parasite-killer-quickdialog-msg
+      sprite: Mobs/Species/Human/organs.rsi
+      state: brain
+    invertProgress: true
+  - type: ESCounterObjective
+    target: 200
+  - type: ESParasiteDamageObjective


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1934 

The parasite objective that kills them if they take another's life has been changed to be based on total damage dealt to entities with minds (real players).

The old objective was technically fine but was prone to a lot of cheese where parasites could play very aggressively while being safeguarded by the fact that as long as you don't fully escalate to lethality, it doesn't matter if you rough people up. This makes parasites kinda ridiculously difficult to deal with, since they can play super aggressively with the expectation that so long as they throw at the end of a conflict, their opponent isn't going to die and they'll be able to fire off their ability.

hopefully with the new setup they can still be a bit aggressive but they have to stave off and ration their damageable-ness lest they kill themselves. (also this is an insane psychid nerf cuz this accumulated damage persists across all lives LMAO)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="845" height="277" alt="image" src="https://github.com/user-attachments/assets/1395889f-b99e-4be2-8343-3e65b4c9fff5" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The Parasite objective for "do not kill" players now works based on total damage dealt rather than kills.
