### PR TITLE
Pick pocket item prioritization

### DIFF
--- a/Content.Server/_ES/Masks/Pickpocket/Components/ESPickpocketPriorityItemComponent.cs
+++ b/Content.Server/_ES/Masks/Pickpocket/Components/ESPickpocketPriorityItemComponent.cs
@@ -1,0 +1,7 @@
+﻿namespace Content.Server._ES.Masks.Pickpocket.Components;
+
+[RegisterComponent]
+public sealed partial class ESPickpocketPriorityItemComponent : Component
+{
+
+}

--- a/Content.Server/_ES/Masks/Pickpocket/ESPickpocketMaskSystem.cs
+++ b/Content.Server/_ES/Masks/Pickpocket/ESPickpocketMaskSystem.cs
@@ -90,7 +90,21 @@ public sealed partial class ESPickpocketMaskSystem : EntitySystem
             return;
         }
 
+        var PriorityItems = new List<EntityUid>();
         var item = _random.Pick(bag.Value.Comp.Container.ContainedEntities);
+
+        foreach (var entity in bag.Value.Comp.Container.ContainedEntities)
+        {
+            if (HasComp<ESPickpocketPriorityItemComponent>(entity))
+                PriorityItems.Add(entity);
+        }
+
+        if (PriorityItems.Count != 0 && _random.Prob(args.PriorityItemChance))
+        {
+            item = _random.Pick(PriorityItems);
+        }
+
+
         if (!_container.Remove(item, bag.Value.Comp.Container))
             return;
 

--- a/Content.Shared/_ES/Masks/Pickpocket/ESPickpocketTargetActionEvent.cs
+++ b/Content.Shared/_ES/Masks/Pickpocket/ESPickpocketTargetActionEvent.cs
@@ -11,4 +11,11 @@ public sealed partial class ESPickpocketTargetActionEvent : EntityTargetActionEv
 }
 
 [Serializable, NetSerializable]
-public sealed partial class ESPickpocketTargetDoAfterEvent : SimpleDoAfterEvent;
+public sealed partial class ESPickpocketTargetDoAfterEvent : SimpleDoAfterEvent
+{
+    /// <summary>
+    /// Chance that the pickpocket will take from the priority item pool instead of just the random one
+    /// </summary>
+    [DataField]
+    public float PriorityItemChance = 0.60f;
+}

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -19,6 +19,7 @@
       - GhostOnlyWarp
 # ES START - necessary for warp stuff rn
   - type: ESStagehandAware
+  - type: ESPickpocketPriorityItem
 # ES END
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -35,6 +35,9 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+  # ES start - Prioritization for pickpocket stealing
+  - type: ESPickpocketPriorityItem
+  # ES end
 
 #IDs with layers
 

--- a/Resources/Prototypes/_ES/Entities/Objects/Devices/subverter.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Devices/subverter.yml
@@ -10,3 +10,4 @@
     state: icon
   - type: ESAddMaskOnUse
     maskToAdd: Recruit
+  - type: ESPickpocketPriorityItem

--- a/Resources/Prototypes/_ES/Entities/Objects/Tools/door_jammer.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Tools/door_jammer.yml
@@ -41,3 +41,4 @@
         Piercing: 6
     soundHit:
       path: "/Audio/Weapons/bladeslice.ogg"
+  - type: ESPickpocketPriorityItem

--- a/Resources/Prototypes/_ES/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Tools/emag.yml
@@ -14,3 +14,4 @@
   - type: ESEmag
   - type: LimitedCharges
     maxCharges: 6
+  - type: ESPickpocketPriorityItem

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/energy.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/energy.yml
@@ -37,6 +37,7 @@
   - type: BatteryAmmoProvider
     proto: ESEnergyBolt
     fireCost: 70
+  - type: ESPickpocketPriorityItem
 
 # TODO: Try giving this a small pointlight to see if it looks good.
 - type: entity

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/pistol.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/pistol.yml
@@ -83,6 +83,7 @@
         whitelist:
           tags:
           - ESGunAttachmentBallisticBarrel
+  - type: ESPickpocketPriorityItem
 
 - type: entity
   parent: ESWeaponPistol9mm

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/revolver.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/revolver.yml
@@ -26,3 +26,4 @@
       tags:
       - ES357Round
       - ES357SpeedLoader
+  - type: ESPickpocketPriorityItem

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/shotgun.yml
@@ -36,6 +36,7 @@
     - SemiAuto
   - type: GunSpreadModifier
     spread: 1.5
+  - type: ESPickpocketPriorityItem
 
 - type: entity
   parent: [ESWeaponShotgun, BaseSecurityBartenderContraband]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
#1911 
Added the ability to prioritize items for pickpocket stealing
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
https://github.com/user-attachments/assets/27e6620d-6c56-4141-b48a-fc77bf1bbc6d

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Pickpockets now prioritize more interesting items
