### PR TITLE
Warp drive fixes

### DIFF
--- a/Content.Client/_ES/Telesci/Ui/ESPortalGeneratorConsoleWindow.xaml.cs
+++ b/Content.Client/_ES/Telesci/Ui/ESPortalGeneratorConsoleWindow.xaml.cs
@@ -23,9 +23,20 @@ public sealed partial class ESPortalGeneratorConsoleWindow : FancyWindow
 
     public void Update(ESPortalGeneratorConsoleBuiState state)
     {
-        StatusLabel.UnsafeSetMarkup(state.Charge >= 1
-            ? Loc.GetString("es-ui-portalgen-console-label-status-ready")
-            : Loc.GetString("es-ui-portalgen-console-label-status-charging"));
+        if (state.FinalPhase)
+        {
+            StatusLabel.UnsafeSetMarkup(Loc.GetString("es-ui-portalgen-console-label-status-final-charging"));
+        }
+        else if (state.Interrupted)
+        {
+            StatusLabel.UnsafeSetMarkup(Loc.GetString("es-ui-portalgen-console-label-status-blocked"));
+        }
+        else
+        {
+            StatusLabel.UnsafeSetMarkup(state.Charge >= 1
+                ? Loc.GetString("es-ui-portalgen-console-label-status-ready")
+                : Loc.GetString("es-ui-portalgen-console-label-status-charging"));
+        }
 
         ActivateButton.Disabled = state.Charge < 1 || state.FinalPhase;
 

--- a/Content.Server/_ES/WarpDrive/Components/ESWarpDriveGameRuleComponent.cs
+++ b/Content.Server/_ES/WarpDrive/Components/ESWarpDriveGameRuleComponent.cs
@@ -18,35 +18,41 @@ public sealed partial class ESWarpDriveGameRuleComponent : Component
     ///     Main interaction with the warp drive.
     ///     Interruptions can be random, or manually caused by throwing items in.
     /// </summary>
-    public bool Interrupted = false;
+    [DataField]
+    public bool Interrupted;
 
     /// <summary>
     ///     The time we were last interrupted at.
     /// </summary>
-    public TimeSpan? LastInterruptionTime = null;
+    [DataField]
+    public TimeSpan? LastInterruptionTime;
 
     /// <summary>
     ///     At start and after each interruption is quelled, picks a random time for a new interruption.
     /// </summary>
-    public TimeSpan? NextInterruptionTime = null;
+    [DataField]
+    public TimeSpan? NextInterruptionTime;
 
     /// <summary>
     ///     Accumulated time spent interrupted, to subtract.
     /// </summary>
+    [DataField]
     public TimeSpan AccumulatedInterruptionTime = TimeSpan.Zero;
 
-    public bool InFinalPhase = false;
+    [DataField]
+    public bool InFinalPhase;
 
     /// <summary>
     ///     IF in final phase, the time we entered it at/ whatever
     /// </summary>
-    public TimeSpan? FinalPhaseAt = null;
+    [DataField]
+    public TimeSpan? FinalPhaseAt;
 
     /// <summary>
     ///     Used to calculate if an interruption should occur from manual sabotage.
     /// </summary>
     [DataField]
-    public int ItemsTeleportedSinceLastInterruption = 0;
+    public int ItemsTeleportedSinceLastInterruption;
 
     /// <summary>
     ///     Base charge time if there were literally 0 interruptions (which there will be)

--- a/Content.Server/_ES/WarpDrive/Components/ESWarpDriveGameRuleComponent.cs
+++ b/Content.Server/_ES/WarpDrive/Components/ESWarpDriveGameRuleComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.EntityTable;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Utility;
 
 namespace Content.Server._ES.WarpDrive.Components;
@@ -24,13 +25,13 @@ public sealed partial class ESWarpDriveGameRuleComponent : Component
     /// <summary>
     ///     The time we were last interrupted at.
     /// </summary>
-    [DataField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? LastInterruptionTime;
 
     /// <summary>
     ///     At start and after each interruption is quelled, picks a random time for a new interruption.
     /// </summary>
-    [DataField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? NextInterruptionTime;
 
     /// <summary>
@@ -45,7 +46,7 @@ public sealed partial class ESWarpDriveGameRuleComponent : Component
     /// <summary>
     ///     IF in final phase, the time we entered it at/ whatever
     /// </summary>
-    [DataField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? FinalPhaseAt;
 
     /// <summary>
@@ -107,6 +108,7 @@ public sealed partial class ESWarpDriveGameRuleComponent : Component
     /// <summary>
     ///     where it all goes
     /// </summary>
+    [DataField]
     public ResPath SingularityWorldMap = new("/Maps/_ES/singularity_world.yml");
 
     [DataField]

--- a/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.cs
+++ b/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.cs
@@ -57,6 +57,9 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
         var query = EntityQueryEnumerator<ESWarpDriveGameRuleComponent>();
         while (query.MoveNext(out _, out var warp))
         {
+            if (warp.InFinalPhase)
+                continue;
+
             warp.FinalPhaseAt = _timing.CurTime;
             warp.InFinalPhase = true;
 
@@ -85,10 +88,10 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
 
     public float GetChargePercentage(ESWarpDriveGameRuleComponent component)
     {
-        var totalTime = (_timing.CurTime - _ticker.RoundStartTimeSpan) - component.AccumulatedInterruptionTime;
-        if (component.LastInterruptionTime is { } lastInterruption)
-            totalTime -= (_timing.CurTime - lastInterruption);
-        return (float) (totalTime / component.BaseChargeTime);
+        var totalTime = _timing.CurTime - _ticker.RoundStartTimeSpan - component.AccumulatedInterruptionTime;
+        if (component.Interrupted && component.LastInterruptionTime is { } lastInterruption)
+            totalTime -= _timing.CurTime - lastInterruption;
+        return Math.Clamp((float) (totalTime / component.BaseChargeTime), 0, 1);
     }
 
     public bool WarpDriveSuccess(ESWarpDriveGameRuleComponent component)
@@ -124,7 +127,7 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
 
         // check if we should play our announcements
         var currentCharge = GetChargePercentage(component);
-        UpdateUiState(currentCharge, component.InFinalPhase);
+        UpdateUiState(currentCharge, component.Interrupted, component.InFinalPhase);
         foreach (var announcement in component.Announcements)
         {
             if (announcement.Completed)
@@ -143,7 +146,7 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
         }
 
         // check if we should make a new random interruption
-        if (_timing.CurTime > component.NextInterruptionTime)
+        if (!component.InFinalPhase && _timing.CurTime > component.NextInterruptionTime)
         {
             if (!component.Interrupted)
             {
@@ -190,12 +193,18 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
         }
     }
 
-    private void UpdateUiState(float charge, bool finalPhase)
+    private void UpdateUiState(float charge, bool interrupted, bool finalPhase)
     {
         var query = EntityQueryEnumerator<ESPortalGeneratorConsoleComponent>();
         while (query.MoveNext(out var uid, out _))
         {
-            _ui.SetUiState(uid, ESPortalGeneratorConsoleUiKey.Key, new ESPortalGeneratorConsoleBuiState() { Charge = charge, FinalPhase = finalPhase });
+            var state = new ESPortalGeneratorConsoleBuiState
+            {
+                Charge = charge,
+                Interrupted = interrupted,
+                FinalPhase = finalPhase,
+            };
+            _ui.SetUiState(uid, ESPortalGeneratorConsoleUiKey.Key, state);
         }
     }
 

--- a/Content.Shared/_ES/Telesci/Components/ESPortalGeneratorConsoleComponent.cs
+++ b/Content.Shared/_ES/Telesci/Components/ESPortalGeneratorConsoleComponent.cs
@@ -30,6 +30,7 @@ public enum ESPortalGeneratorConsoleUiKey : byte
 public sealed class ESPortalGeneratorConsoleBuiState : BoundUserInterfaceState
 {
     public float Charge;
+    public bool Interrupted;
     public bool FinalPhase;
 }
 

--- a/Resources/Locale/en-US/_ES/telesci/telesci.ftl
+++ b/Resources/Locale/en-US/_ES/telesci/telesci.ftl
@@ -7,7 +7,9 @@ es-telesci-announcement-stage-4 = The station has undergone a beta-magnitude tel
 es-ui-portalgen-console-title = Warp Drive Control Terminal
 es-ui-portalgen-console-label-current-status = [bold]Current Status:[/bold]
 es-ui-portalgen-console-label-status-nopower = [font size=18][color=red][bold]No Power[/bold][/color][/font]
+es-ui-portalgen-console-label-status-blocked = [font size=18][color=red][bold]Interruption Present[/bold][/color][/font]
 es-ui-portalgen-console-label-status-charging = [font size=18][color=yellow][bold]Charging[/bold][/color][/font]
+es-ui-portalgen-console-label-status-final-charging = [font size=18][color=magenta][bold]Final Phase Charging[/bold][/color][/font]
 es-ui-portalgen-console-label-status-stillthreats = [font size=14][color=lavender][bold]{$threats} Anomalies Left[/bold][/color][/font]
 es-ui-portalgen-console-label-status-ready = [font size=18][color=lime][bold]Ready[/bold][/color][/font]
 es-ui-portalgen-console-label-charge-header = [bold]Charge:[/bold]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1851 
Closes #1855

changes:
- Add console statuses for if the warp drive is blocked or doing the final charge
  - People always were getting confused about this so it seems like a logical fix.
- Prevent double announcing the start of the final phase (happened due to network messages coming in at the same time)
- Prevent random interruptions from happening during the final phase 
  - This didnt even have an effect but it was just confusing so i figured might as well remove it
- Fix the charge percentage calculation
  - It would essentially get "stuck" at a specific time after getting interrupted, since it didnt distinguish between being currently interrupted and having an interruption in the past
  - I think this also caused the negative charge issue if the time the thing was paused for was an exceedingly long value and the total charge was low enough.    

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The warp drive console now shows when the warp drive is interrupted or doing the final charge
- fix: Fixed an issue where the warp drive progress would not update and would show the same value continuously
