### PR TITLE
Disable a lot of admin chat spam

### DIFF
--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -78,7 +78,6 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
     private int _queueMax;
     private int _preRoundQueueMax;
     private int _dropThreshold;
-    private int _highImpactLogPlaytime;
 
     // Per update
     private TimeSpan _nextUpdateTime;
@@ -113,8 +112,6 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
             value => _preRoundQueueMax = value, true);
         _configuration.OnValueChanged(CCVars.AdminLogsDropThreshold,
             value => _dropThreshold = value, true);
-        _configuration.OnValueChanged(CCVars.AdminLogsHighLogPlaytime,
-            value => _highImpactLogPlaytime = value, true);
 
         if (_metricsEnabled)
         {
@@ -461,18 +458,6 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
             if (impact == LogImpact.Extreme) // Always chat-notify Extreme logs
                 adminLog = true;
 
-            if (impact == LogImpact.High) // Only chat-notify High logs if the player is below a threshold playtime
-            {
-                if (_highImpactLogPlaytime >= 0 && _player.TryGetSessionById(new NetUserId(id), out var session))
-                {
-                    var playtimes = _playtime.GetPlayTimes(session);
-                    if (playtimes.TryGetValue(PlayTimeTrackingShared.TrackerOverall, out var overallTime) &&
-                        overallTime <= TimeSpan.FromHours(_highImpactLogPlaytime))
-                    {
-                        adminLog = true;
-                    }
-                }
-            }
         }
 
         if (adminLog)

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -308,11 +308,6 @@ internal sealed partial class ChatManager : IChatManager
 
     private void SendAdminChat(ICommonSession player, string message)
     {
-        if (!_adminManager.IsAdmin(player))
-        {
-            _adminLogger.Add(LogType.Chat, LogImpact.Extreme, $"{player:Player} attempted to send admin message but was not admin");
-            return;
-        }
 
         var clients = _adminManager.ActiveAdmins.Select(p => p.Channel);
         var wrappedMessage = Loc.GetString("chat-manager-send-admin-chat-wrap-message",

--- a/Content.Server/Destructible/Thresholds/Behaviors/GibBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/GibBehavior.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Destructible.Thresholds.Behaviors
     {
         [DataField("recursive")] private bool _recursive = true;
 
-        public LogImpact Impact => LogImpact.Extreme;
+        public LogImpact Impact => LogImpact.High;
 
         public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
         {

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -258,10 +258,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         }
         else
         {
-            var alertMinExplosionIntensity = _cfg.GetCVar(CCVars.AdminAlertExplosionMinIntensity);
-            var logImpact = (alertMinExplosionIntensity > -1 && totalIntensity >= alertMinExplosionIntensity)
-                ? LogImpact.Extreme
-                : LogImpact.High;
+            var logImpact = LogImpact.High;
             if (posFound)
                 _adminLogger.Add(LogType.Explosion, logImpact, $"{ToPrettyString(user.Value):user} caused {ToPrettyString(uid):entity} to explode ({typeId}) at Pos:{gridPos:coordinates} with intensity {totalIntensity} slope {slope}");
             else

--- a/Content.Server/Materials/MaterialReclaimerSystem.cs
+++ b/Content.Server/Materials/MaterialReclaimerSystem.cs
@@ -186,8 +186,7 @@ public sealed partial class MaterialReclaimerSystem : SharedMaterialReclaimerSys
 
         if (CanGib(uid, item, component))
         {
-            var logImpact = HasComp<HumanoidAppearanceComponent>(item) ? LogImpact.Extreme : LogImpact.Medium;
-            _adminLogger.Add(LogType.Gib, logImpact, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity} ");
+            _adminLogger.Add(LogType.Gib, LogImpact.Medium, $"{ToPrettyString(item):victim} was gibbed by {ToPrettyString(uid):entity} ");
             if (component.ReclaimSolutions)
                 SpawnChemicalsFromComposition(uid, item, completion, false, component, xform);
             _gibbing.Gib(item);

--- a/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
+++ b/Content.Server/Robotics/Systems/RoboticsConsoleSystem.cs
@@ -137,7 +137,7 @@ public sealed partial class RoboticsConsoleSystem : SharedRoboticsConsoleSystem
 
         var message = Loc.GetString(ent.Comp.DestroyMessage, ("name", data.Name));
         _radio.SendRadioMessage(ent, message, ent.Comp.RadioChannel, ent);
-        _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{ToPrettyString(args.Actor):user} destroyed borg {data.Name} with address {args.Address}");
+        _adminLogger.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(args.Actor):user} destroyed borg {data.Name} with address {args.Address}");
 
         ent.Comp.NextDestroy = now + ent.Comp.DestroyCooldown;
         Dirty(ent, ent.Comp);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -1012,7 +1012,7 @@ public sealed partial class ShuttleSystem
 
                 if (_bodyQuery.TryGetComponent(ent, out var mob))
                 {
-                    _logger.Add(LogType.Gib, LogImpact.Extreme, $"{ToPrettyString(ent):player} got gibbed by the shuttle" +
+                    _logger.Add(LogType.Gib, LogImpact.High, $"{ToPrettyString(ent):player} got gibbed by the shuttle" +
                                                                 $" {ToPrettyString(uid)} arriving from FTL at {xform.Coordinates:coordinates}");
                     var gibs = _gibbing.Gib(ent);
                     _immuneEnts.UnionWith(gibs);

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.Impact.cs
@@ -174,13 +174,9 @@ public sealed partial class ShuttleSystem
             var toUsEnergy = otherMass * energyMult * inertiaMult * ourMassDR;
             var toOtherEnergy = ourMass * energyMult * inertiaMult * otherMassDR;
 
-            var impact = LogImpact.High;
-            // if impact isn't tiny, log it as extreme
-            if (toUsEnergy + toOtherEnergy > 2f * _tileBreakEnergyMultiplier * _platingMass)
-                impact = LogImpact.Extreme;
             // TODO: would be nice for it to also log who is piloting the grid(s)
             if (CheckShouldLog(args.OurEntity) && CheckShouldLog(args.OtherEntity))
-                _logger.Add(LogType.ShuttleImpact, impact, $"Shuttle impact of {ToPrettyString(args.OurEntity)} with {ToPrettyString(args.OtherEntity)} at {worldPoint}");
+                _logger.Add(LogType.ShuttleImpact, LogImpact.High, $"Shuttle impact of {ToPrettyString(args.OurEntity)} with {ToPrettyString(args.OtherEntity)} at {worldPoint}");
 
             _impactedAt[args.OurEntity] = _gameTiming.CurTime;
             _impactedAt[args.OtherEntity] = _gameTiming.CurTime;

--- a/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
+++ b/Content.Server/Voting/Managers/VoteManager.DefaultVotes.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Voting.Managers
             if (initiator != null && args == null)
                 _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a {voteType.ToString()} vote");
             else if (initiator != null && args != null)
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"{initiator} initiated a {voteType.ToString()} vote with the arguments: {String.Join(",", args)}");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"{initiator} initiated a {voteType.ToString()} vote with the arguments: {String.Join(",", args)}");
             else
                 _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Initiated a {voteType.ToString()} vote");
 
@@ -344,7 +344,7 @@ namespace Content.Server.Voting.Managers
             if (_votingSystem != null && !await _votingSystem.CheckVotekickInitEligibility(initiator))
             {
                 _logManager.GetSawmill("admin.votekick").Warning($"User {initiator} attempted a votekick, despite not being eligible to!");
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick attempted by {initiator}, but they are not eligible to votekick!");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick attempted by {initiator}, but they are not eligible to votekick!");
                 DirtyCanCallVoteAll();
                 return;
             }
@@ -367,7 +367,7 @@ namespace Content.Server.Voting.Managers
             {
                 _logManager.GetSawmill("admin.votekick")
                     .Warning($"Votekick attempted for player {target} but they couldn't be found!");
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick attempted by {initiator} for player string {target}, but they could not be found!");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick attempted by {initiator} for player string {target}, but they could not be found!");
                 DirtyCanCallVoteAll();
                 return;
             }
@@ -379,7 +379,7 @@ namespace Content.Server.Voting.Managers
             {
                 _logManager.GetSawmill("admin.votekick")
                     .Warning($"Votekick attempted for player {target} but their session couldn't be found!");
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick attempted by {initiator} for player string {target}, but they could not be found!");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick attempted by {initiator} for player string {target}, but they could not be found!");
                 DirtyCanCallVoteAll();
                 return;
             }
@@ -406,7 +406,7 @@ namespace Content.Server.Voting.Managers
             // Don't let a user votekick themselves
             if (initiator == targetSession)
             {
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick attempted by {initiator} for themselves? Votekick cancelled.");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick attempted by {initiator} for themselves? Votekick cancelled.");
                 DirtyCanCallVoteAll();
                 return;
             }
@@ -414,7 +414,7 @@ namespace Content.Server.Voting.Managers
             // Cancels the vote if there's not enough voters; only the person initiating the vote gets a return message.
             if (eligibleVoterNumber < eligibleVoterNumberRequirement)
             {
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick attempted by {initiator} for player {targetSession}, but there were not enough ghost roles! {eligibleVoterNumberRequirement} required, {eligibleVoterNumber} found.");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick attempted by {initiator} for player {targetSession}, but there were not enough ghost roles! {eligibleVoterNumberRequirement} required, {eligibleVoterNumber} found.");
                 if (initiator != null)
                 {
                     var message = Loc.GetString("ui-vote-votekick-not-enough-eligible", ("voters", eligibleVoterNumber.ToString()), ("requirement", eligibleVoterNumberRequirement.ToString()));
@@ -428,7 +428,7 @@ namespace Content.Server.Voting.Managers
             // Check for stuff like the target being an admin. These targets shouldn't show up in the UI, but it's necessary to doublecheck in case someone writes the command in console.
             if (_votingSystem != null && !_votingSystem.CheckVotekickTargetEligibility(targetSession))
             {
-                _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick attempted by {initiator} for player {targetSession}, but they are not eligible to be votekicked!");
+                _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick attempted by {initiator} for player {targetSession}, but they are not eligible to be votekicked!");
                 DirtyCanCallVoteAll();
                 return;
             }
@@ -460,7 +460,7 @@ namespace Content.Server.Voting.Managers
             WirePresetVoteInitiator(options, initiator);
 
             var vote = CreateVote(options);
-            _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick for {located.Username} ({targetEntityName}) due to {reason} started, initiated by {initiator}.");
+            _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick for {located.Username} ({targetEntityName}) due to {reason} started, initiated by {initiator}.");
 
             // Create Discord webhook
             var webhookState = _voteWebhooks.CreateWebhookIfConfigured(options, _cfg.GetCVar(CCVars.DiscordVotekickWebhook), Loc.GetString("votekick-webhook-name"), options.Title + "\n" + Loc.GetString("votekick-webhook-description", ("initiator", initiatorName), ("target", targetSession)));
@@ -501,7 +501,7 @@ namespace Content.Server.Voting.Managers
                     // Check if an admin is online, and ignore the vote if the cvar is enabled
                     if (_cfg.GetCVar(CCVars.VotekickNotAllowedWhenAdminOnline) && _adminMgr.ActiveAdmins.Count() != 0)
                     {
-                        _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick for {located.Username} attempted to pass, but an admin was online. Yes: {votesYes} / No: {votesNo}. Yes: {yesVotersString} / No: {noVotersString}");
+                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick for {located.Username} attempted to pass, but an admin was online. Yes: {votesYes} / No: {votesNo}. Yes: {yesVotersString} / No: {noVotersString}");
                         AnnounceCancelledVotekickForVoters(targetEntityName);
                         _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState, Loc.GetString("votekick-webhook-cancelled-admin-online"));
                         return;
@@ -509,7 +509,7 @@ namespace Content.Server.Voting.Managers
                     // Check if the target is an antag and the vote reason is raiding (this is to prevent false positives)
                     else if (isAntagSafe && reason == VotekickReasonType.Raiding.ToString())
                     {
-                        _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick for {located.Username} due to {reason} finished, created by {initiator}, but was cancelled due to the target being an antagonist.");
+                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick for {located.Username} due to {reason} finished, created by {initiator}, but was cancelled due to the target being an antagonist.");
                         AnnounceCancelledVotekickForVoters(targetEntityName);
                         _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState, Loc.GetString("votekick-webhook-cancelled-antag-target"));
                         return;
@@ -517,14 +517,14 @@ namespace Content.Server.Voting.Managers
                     // Check if the target is an admin/de-admined admin
                     else if (targetSession.AttachedEntity != null && _adminMgr.IsAdmin(targetSession.AttachedEntity.Value, true))
                     {
-                        _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick for {located.Username} due to {reason} finished, created by {initiator}, but was cancelled due to the target being a de-admined admin.");
+                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick for {located.Username} due to {reason} finished, created by {initiator}, but was cancelled due to the target being a de-admined admin.");
                         AnnounceCancelledVotekickForVoters(targetEntityName);
                         _voteWebhooks.UpdateCancelledWebhookIfConfigured(webhookState, Loc.GetString("votekick-webhook-cancelled-admin-target"));
                         return;
                     }
                     else
                     {
-                        _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick for {located.Username} succeeded:  Yes: {votesYes} / No: {votesNo}. Yes: {yesVotersString} / No: {noVotersString}");
+                        _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick for {located.Username} succeeded:  Yes: {votesYes} / No: {votesNo}. Yes: {yesVotersString} / No: {noVotersString}");
                         _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-votekick-success", ("target", targetEntityName), ("reason", reason)));
 
                         if (!Enum.TryParse(_cfg.GetCVar(CCVars.VotekickBanDefaultSeverity), out NoteSeverity severity))
@@ -556,7 +556,7 @@ namespace Content.Server.Voting.Managers
                     // Discord webhook, failure
                     _voteWebhooks.UpdateWebhookIfConfigured(webhookState, eventArgs);
 
-                    _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"Votekick failed: Yes: {votesYes} / No: {votesNo}. Yes: {yesVotersString} / No: {noVotersString}");
+                    _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"Votekick failed: Yes: {votesYes} / No: {votesNo}. Yes: {yesVotersString} / No: {noVotersString}");
                     _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-votekick-failure", ("target", targetEntityName), ("reason", reason)));
                 }
             };

--- a/Content.Shared/CCVar/CCVars.Admin.Logs.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.Logs.cs
@@ -39,11 +39,4 @@ public sealed partial class CCVars
 
     public static readonly CVarDef<string> AdminLogsServerName =
         CVarDef.Create("adminlogs.server_name", "unknown", CVar.SERVERONLY);
-
-    /// <summary>
-    /// Any session below this playtime will send an admin alert whenever they cause a LogImpact.High log.
-    /// Set to -1 to disable.
-    /// </summary>
-    public static readonly CVarDef<int> AdminLogsHighLogPlaytime =
-        CVarDef.Create("adminlogs.high_log_playtime", 5, CVar.SERVERONLY);
 }

--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -105,12 +105,6 @@ public sealed partial class CCVars
         CVarDef.Create("admin.alert.min_players_sharing_connection", -1, CVar.SERVERONLY);
 
     /// <summary>
-    ///     Minimum explosion intensity to create an admin alert message. -1 to disable the alert.
-    /// </summary>
-    public static readonly CVarDef<int> AdminAlertExplosionMinIntensity =
-        CVarDef.Create("admin.alert.explosion_min_intensity", 60, CVar.SERVERONLY);
-
-    /// <summary>
     ///     Minimum particle accelerator strength to create an admin alert message.
     /// </summary>
     public static readonly CVarDef<int> AdminAlertParticleAcceleratorMinPowerState =

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -319,10 +319,8 @@ public sealed partial class SharedKitchenSpikeSystem : EntitySystem
         {
             _gibbing.Gib(args.Target.Value);
 
-            var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.Extreme : LogImpact.High;
-
             _logger.Add(LogType.Gib,
-                logSeverity,
+                LogImpact.High,
                 $"{ToPrettyString(args.User):user} finished butchering {ToPrettyString(args.Target):target} on the {ToPrettyString(ent):spike}");
         }
         else


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Currently admin logs are pushed to the chat when they're either LogImpact.Extreme or the player is below a time threshold + LogImpact.High
I've removed the second case despite the cvar being 0 by default because it felt useless but it would be easy to revert, this also makes the High and Medium impacts functionally the same afaict (maybe should consolidate them?)
The remaining Extreme impacts are just admin commands since those seem prudent to keep track of

doesnt include the PA and AME controller ones cause i assume those will be removed eventually and didnt want to cause any conflicts
