### PR TITLE
Make basic explosive fires not spread

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.Processing.cs
@@ -264,7 +264,8 @@ public sealed partial class ExplosionSystem
             {
                 _tileFire.TryDoTileFire(_map.ToCoordinates(grid, tile, grid),
                     stage: _robustRandom.Next(explosionType.MinFireLevel, explosionType.MaxFireLevel + 1),
-                    originatingUser: origin);
+                    originatingUser: origin,
+                    spread: explosionType.FireSpread);
             }
         }
 // ES END

--- a/Content.Server/_ES/TileFires/ESTileFireSystem.cs
+++ b/Content.Server/_ES/TileFires/ESTileFireSystem.cs
@@ -162,7 +162,7 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
     #region API
 
     [PublicAPI]
-    public override bool TryDoTileFire(EntityCoordinates coords, EntityUid? originatingUser = null, int stage = 1)
+    public override bool TryDoTileFire(EntityCoordinates coords, EntityUid? originatingUser = null, int stage = 1, bool spread = true)
     {
         var xform = Transform(coords.EntityId);
         if (xform.GridUid is not { } grid || !TryComp<MapGridComponent>(grid, out var mapGrid))
@@ -178,10 +178,18 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
 
         var fire = SpawnAtPosition(proto, coords);
 
+        if (!spread)
+        {
+            RemCompDeferred<ESTileFireComponent>(fire);
+        }
+
         if (!TerminatingOrDeleted(originatingUser) && Exists(originatingUser))
         {
-            EnsureComp<ESTileFireComponent>(fire).Origin = originatingUser;
-            EnsureComp<ESTileFireOriginComponent>(originatingUser.Value).Fires.Add(fire);
+            if (spread)
+            {
+                EnsureComp<ESTileFireComponent>(fire).Origin = originatingUser;
+                EnsureComp<ESTileFireOriginComponent>(originatingUser.Value).Fires.Add(fire);
+            }
 
             var ev = new ESTileFireCreatedEvent(coords, originatingUser);
             RaiseLocalEvent(originatingUser.Value, ref ev);

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -115,15 +115,31 @@ public sealed partial class ExplosionPrototype : IPrototype
     // steal code from.
     [DataField("fireStates")]
     public int FireStates = 3;
+
 // ES START
+    /// <summary>
+    /// Chance per tile processed to start a fire.
+    /// </summary>
     [DataField]
     public float FireChance = 0.15f;
 
+    /// <summary>
+    /// Minimum level of fire started when <see cref="FireChance"/> occurs
+    /// </summary>
     [DataField]
     public int MinFireLevel = 1;
 
+    /// <summary>
+    /// Maximum level of fire started when <see cref="FireChance"/> occurs
+    /// </summary>
     [DataField]
     public int MaxFireLevel = 1;
+
+    /// <summary>
+    /// Whether the fire should be smoldering when spawned, meaning it does not spread.
+    /// </summary>
+    [DataField]
+    public bool FireSpread;
 // ES END
 
     /// <summary>

--- a/Content.Shared/Explosion/ExplosionPrototype.cs
+++ b/Content.Shared/Explosion/ExplosionPrototype.cs
@@ -136,7 +136,7 @@ public sealed partial class ExplosionPrototype : IPrototype
     public int MaxFireLevel = 1;
 
     /// <summary>
-    /// Whether the fire should be smoldering when spawned, meaning it does not spread.
+    /// Whether the fire should spread after being spawned.
     /// </summary>
     [DataField]
     public bool FireSpread;

--- a/Content.Shared/_ES/TileFires/ESSharedTileFireSystem.cs
+++ b/Content.Shared/_ES/TileFires/ESSharedTileFireSystem.cs
@@ -59,16 +59,16 @@ public abstract partial class ESSharedTileFireSystem : EntitySystem
     ///     Spawns a tile fire at stage <see cref="stage"/> at the given entity.
     /// </summary>
     [PublicAPI]
-    public bool TryDoTileFire(Entity<TransformComponent?> entity, EntityUid? originatingUser = null, int stage = 1)
+    public bool TryDoTileFire(Entity<TransformComponent?> entity, EntityUid? originatingUser = null, int stage = 1, bool spread = true)
     {
-        return TryDoTileFire(entity.Comp?.Coordinates ?? Transform(entity.Owner).Coordinates, originatingUser, stage);
+        return TryDoTileFire(entity.Comp?.Coordinates ?? Transform(entity.Owner).Coordinates, originatingUser, stage, spread);
     }
 
     /// <summary>
     ///     Spawns a tile fire at stage <see cref="stage"/> at the given entity's coordinates.
     /// </summary>
     [PublicAPI]
-    public virtual bool TryDoTileFire(EntityCoordinates coords, EntityUid? originatingUser = null, int stage = 1)
+    public virtual bool TryDoTileFire(EntityCoordinates coords, EntityUid? originatingUser = null, int stage = 1, bool spread = true)
     {
         // See server logic
         return false;

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -138,6 +138,7 @@
   fireChance: 0.8
   minFireLevel: 1
   maxFireLevel: 3
+  fireSpread: true
 # ES END
 
 # ES START
@@ -158,4 +159,5 @@
   fireChance: 0.6
   minFireLevel: 1
   maxFireLevel: 3
+  fireSpread: true
 # ES END


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Something i was pondering as a small balancing lever for explosives. Basically spawn fires but don't let them spread (fires spawned cuz of explosive damage will still spread)

Really just interested in seeing if this is a good modifier on explosive stuff.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Fires from grenades and other basic explosions no longer spread. Dedicated fiery explosions will still spread.
