### PR TITLE
More rare maintenance loot

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
@@ -413,9 +413,10 @@
     - id: ESSleepyPen
       weight: 0.5
     - id: C4
-    - id: ESWeaponRevolver357
-    - id: ESWeaponPistol9mm
-    - id: ESWeaponPistol9mmSilenced
+    - group:
+      - id: ESWeaponRevolver357
+      - id: ESWeaponPistol9mm
+      - id: ESWeaponPistol9mmSilenced
     - id: ESClothingOuterArmorSecurity
     - id: ExGrenade
     - id: ESSpeedLoader357

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
@@ -413,11 +413,9 @@
     - id: ESSleepyPen
       weight: 0.5
     - id: C4
-    - group:
-      - id: ESWeaponRevolver357
-      - id: ESWeaponPistol9mm
-      - id: ESWeaponPistol9mmSilenced
-      weight: 2
+    - id: ESWeaponRevolver357
+    - id: ESWeaponPistol9mm
+    - id: ESWeaponPistol9mmSilenced
     - id: ESClothingOuterArmorSecurity
     - id: ExGrenade
     - id: ESSpeedLoader357

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
@@ -413,9 +413,11 @@
     - id: ESSleepyPen
       weight: 0.5
     - id: C4
-    - id: ESWeaponRevolver357
-    - id: ESWeaponPistol9mm
-    - id: ESWeaponPistol9mmSilenced
+    - group:
+      - id: ESWeaponRevolver357
+      - id: ESWeaponPistol9mm
+      - id: ESWeaponPistol9mmSilenced
+      weight: 2
     - id: ESClothingOuterArmorSecurity
     - id: ExGrenade
     - id: ESSpeedLoader357

--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -7,18 +7,18 @@
     - tableId: ESMaintLootCommon
       weight: 45
     - tableId: ESMaintLootUncommon
-      weight: 24
+      weight: 26
     - tableId: ESMaintLootRare
-      weight: 6
+      weight: 4
 
 - type: entityTable
   id: ESMaintLootExposed # for placing on racks or tables
   table:
     group:
     - tableId: ESMaintLootCommon
-      weight: 48
+      weight: 50
     - tableId: ESMaintLootUncommon
-      weight: 43
+      weight: 49
     - weight: 3
       group:
       - id: ToolboxEmergencyFilled
@@ -28,7 +28,7 @@
       - id: ToolboxArtisticFilled
         weight: 0.1
     - tableId: ESMaintLootRare
-      weight: 6
+      weight: 3
 
 - type: entityTable
   id: ESMaintLootValuable

--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -3,22 +3,22 @@
   table:
     group:
     - tableId: ESMaintLootWorthless
-      weight: 35
+      weight: 25
     - tableId: ESMaintLootCommon
-      weight: 52
+      weight: 45
     - tableId: ESMaintLootUncommon
-      weight: 12
+      weight: 24
     - tableId: ESMaintLootRare
-      weight: 1
+      weight: 6
 
 - type: entityTable
   id: ESMaintLootExposed # for placing on racks or tables
   table:
     group:
     - tableId: ESMaintLootCommon
-      weight: 50
+      weight: 48
     - tableId: ESMaintLootUncommon
-      weight: 45
+      weight: 43
     - weight: 3
       group:
       - id: ToolboxEmergencyFilled
@@ -28,7 +28,7 @@
       - id: ToolboxArtisticFilled
         weight: 0.1
     - tableId: ESMaintLootRare
-      weight: 2
+      weight: 6
 
 - type: entityTable
   id: ESMaintLootValuable
@@ -302,7 +302,7 @@
   table:
     group:
     - tableId: ESMaintsTraitorLoot
-      weight: 4
+      weight: 8
     - id: ESWeaponKnife
       weight: 2
     - id: WelderIndustrialAdvanced


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Resolves #1966

Increased the chance of "rare" maintenance loot, including traitor items.
They're around 4 times more common, and I saw around 4-10 in a wide sweep of maintenance.

The chance for pistols from maintenance also reduced to 1/3 previous.

Personally I feel this is a bit on the lower side given what is actually in the rare pool, but I'll leave it and come back to it if we feel like it.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased the odds of traitor, and likewise rare items, from maintenance
