### PR TITLE
Fix lobby ready up issues

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Content.Shared.GameTicking;
 using Content.Server.Station.Components;
 using Robust.Shared.Network;
@@ -191,7 +190,7 @@ namespace Content.Server.GameTicking
             }
 
             var playerCount = $"{_playerManager.PlayerCount}";
-            var readyCount = _playerGameStatuses.Values.Count(x => x == PlayerGameStatus.ReadyToPlay);
+            var readyCount = ReadyPlayerCount();
 
             var stationNames = new StringBuilder();
             var query =

--- a/Content.Server/GameTicking/GameTicker.Player.cs
+++ b/Content.Server/GameTicking/GameTicker.Player.cs
@@ -239,7 +239,17 @@ namespace Content.Server.GameTicking
                 AttachPlayerToLobbyCharacter(session);
 // ES END
 
-            _playerGameStatuses[session.UserId] = LobbyEnabled ? PlayerGameStatus.NotReadyToPlay : PlayerGameStatus.ReadyToPlay;
+            if (LobbyEnabled)
+            {
+                // If we're in the lobby, preserve ready up status if we are coming the lobby
+                if (!_playerGameStatuses.TryGetValue(session.UserId, out var oldStatus) ||
+                    oldStatus != PlayerGameStatus.ReadyToPlay)
+                    _playerGameStatuses[session.UserId] = PlayerGameStatus.NotReadyToPlay;
+            }
+            else
+            {
+                _playerGameStatuses[session.UserId] = PlayerGameStatus.ReadyToPlay;
+            }
             _db.AddRoundPlayers(RoundId, session.UserId);
 
             var client = session.Channel;


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1972 

changes:
- Fix ready count being able to exceed player count (was counting disconnected players)
- Fix getting set to unready when DCing after readying up
  - the solution is weird but uhhh uhhh uhmmmm

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed ready status getting reset upon disconnecting.
