### PR TITLE
Fix thruster announcements

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/computers.yml
@@ -447,8 +447,8 @@
     modifier: 0.5
     disableAnnouncement: es-radstorm-power-on-navigation-console
     enableAnnouncement: es-radstorm-power-off-navigation-console
-    announcementSoundEnabled: /Audio/_ES/Announcements/navigation_online.ogg
-    announcementSoundDisabled: /Audio/_ES/Announcements/navigation_offline.ogg
+    announcementSoundDisabled: /Audio/_ES/Announcements/navigation_online.ogg
+    announcementSoundEnabled: /Audio/_ES/Announcements/navigation_offline.ogg
   - type: PointLight
     color: "#1bfff3"
   - type: ApcPowerReceiverBattery

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/thruster.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/thruster.yml
@@ -42,10 +42,8 @@
         - WallLayer
   - type: ESRadstormModifierMachine
     modifier: 1.00
-    enableAnnouncement: es-radstorm-power-on-navigation-console
-    disableAnnouncement: es-radstorm-power-off-navigation-console
-    announcementSoundEnabled: /Audio/_ES/Announcements/thruster_fuelled.ogg
-    announcementSoundDisabled: /Audio/_ES/Announcements/thruster_no_fuel.ogg
+    announcementSoundDisabled: /Audio/_ES/Announcements/thruster_fuelled.ogg
+    announcementSoundEnabled: /Audio/_ES/Announcements/thruster_no_fuel.ogg
   - type: AmbientSound
     enabled: true
     volume: -6


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1975 

i said i'd reverse the whole thing but honestly i cant be fucked. it's backwards. it's backwards and its all my fault. kill me dead i dont fucking care anymoree.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed thruster and navigation console announcements being backwards.
