### PR TITLE
Fix some degradation events

### DIFF
--- a/Resources/Prototypes/_ES/GameRules/degradation_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/degradation_events.yml
@@ -21,7 +21,7 @@
     - id: ESDegradationEventCriminalRecords
     - id: ESDegradationEventTelecoms
     - id: ESDegradationEventCrewMonitoring
-    - id: ESDegradationEventIDCardComputer
+    - id: ESDegradationEventEmergencyAccess
 
 # Event Prototypes
 
@@ -69,6 +69,7 @@
   components:
   - type: ESDegradationEvent
     component: CommunicationsConsole
+    degradeImmediately: true
 
 - type: entity
   parent: ESBaseDegradationEvent
@@ -103,9 +104,10 @@
 
 - type: entity
   parent: ESBaseDegradationEvent
-  id: ESDegradationEventIDCardComputer
-  name: ID Scramble
-  description: Messes up the icons on IDs all over the station.
+  id: ESDegradationEventEmergencyAccess
+  name: False Emergency Access
+  description: Randomly enables emergency access on various airlocks across the station.
   components:
   - type: ESDegradationEvent
-    component: IdCardConsole
+    component: ESEmergencyAccessConsole
+    degradeImmediately: true # Doesn't react to anything


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1686 
Closes #1974 

changes:
- comms degradation event now is instant instead of queued.
- add event for EA console and remove old useless ID computer event

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A


