### PR TITLE
melee slow effect on attacking / being hit

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -69,7 +69,10 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private DamageExamineSystem _damageExamine = default!;
     // ES START
     [Dependency] private ESScreenshakeSystem _shake = default!;
+    [Dependency] private StatusEffectNew.StatusEffectsSystem _status = default!;
     // ES END
+
+    private static readonly EntProtoId MeleeSlowStatusEffect = "ESMeleeTemporarySlowdown";
 
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
@@ -539,6 +542,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
             var missEvent = new MeleeHitEvent(new List<EntityUid>(), user, meleeUid, damage, null);
             RaiseLocalEvent(meleeUid, missEvent);
             _meleeSound.PlaySwingSound(user, meleeUid, component);
+            _status.TrySetStatusEffectDuration(user, MeleeSlowStatusEffect, TimeSpan.FromSeconds(0.35));
             return;
         }
 
@@ -564,6 +568,8 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         // If the user is using a long-range weapon, this probably shouldn't be happening? But I'll interpret melee as a
         // somewhat messy scuffle. See also, heavy attacks.
         Interaction.DoContactInteraction(user, target, weapon, true, interactionParticles: false); // Stellar/ES - Interaction particles
+
+        _status.TrySetStatusEffectDuration(user, MeleeSlowStatusEffect, TimeSpan.FromSeconds(0.35));
 
         // For stuff that cares about it being attacked.
         var attackedEvent = new AttackedEvent(meleeUid, user, targetXform.Coordinates);
@@ -601,6 +607,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         if (damageResult.GetTotal() > FixedPoint2.Zero)
         {
             DoDamageEffect(targets, user, targetXform);
+            _status.TrySetStatusEffectDuration(target.Value, MeleeSlowStatusEffect, TimeSpan.FromSeconds(0.35));
 
             // ES START
             // dog shit copy plaste but thats melee for you
@@ -655,6 +662,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
             RaiseLocalEvent(meleeUid, missEvent);
 
             // immediate audio feedback
+            _status.TrySetStatusEffectDuration(user, MeleeSlowStatusEffect, TimeSpan.FromSeconds(0.35));
             _meleeSound.PlaySwingSound(user, meleeUid, component);
 
             return true;
@@ -709,6 +717,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
         var weapon = GetEntity(ev.Weapon);
 
         Interaction.DoContactInteraction(user, weapon, null, true); // Stellar - Interaction particles
+        _status.TrySetStatusEffectDuration(user, MeleeSlowStatusEffect, TimeSpan.FromSeconds(0.35));
 
         // For stuff that cares about it being attacked.
         foreach (var target in targets)
@@ -750,6 +759,7 @@ public abstract partial class SharedMeleeWeaponSystem : EntitySystem
                 }
 
                 appliedDamage += damageResult;
+                _status.TrySetStatusEffectDuration(entity, MeleeSlowStatusEffect, TimeSpan.FromSeconds(0.35));
 
                 if (meleeUid == user)
                 {

--- a/Resources/Prototypes/_ES/Entities/StatusEffects/melee.yml
+++ b/Resources/Prototypes/_ES/Entities/StatusEffects/melee.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: StatusEffectSlowdown
+  id: ESMeleeTemporarySlowdown
+  name: melee temporary slowdown
+  components:
+  - type: MovementModStatusEffect
+    sprintSpeedModifier: 0.5
+    walkSpeedModifier: 0.5


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

lets see if this is true or rubbish

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

https://github.com/user-attachments/assets/338afbd8-9e89-45b7-ac36-4088ed3694e3

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: You will now be slowed for a short time when swinging a melee weapon, or when being hit by a melee weapon