### PR TITLE
nerf revolver

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/bullet.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/bullet.yml
@@ -32,7 +32,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 40
+        Piercing: 30
   - type: Tag
     tags:
     - ES357Projectile


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
changes revolver damage from 30 to 40. revolver felt too strong so this makes it less so hopefully. this puts it from 3 shots to crit to 4
it still retains its armor piercing properties even on opponents with the max 5DT, meaning its basically just the same but with 1 more shot required

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Nerfed revolver damage slightly. It now takes 4 shots to down instead of 3.
