### PR TITLE
zero g tweaks experiment

### DIFF
--- a/Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs
+++ b/Content.Shared/Damage/Components/DamageOnHighSpeedImpactComponent.cs
@@ -12,29 +12,26 @@ namespace Content.Shared.Damage.Components;
 public sealed partial class DamageOnHighSpeedImpactComponent : Component
 {
     [DataField("minimumSpeed"), ViewVariables(VVAccess.ReadWrite)]
-    public float MinimumSpeed = 20f;
+    public float MinimumSpeed = 5.5f;
 
     [DataField("speedDamageFactor"), ViewVariables(VVAccess.ReadWrite)]
-    public float SpeedDamageFactor = 0.5f;
+    public float SpeedDamageFactor = 1f;
 
-    [DataField("soundHit", required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(required: true)]
     public SoundSpecifier SoundHit = default!;
 
-    [DataField("stunChance"), ViewVariables(VVAccess.ReadWrite)]
-    public float StunChance = 0.25f;
-
-    [DataField("stunMinimumDamage"), ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public int StunMinimumDamage = 10;
 
-    [DataField("stunSeconds"), ViewVariables(VVAccess.ReadWrite)]
-    public float StunSeconds = 1f;
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan StunTime = TimeSpan.FromSeconds(3f);
 
-    [DataField("damageCooldown"), ViewVariables(VVAccess.ReadWrite)]
-    public float DamageCooldown = 2f;
+    [DataField]
+    public TimeSpan DamageCooldown = TimeSpan.FromSeconds(3f);
 
-    [DataField("lastHit", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan? LastHit;
 
-    [DataField("damage", required: true), ViewVariables(VVAccess.ReadWrite)]
+    [DataField(required: true)]
     public DamageSpecifier Damage = default!;
 }

--- a/Content.Shared/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageOnHighSpeedImpactSystem.cs
@@ -1,9 +1,12 @@
+using System.Numerics;
 using Content.Shared.Stunnable;
 using Content.Shared.Damage.Components;
 using Content.Shared.Effects;
+using Content.Shared.Popups;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -13,11 +16,12 @@ namespace Content.Shared.Damage.Systems;
 public sealed partial class DamageOnHighSpeedImpactSystem : EntitySystem
 {
     [Dependency] private IGameTiming _gameTiming = default!;
-    [Dependency] private IRobustRandom _robustRandom = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedColorFlashEffectSystem _color = default!;
     [Dependency] private SharedStunSystem _stun = default!;
+    [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -40,21 +44,25 @@ public sealed partial class DamageOnHighSpeedImpactSystem : EntitySystem
             return;
 
         if (component.LastHit != null
-            && (_gameTiming.CurTime - component.LastHit.Value).TotalSeconds < component.DamageCooldown)
+            && (_gameTiming.CurTime - component.LastHit.Value) < component.DamageCooldown)
             return;
 
         component.LastHit = _gameTiming.CurTime;
 
-        if (_robustRandom.Prob(component.StunChance))
-            _stun.TryUpdateStunDuration(uid, TimeSpan.FromSeconds(component.StunSeconds));
+        _stun.TryUpdateParalyzeDuration(uid, component.StunTime);
 
         var damageScale = component.SpeedDamageFactor * speed / component.MinimumSpeed;
 
         _damageable.TryChangeDamage(uid, component.Damage * damageScale);
 
-        if (_gameTiming.IsFirstTimePredicted)
-            _audio.PlayPvs(component.SoundHit, uid, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
+        var msg = Loc.GetString("es-damage-high-speed-impact-impacted",
+            ("entity", uid),
+            ("impacted", args.OtherEntity));
+        _popup.PopupEntity(msg, uid, Filter.Pvs(uid), true, PopupType.MediumCaution);
+
+        _audio.PlayPredicted(component.SoundHit, uid, uid, AudioParams.Default.WithVariation(0.125f).WithVolume(-0.125f));
         _color.RaiseEffect(Color.Red, new List<EntityUid>() { uid }, Filter.Pvs(uid, entityManager: EntityManager));
+        _physics.SetLinearVelocity(uid, Vector2.Zero);
     }
 
     public void ChangeCollide(EntityUid uid, float minimumSpeed, float stunSeconds, float damageCooldown, float speedDamage, DamageOnHighSpeedImpactComponent? collide = null)
@@ -62,9 +70,10 @@ public sealed partial class DamageOnHighSpeedImpactSystem : EntitySystem
         if (!Resolve(uid, ref collide, false))
             return;
 
+        // TODO ew what the fuck
         collide.MinimumSpeed = minimumSpeed;
-        collide.StunSeconds = stunSeconds;
-        collide.DamageCooldown = damageCooldown;
+        collide.StunTime = TimeSpan.FromSeconds(stunSeconds);
+        collide.DamageCooldown = TimeSpan.FromSeconds(damageCooldown);
         collide.SpeedDamageFactor = speedDamage;
         Dirty(uid, collide);
     }

--- a/Content.Shared/Movement/Components/MobMoverComponent.cs
+++ b/Content.Shared/Movement/Components/MobMoverComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared.Movement.Components
     public sealed partial class MobMoverComponent : Component
     {
         private float _stepSoundDistance;
-        [DataField] public float GrabRange = 1.0f;
+        [DataField] public float GrabRange = 0.85f;
 
         [DataField] public float PushStrength = 600f;
 

--- a/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
+++ b/Content.Shared/Movement/Components/MovementSpeedModifierComponent.cs
@@ -14,9 +14,10 @@ namespace Content.Shared.Movement.Components
         #region defaults
 
         // weightless
-        public const float DefaultWeightlessFriction = 1f;
-        public const float DefaultWeightlessModifier = 0.7f;
-        public const float DefaultWeightlessAcceleration = 1f;
+        public const float DefaultWeightlessFriction = 0.7f;
+        public const float DefaultWeightlessFrictionNoInput = 4.5f;
+        public const float DefaultWeightlessModifier = 2.4f;
+        public const float DefaultWeightlessAcceleration = 0.25f;
 
         // friction
         public const float DefaultAcceleration = 7f;
@@ -116,6 +117,9 @@ namespace Content.Shared.Movement.Components
         /// </summary>
         [AutoNetworkedField, DataField]
         public float BaseWeightlessFriction = DefaultWeightlessFriction;
+
+        [AutoNetworkedField, DataField]
+        public float BaseWeightlessFrictionNoInput = DefaultWeightlessFrictionNoInput;
 
         [AutoNetworkedField, DataField]
         public float BaseWeightlessModifier = DefaultWeightlessModifier;

--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -34,7 +34,7 @@ namespace Content.Shared.Movement.Systems
             ent.Comp.WeightlessAcceleration = ent.Comp.BaseWeightlessAcceleration;
             ent.Comp.WeightlessModifier = ent.Comp.BaseWeightlessModifier;
             ent.Comp.WeightlessFriction = _airDamping * ent.Comp.BaseWeightlessFriction;
-            ent.Comp.WeightlessFrictionNoInput = _airDamping * ent.Comp.BaseWeightlessFriction;
+            ent.Comp.WeightlessFrictionNoInput = _airDamping * ent.Comp.BaseWeightlessFrictionNoInput;
             ent.Comp.OffGridFriction = _offGridDamping * ent.Comp.BaseWeightlessFriction;
             ent.Comp.Acceleration = ent.Comp.BaseAcceleration;
             ent.Comp.Friction = _frictionModifier * ent.Comp.BaseFriction;

--- a/Content.Shared/Movement/Systems/SharedMobCollisionSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedMobCollisionSystem.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Shared.CCVar;
+using Content.Shared.Gravity;
 using Content.Shared.Movement.Components;
 using Robust.Shared;
 using Robust.Shared.Configuration;
@@ -22,6 +23,7 @@ public abstract partial class SharedMobCollisionSystem : EntitySystem
 
     protected EntityQuery<MobCollisionComponent> MobQuery;
     protected EntityQuery<PhysicsComponent> PhysicsQuery;
+    protected EntityQuery<GravityAffectedComponent> WeightlessQuery;
 
     /// <summary>
     /// <see cref="CCVars.MovementPushingCap"/>
@@ -66,6 +68,7 @@ public abstract partial class SharedMobCollisionSystem : EntitySystem
 
         MobQuery = GetEntityQuery<MobCollisionComponent>();
         PhysicsQuery = GetEntityQuery<PhysicsComponent>();
+        WeightlessQuery = GetEntityQuery<GravityAffectedComponent>();
         SubscribeAllEvent<MobCollisionMessage>(OnCollision);
         SubscribeLocalEvent<MobCollisionComponent, RefreshMovementSpeedModifiersEvent>(OnMoveModifier);
 
@@ -103,12 +106,17 @@ public abstract partial class SharedMobCollisionSystem : EntitySystem
             {
                 DebugTools.Assert(direction.LengthSquared() >= _minimumPushSquared);
 
+                // mildly jank but just make pushing less effective when weightless.
+                var impulseMultiplier = 1f;
+                if (WeightlessQuery.TryGetComponent(uid, out var weightless) && weightless.Weightless)
+                    impulseMultiplier /= 10f;
+
                 if (direction.Length() > _pushingCap)
                 {
                     direction = direction.Normalized() * _pushingCap;
                 }
 
-                Physics.ApplyLinearImpulse(uid, direction * physics.Mass, body: physics);
+                Physics.ApplyLinearImpulse(uid, direction * physics.Mass * impulseMultiplier, body: physics);
                 comp.Direction = Vector2.Zero;
                 DirtyField(uid, comp, nameof(MobCollisionComponent.Direction));
             }

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -282,11 +282,12 @@ public abstract partial class SharedMoverController : VirtualController
             var ev = new CanWeightlessMoveEvent(uid);
             RaiseLocalEvent(uid, ref ev, true);
 
-            touching = ev.CanMove || xform.GridUid != null || MapGridQuery.HasComp(xform.GridUid);
+            touching = ev.CanMove;
+            var onGrid = xform.GridUid != null || MapGridQuery.HasComp(xform.GridUid);
 
-            // If we're not on a grid, and not able to move in space check if we're close enough to a grid to touch.
+            // Check if we're close enough to a wall to count as touching
             if (!touching && MobMoverQuery.TryComp(uid, out var mobMover))
-                touching |= IsAroundCollider(_lookup, (uid, physicsComponent, mobMover, xform));
+                touching |= IsAroundCollider(_lookup, (uid, physicsComponent, mobMover, xform), onGrid);
 
             // If we're touching then use the weightless values
             if (touching)
@@ -516,13 +517,14 @@ public abstract partial class SharedMoverController : VirtualController
     /// <summary>
     /// Used for weightlessness to determine if we are near a wall.
     /// </summary>
-    private bool IsAroundCollider(EntityLookupSystem lookupSystem, Entity<PhysicsComponent, MobMoverComponent, TransformComponent> entity)
+    private bool IsAroundCollider(EntityLookupSystem lookupSystem, Entity<PhysicsComponent, MobMoverComponent, TransformComponent> entity, bool onGrid)
     {
         var (uid, collider, mover, transform) = entity;
+        // enlarge more off grid, on grid its fine to require being kinda close to stuff
         var enlargedAABB = _lookup.GetWorldAABB(entity.Owner, transform).Enlarged(mover.GrabRange);
 
         _aroundColliderSet.Clear();
-        lookupSystem.GetEntitiesIntersecting(transform.MapID, enlargedAABB, _aroundColliderSet);
+        lookupSystem.GetEntitiesIntersecting(transform.MapID, enlargedAABB, _aroundColliderSet, LookupFlags.Static);
         foreach (var otherEntity in _aroundColliderSet)
         {
             if (otherEntity == uid)

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -28,7 +28,7 @@ public sealed partial class ThrowingSystem : EntitySystem
     public const float ESThrowSpeedDefault = 8.5f;
     // ES END
 
-    public const float PushbackDefault = 2f;
+    public const float PushbackDefault = 5f;
 
     public const float FlyTimePercentage = 0.8f;
 

--- a/Resources/Changelog/Old.yml
+++ b/Resources/Changelog/Old.yml
@@ -1,8 +1,0 @@
-Entries:
-- author: test2
-  changes:
-  - message: test
-    type: Remove
-  id: 1
-  time: '2025-08-31T12:54:45.0000000+00:00'
-  url: https://github.com/space-wizards/space-station-14/pull/39027

--- a/Resources/Locale/en-US/_ES/damage/popup.ftl
+++ b/Resources/Locale/en-US/_ES/damage/popup.ftl
@@ -1,0 +1,1 @@
+es-damage-high-speed-impact-impacted = {CAPITALIZE(THE($entity))} crashes into {THE($impacted)} at high speed!

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -55,7 +55,7 @@
   - type: PowerCharge
     windowTitle: gravity-generator-window-title
     idlePower: 50
-    activePower: 2500
+    activePower: 800
   - type: GravityGenerator
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -8,13 +8,6 @@
     bodyType: Static
   - type: Fixtures
     fixtures:
-      light:
-        shape:
-          !type:PhysShapeCircle
-          radius: 5
-        hard: false
-        mask:
-        - GhostImpassable
       fix1:
         shape:
           !type:PhysShapeAabb

--- a/Resources/Prototypes/_Offbrand/base_mob.yml
+++ b/Resources/Prototypes/_Offbrand/base_mob.yml
@@ -26,7 +26,7 @@
   - type: DamageOnHighSpeedImpact
     damage:
       types:
-        Blunt: 5
+        Blunt: 18
     soundHit:
       path: /Audio/Effects/hit_kick.ogg
   - type: Pullable


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

testing stuff out

also reworks damageonhighspeedimpact to actually function at all

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->


https://github.com/user-attachments/assets/f96e9793-7ca8-4900-aa80-24ba0c452998



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Zero G movement has been changed substantially: you must now be near walls even when on station to move effectively, acceleration is much higher (and max speed is muuuuch higher, you can go quite fast), and its easier to stop with no inputs held when near walls
- tweak: Gravgen now runs out of power & charges faster
