### PR TITLE
reduce the weight of bolted/welded doors in variant spawners

### DIFF
--- a/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/maintenance_structures.yml
+++ b/Resources/Prototypes/_ES/Entities/Markers/Spawners/Random/maintenance_structures.yml
@@ -17,7 +17,9 @@
       - id: AirlockMaintLocked
         weight: 1.5
       - id: ESAirlockMaintLockedWelded
+        weight: 0.5
       - id: ESAirlockMaintLockedBolted
+        weight: 0.25
       - all:
         - id: AirlockMaintLocked
         - id: BarricadeBlock
@@ -43,13 +45,15 @@
       - id: AirlockMaintLocked
         weight: 1.5
       - id: ESAirlockMaintLockedWelded
+        weight: 0.5
       - id: ESAirlockMaintLockedBolted
+        weight: 0.25
       - all:
         - id: AirlockMaintLocked
         - id: BarricadeBlock
       - id: WallSolid
-      - id: SolidSecretDoor
         weight: 0.5
+      - id: SolidSecretDoor
 
 # Obstructions (random girders/grilles/etc.)
 - type: entity


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

also solidwalls in the wall/door variant spawner

too many obstructions in maint, made deepmaint too annoying to access generally and too easy to get stuck in areas

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: There should be less welded/bolted doors in maints in general
