### PR TITLE
Fix APC sprite not reverting after bugging completes

### DIFF
--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -160,7 +160,7 @@ public sealed partial class ESEntityTimerSystem : EntitySystem
                 RaiseLocalEvent(target, (object) timer.TimerEndEvent);
             }
 
-            if (TerminatingOrDeleted(uid))
+            if (!TerminatingOrDeleted(uid))
                 PredictedQueueDel(uid);
         }
     }

--- a/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
+++ b/Content.Shared/_ES/Core/Timer/ESEntityTimerSystem.cs
@@ -160,7 +160,8 @@ public sealed partial class ESEntityTimerSystem : EntitySystem
                 RaiseLocalEvent(target, (object) timer.TimerEndEvent);
             }
 
-            PredictedQueueDel(uid);
+            if (TerminatingOrDeleted(uid))
+                PredictedQueueDel(uid);
         }
     }
 }

--- a/Content.Shared/_ES/Masks/Traitor/ESTraitorBugSystem.cs
+++ b/Content.Shared/_ES/Masks/Traitor/ESTraitorBugSystem.cs
@@ -157,8 +157,7 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
 
     private void OnTraitorBugTimer(Entity<ESTraitorBuggableComponent> ent, ref ESTraitorBugTimerEvent args)
     {
-        ent.Comp.Timer = null;
-        Dirty(ent);
+        CancelBug(ent.AsNullable());
 
         _sparks.DoSparks(ent);
         var ev = new ESTraitorBugHackedEvent(ent.Comp.Department);


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2048 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: APCs no longer show the bug sprite after the bug has successfully completed.
