### PR TITLE
Make burstworm awesome

### DIFF
--- a/Content.Server/_ES/Masks/Burstworm/ESBurstwormSystem.cs
+++ b/Content.Server/_ES/Masks/Burstworm/ESBurstwormSystem.cs
@@ -1,21 +1,30 @@
 using System.Numerics;
 using Content.Server._ES.Masks.Burstworm.Components;
 using Content.Server.Popups;
+using Content.Server.Storage.EntitySystems;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared._ES.Core.Timer;
 using Content.Shared._ES.KillTracking.Components;
+using Content.Shared.Gibbing;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Lock;
 using Content.Shared.Mind;
 using Content.Shared.Popups;
+using Content.Shared.Storage.Components;
 using Robust.Server.Audio;
+using Robust.Server.Containers;
 
 namespace Content.Server._ES.Masks.Burstworm;
 
 public sealed partial class ESBurstwormSystem : EntitySystem
 {
     [Dependency] private AudioSystem _audio = default!;
+    [Dependency] private ContainerSystem _container = default!;
+    [Dependency] private EntityStorageSystem _entityStorage = default!;
     [Dependency] private ESEntityTimerSystem _entityTimer = default!;
+    [Dependency] private GibbingSystem _gibbing = default!;
     [Dependency] private GunSystem _gun = default!;
+    [Dependency] private LockSystem _lock = default!;
     [Dependency] private PopupSystem _popup = default!;
 
     /// <inheritdoc/>
@@ -49,6 +58,14 @@ public sealed partial class ESBurstwormSystem : EntitySystem
             mind.OwnedEntity is not { } owned)
             return;
 
+        if (_container.TryGetContainingContainer(owned, out var container) &&
+            TryComp<EntityStorageComponent>(container.Owner, out var storage))
+        {
+            _lock.Unlock(container.Owner, null);
+            _entityStorage.OpenStorage(container.Owner, storage);
+        }
+
+        _gibbing.Gib(owned);
         _audio.PlayPvs(ent.Comp.BurstSound, owned);
 
         var angleSegment = MathF.Tau / ent.Comp.ProjectileCount;

--- a/Content.Shared/Projectiles/ESProjectileShooterComponent.cs
+++ b/Content.Shared/Projectiles/ESProjectileShooterComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Projectiles;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ESProjectileShooterComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public HashSet<EntityUid> Projectiles = [];
+}

--- a/Content.Shared/Projectiles/ESProjectileWeaponComponent.cs
+++ b/Content.Shared/Projectiles/ESProjectileWeaponComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Projectiles;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ESProjectileWeaponComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public HashSet<EntityUid> Projectiles = [];
+}

--- a/Content.Shared/Projectiles/ProjectileComponent.cs
+++ b/Content.Shared/Projectiles/ProjectileComponent.cs
@@ -25,12 +25,14 @@ public sealed partial class ProjectileComponent : Component
     ///     User that shot this projectile.
     /// </summary>
     [DataField, AutoNetworkedField]
+    [Access(typeof(SharedProjectileSystem), Other = AccessPermissions.ReadExecute)]
     public EntityUid? Shooter;
 
     /// <summary>
     ///     Weapon used to shoot.
     /// </summary>
     [DataField, AutoNetworkedField]
+    [Access(typeof(SharedProjectileSystem), Other = AccessPermissions.ReadExecute)]
     public EntityUid? Weapon;
 
     /// <summary>

--- a/Content.Shared/Projectiles/SharedProjectileSystem.cs
+++ b/Content.Shared/Projectiles/SharedProjectileSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared.Inventory;
 using Content.Shared.Throwing;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
-using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;
@@ -32,6 +31,9 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ProjectileComponent, PreventCollideEvent>(PreventCollision);
+        SubscribeLocalEvent<ProjectileComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<ESProjectileShooterComponent, ComponentShutdown>(OnShooterShutdown);
+        SubscribeLocalEvent<ESProjectileWeaponComponent, ComponentShutdown>(OnWeaponShutdown);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ProjectileHitEvent>(OnEmbedProjectileHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ThrowDoHitEvent>(OnEmbedThrowDoHit);
         SubscribeLocalEvent<EmbeddableProjectileComponent, ActivateInWorldEvent>(OnEmbedActivate);
@@ -207,13 +209,84 @@ public abstract partial class SharedProjectileSystem : EntitySystem
         }
     }
 
+    private void OnShutdown(Entity<ProjectileComponent> ent, ref ComponentShutdown args)
+    {
+        if (TryComp<ESProjectileShooterComponent>(ent.Comp.Shooter, out var shooterComp))
+        {
+            shooterComp.Projectiles.Remove(ent);
+            Dirty(ent.Comp.Shooter.Value, shooterComp);
+        }
+
+        if (TryComp<ESProjectileWeaponComponent>(ent.Comp.Weapon, out var weaponComp))
+        {
+            weaponComp.Projectiles.Remove(ent);
+            Dirty(ent.Comp.Weapon.Value, weaponComp);
+        }
+    }
+
+    private void OnShooterShutdown(Entity<ESProjectileShooterComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var projectile in ent.Comp.Projectiles)
+        {
+            if (!TryComp<ProjectileComponent>(projectile, out var comp))
+                continue;
+            comp.Shooter = null;
+            Dirty(projectile, comp);
+        }
+    }
+
+    private void OnWeaponShutdown(Entity<ESProjectileWeaponComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var projectile in ent.Comp.Projectiles)
+        {
+            if (!TryComp<ProjectileComponent>(projectile, out var comp))
+                continue;
+            comp.Weapon = null;
+            Dirty(projectile, comp);
+        }
+    }
+
     public void SetShooter(EntityUid id, ProjectileComponent component, EntityUid shooterId)
     {
         if (component.Shooter == shooterId)
             return;
 
+        if (component.Shooter is { } oldShooter)
+        {
+            var oldShooterComp = EnsureComp<ESProjectileShooterComponent>(oldShooter);
+            oldShooterComp.Projectiles.Remove(id);
+            Dirty(oldShooter, oldShooterComp);
+        }
+
         component.Shooter = shooterId;
         Dirty(id, component);
+
+        var shooterComp = EnsureComp<ESProjectileShooterComponent>(shooterId);
+        shooterComp.Projectiles.Add(id);
+        Dirty(shooterId, shooterComp);
+    }
+
+    public void SetWeapon(EntityUid uid, ProjectileComponent component, EntityUid? weapon)
+    {
+        if (component.Weapon == weapon)
+            return;
+
+        if (component.Weapon is { } oldWeapon)
+        {
+            var oldWeaponComp = EnsureComp<ESProjectileWeaponComponent>(oldWeapon);
+            oldWeaponComp.Projectiles.Remove(uid);
+            Dirty(oldWeapon, oldWeaponComp);
+        }
+
+        component.Weapon = weapon;
+        Dirty(uid, component);
+
+        if (weapon.HasValue)
+        {
+            var weaponComp = EnsureComp<ESProjectileWeaponComponent>(weapon.Value);
+            weaponComp.Projectiles.Add(uid);
+            Dirty(weapon.Value, weaponComp);
+        }
     }
 
     [Serializable, NetSerializable]

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -461,7 +461,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         Physics.SetLinearVelocity(uid, finalLinear, body: physics);
 
         var projectile = EnsureComp<ProjectileComponent>(uid);
-        projectile.Weapon = gunUid;
+        Projectiles.SetWeapon(uid, projectile, gunUid);
         var shooter = user ?? gunUid;
         if (shooter != null)
             Projectiles.SetShooter(uid, projectile, shooter.Value);

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -31,6 +31,7 @@ public sealed partial class ReflectSystem : EntitySystem
     [Dependency] private ItemToggleSystem _toggle = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SharedProjectileSystem _projectile = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
 
@@ -129,9 +130,8 @@ public sealed partial class ReflectSystem : EntitySystem
         {
             _adminLogger.Add(LogType.BulletHit, LogImpact.Medium, $"{ToPrettyString(user)} reflected {ToPrettyString(projectile)} from {ToPrettyString(projectile.Comp.Weapon)} shot by {projectile.Comp.Shooter}");
 
-            projectile.Comp.Shooter = user;
-            projectile.Comp.Weapon = user;
-            Dirty(projectile, projectile.Comp);
+            _projectile.SetShooter(projectile, projectile.Comp, user);
+            _projectile.SetWeapon(projectile, projectile.Comp, user);
         }
         else
         {

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/parasite.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/parasite.yml
@@ -13,7 +13,6 @@
   - type: ESMaskConversionProjectile
   - type: Projectile
     deleteOnCollide: false
-    onlyCollideWhenShot: true
     damage:
       types:
         Piercing: 5


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2038 

burstworms now gib on explosion and also force open any container that dares to restrain them. it's peam.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Burstworm explosions have been amped up to the point where they both destroy the original body and have enough strength to force open containers.
