### PR TITLE
a few changes

### DIFF
--- a/Content.Server/_ES/Armory/Components/ESArmoryGameRuleComponent.cs
+++ b/Content.Server/_ES/Armory/Components/ESArmoryGameRuleComponent.cs
@@ -49,7 +49,7 @@ public sealed partial class ESArmoryGameRuleComponent : Component
     /// </summary>
     // Who up failwrithing
     [DataField, AutoNetworkedField]
-    public TimeSpan FailWritheDuration = TimeSpan.FromSeconds(5);
+    public TimeSpan FailWritheDuration = TimeSpan.FromSeconds(15);
 
     [DataField]
     public SoundSpecifier ArmoryOpeningAnnouncementSound =

--- a/Content.Server/_ES/Masks/Leapleech/Components/ESLeapleechComponent.cs
+++ b/Content.Server/_ES/Masks/Leapleech/Components/ESLeapleechComponent.cs
@@ -19,7 +19,7 @@ public sealed partial class ESLeapleechComponent : Component
     public int LeechCount => LeechedEntities.Count(p => p.Value >= LeechDamageThreshold);
 
     [DataField]
-    public FixedPoint2 LeechDamageThreshold = 50;
+    public FixedPoint2 LeechDamageThreshold = 10;
 
     [DataField]
     public TimeSpan BurstDelay = TimeSpan.FromSeconds(1.5f);

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -15,6 +15,11 @@
       map: ["enum.DoorVisualLayers.Base"]
     - state: welded
       map: ["enum.WeldableLayers.BaseWelded"]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        layer:
+          - WallLayer
   - type: Door
     closeTimeOne: 0.4
     closeTimeTwo: 0.4


### PR DESCRIPTION
## About the PR
Leep leech damage threshold lowered to 10. Closes #2039 
armory stun increased to 15. Closes #2054 
phantom can't steal the armory anymore. Closes #1925 

## Media


https://github.com/user-attachments/assets/6490264a-a6cd-4065-9741-43d8b0921f60




**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: phantoms can no longer steal from the armory
- tweak: armory now stuns you for longer
- tweak: leep leaches damage threshold lowered to 10 from 50
