### PR TITLE
Explosive count changes

### DIFF
--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -69,6 +69,7 @@
     - id: ESWeaponKnife
     - id: ESClothingOuterArmorSecurity
     - id: ExGrenade
+    - id: ExGrenade
 
 # Subverter
 - type: entity

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -69,7 +69,7 @@
     - id: ESWeaponKnife
     - id: ESClothingOuterArmorSecurity
     - id: ExGrenade
-    - id: ExGrenade
+      amount: 2
 
 # Subverter
 - type: entity

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
@@ -413,12 +413,14 @@
     - id: ESSleepyPen
       weight: 0.5
     - id: C4
+      weight: 0.5
+    - id: ExGrenade
+      weight: 0.5
     - group:
       - id: ESWeaponRevolver357
       - id: ESWeaponPistol9mm
       - id: ESWeaponPistol9mmSilenced
     - id: ESClothingOuterArmorSecurity
-    - id: ExGrenade
     - id: ESSpeedLoader357
       amount: 2
     - id: ESMagazine9mm


### PR DESCRIPTION

## About the PR
Resolves #2071
Resolves #2068 

Halves the odds of c4 and explosive grenades, and gives marauder one more nade.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Maurader has two grenades again
- tweak: Traitor explosives are less common maints loot
