### PR TITLE
refactor parasite kill validity checks

### DIFF
--- a/Content.Server/_ES/SecretIdentity/Burstworm/ESBurstwormSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Burstworm/ESBurstwormSystem.cs
@@ -1,10 +1,10 @@
 using System.Numerics;
 using Content.Server._ES.SecretIdentity.Burstworm.Components;
+using Content.Server._ES.SecretIdentity.Parasite;
 using Content.Server.Popups;
 using Content.Server.Storage.EntitySystems;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared._ES.Core.Timer;
-using Content.Shared._ES.KillTracking.Components;
 using Content.Shared.Gibbing;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Lock;
@@ -16,7 +16,7 @@ using Robust.Server.Containers;
 
 namespace Content.Server._ES.SecretIdentity.Burstworm;
 
-public sealed partial class ESBurstwormSystem : EntitySystem
+public sealed partial class ESBurstwormSystem : ESBaseParasiteSystem<ESBurstwormComponent>
 {
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private ContainerSystem _container = default!;
@@ -30,18 +30,20 @@ public sealed partial class ESBurstwormSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<ESBurstwormComponent, ESPlayerKilledEvent>(OnPlayerKilled);
+        base.Initialize();
+
         SubscribeLocalEvent<ESBurstwormComponent, ESBurstwormBurstTimerEvent>(OnBurstTimer);
     }
 
-    private void OnPlayerKilled(Entity<ESBurstwormComponent> ent, ref ESPlayerKilledEvent args)
+    protected override void OnValidParasiteKill(Entity<ESBurstwormComponent> ent,
+        EntityUid killed,
+        EntityUid killer,
+        Entity<MindComponent> killedMind,
+        Entity<MindComponent> killerMind)
     {
-        if (!args.ValidKill)
-            return;
-
         _popup.PopupEntity(
-            Loc.GetString("es-parasite-burstworm-warning", ("name", Identity.Entity(args.Killed, EntityManager))),
-            args.Killed,
+            Loc.GetString("es-parasite-burstworm-warning", ("name", Identity.Entity(killed, EntityManager))),
+            killed,
             PopupType.LargeCaution);
 
         _entityTimer.SpawnTimer(ent, ent.Comp.BurstDelay, new ESBurstwormBurstTimerEvent());

--- a/Content.Server/_ES/SecretIdentity/Hemophage/ESHemophageSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Hemophage/ESHemophageSystem.cs
@@ -1,5 +1,5 @@
 using Content.Server._ES.SecretIdentity.Hemophage.Components;
-using Content.Shared._ES.KillTracking.Components;
+using Content.Server._ES.SecretIdentity.Parasite;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
@@ -10,26 +10,17 @@ using Content.Shared.Mind;
 
 namespace Content.Server._ES.SecretIdentity.Hemophage;
 
-public sealed partial class ESHemophageSystem : EntitySystem
+public sealed partial class ESHemophageSystem : ESBaseParasiteSystem<ESHemophageComponent>
 {
     [Dependency] private SharedSolutionContainerSystem _solutionContainer = default!;
 
-    /// <inheritdoc/>
-    public override void Initialize()
+    protected override void OnValidParasiteKill(Entity<ESHemophageComponent> ent,
+        EntityUid killed,
+        EntityUid killer,
+        Entity<MindComponent> killedMind,
+        Entity<MindComponent> killerMind)
     {
-        SubscribeLocalEvent<ESHemophageComponent, ESPlayerKilledEvent>(OnPlayerKilled);
-    }
-
-    private void OnPlayerKilled(Entity<ESHemophageComponent> ent, ref ESPlayerKilledEvent args)
-    {
-        if (!args.ValidKill)
-            return;
-
-        if (!TryComp<MindComponent>(ent, out var mind) ||
-            mind.OwnedEntity is not { } owned)
-            return;
-
-        if (!TryComp<DnaComponent>(owned, out var dna) || dna.DNA == null)
+        if (!TryComp<DnaComponent>(killed, out var dna) || dna.DNA == null)
             return;
 
         var query = EntityQueryEnumerator<PuddleComponent, SolutionContainerManagerComponent, TransformComponent>();

--- a/Content.Server/_ES/SecretIdentity/Leapleech/ESLeapleechSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Leapleech/ESLeapleechSystem.cs
@@ -1,10 +1,10 @@
 ﻿using Content.Server._ES.SecretIdentity.Leapleech.Components;
 using Content.Server._ES.SecretIdentity.Objectives.Relays;
 using Content.Server._ES.SecretIdentity.Objectives.Relays.Components;
+using Content.Server._ES.SecretIdentity.Parasite;
 using Content.Server.Mind;
 using Content.Server.Popups;
 using Content.Shared._ES.Core.Timer;
-using Content.Shared._ES.KillTracking.Components;
 using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.Gibbing;
@@ -18,26 +18,26 @@ using Robust.Shared.Utility;
 
 namespace Content.Server._ES.SecretIdentity.Leapleech;
 
-public sealed partial class ESLeapleechSystem : EntitySystem
+public sealed partial class ESLeapleechSystem : ESBaseParasiteSystem<ESLeapleechComponent>
 {
     [Dependency] private AlertsSystem _alerts = default!;
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private ESEntityTimerSystem _entityTimer = default!;
     [Dependency] private GibbingSystem _gibbing = default!;
-    [Dependency] private ESSecretIdentitySystem _secretIdentity = default!;
     [Dependency] private MindSystem _mind = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private ThrowingSystem _throwingSystem = default!;
 
     public override void Initialize()
     {
+        base.Initialize();
+
         SubscribeLocalEvent<ESLeapleechComponent, ComponentStartup>(OnComponentStartup);
         SubscribeLocalEvent<ESLeapleechComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<ESLeapleechComponent, MindGotAddedEvent>(OnMindGotAdded);
         SubscribeLocalEvent<ESLeapleechComponent, MindGotRemovedEvent>(OnMindGotRemoved);
 
         SubscribeLocalEvent<ESLeapleechComponent, ESDamageTakenEvent>(OnDamageTaken);
-        SubscribeLocalEvent<ESLeapleechComponent, ESPlayerKilledEvent>(OnPlayerKilled);
         SubscribeLocalEvent<ESLeapleechComponent, ESLeapLeechBurstTimerEvent>(OnBurstTimer);
     }
 
@@ -77,7 +77,7 @@ public sealed partial class ESLeapleechSystem : EntitySystem
     private void OnDamageTaken(Entity<ESLeapleechComponent> ent, ref ESDamageTakenEvent args)
     {
         if (args.Origin is not { } origin ||
-            _secretIdentity.GetOrganizationOrNull(origin) == ent.Comp.IgnoreOrganization)
+            SecretIdentity.GetOrganizationOrNull(origin) == ent.Comp.IgnoreOrganization)
             return;
 
         if (!_mind.TryGetMind(origin, out _))
@@ -91,14 +91,18 @@ public sealed partial class ESLeapleechSystem : EntitySystem
         _alerts.ShowAlert(args.Body, ent.Comp.Alert, (short) level);
     }
 
-    private void OnPlayerKilled(Entity<ESLeapleechComponent> ent, ref ESPlayerKilledEvent args)
+    protected override void OnValidParasiteKill(Entity<ESLeapleechComponent> ent,
+        EntityUid killed,
+        EntityUid killer,
+        Entity<MindComponent> killedMind,
+        Entity<MindComponent> killerMind)
     {
-        if (!args.ValidKill || ent.Comp.LeechCount == 0)
+        if (ent.Comp.LeechCount == 0)
             return;
 
         _popup.PopupEntity(
-            Loc.GetString("es-parasite-burstworm-warning", ("name", Identity.Entity(args.Killed, EntityManager))),
-            args.Killed,
+            Loc.GetString("es-parasite-burstworm-warning", ("name", Identity.Entity(killed, EntityManager))),
+            killed,
             PopupType.LargeCaution);
 
         _entityTimer.SpawnTimer(ent, ent.Comp.BurstDelay, new ESLeapLeechBurstTimerEvent());

--- a/Content.Server/_ES/SecretIdentity/Leapleech/ESLeapleechSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Leapleech/ESLeapleechSystem.cs
@@ -2,7 +2,6 @@
 using Content.Server._ES.SecretIdentity.Objectives.Relays;
 using Content.Server._ES.SecretIdentity.Objectives.Relays.Components;
 using Content.Server._ES.SecretIdentity.Parasite;
-using Content.Server.Mind;
 using Content.Server.Popups;
 using Content.Shared._ES.Core.Timer;
 using Content.Shared.Alert;
@@ -24,7 +23,6 @@ public sealed partial class ESLeapleechSystem : ESBaseParasiteSystem<ESLeapleech
     [Dependency] private AudioSystem _audio = default!;
     [Dependency] private ESEntityTimerSystem _entityTimer = default!;
     [Dependency] private GibbingSystem _gibbing = default!;
-    [Dependency] private MindSystem _mind = default!;
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private ThrowingSystem _throwingSystem = default!;
 
@@ -80,7 +78,7 @@ public sealed partial class ESLeapleechSystem : ESBaseParasiteSystem<ESLeapleech
             SecretIdentity.GetOrganizationOrNull(origin) == ent.Comp.IgnoreOrganization)
             return;
 
-        if (!_mind.TryGetMind(origin, out _))
+        if (!Mind.TryGetMind(origin, out _))
             return;
 
         var damage = DamageSpecifier.GetPositive(args.DamageDone).GetTotal();

--- a/Content.Server/_ES/SecretIdentity/Parasite/ESBaseParasiteSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Parasite/ESBaseParasiteSystem.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Content.Server._ES.Objectives;
+using Content.Server._ES.SecretIdentity.Parasite.Components;
+using Content.Shared._ES.KillTracking.Components;
+using Content.Shared._ES.SecretIdentity;
+using Content.Shared.Mind;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._ES.SecretIdentity.Parasite;
+
+/// <summary>
+///     Handles shared checks for parasite kill validity.
+/// </summary>
+public abstract partial class ESBaseParasiteSystem<T> : EntitySystem
+    where T: Component
+{
+    [Dependency] protected SharedMindSystem Mind = default!;
+    [Dependency] protected ESObjectiveSystem Objectives = default!;
+    [Dependency] protected ESSecretIdentitySystem SecretIdentity = default!;
+
+    private readonly ProtoId<ESOrganizationPrototype> _parasiteOrganization = "Parasite";
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<T, ESPlayerKilledEvent>(OnPlayerKilled);
+    }
+
+    private void OnPlayerKilled(Entity<T> ent, ref ESPlayerKilledEvent args)
+    {
+        if (!args.ValidKill || args.Killer is not { } killer)
+            return;
+
+        if (!TryComp<MindComponent>(ent.Owner, out var killedMind))
+            return;
+
+        if (!Mind.TryGetMind(killer, out var killerMindEntity, out var killerMind))
+            return;
+
+        if (Objectives.GetObjectives<ESParasiteDamageObjectiveComponent>(ent.Owner).Any(obj => obj.Comp.Failed))
+            return;
+
+        if (SecretIdentity.GetOrganizationOrNull((killerMindEntity, killerMind)) == _parasiteOrganization)
+            return;
+
+        OnValidParasiteKill(ent, args.Killed, args.Killer.Value, (ent.Owner, killedMind), (killerMindEntity, killerMind));
+    }
+
+    /// <summary>
+    ///     Called when a valid parasite kill happens.
+    ///     Parasite systems should perform their 'on-kill conversion' logic (or any other logic) in this function.
+    /// </summary>
+    protected abstract void OnValidParasiteKill(Entity<T> ent, EntityUid killed, EntityUid killer, Entity<MindComponent> killedMind, Entity<MindComponent> killerMind);
+}

--- a/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
+++ b/Content.Shared/_ES/Objectives/ESSharedObjectiveSystem.cs
@@ -450,6 +450,17 @@ public abstract partial class ESSharedObjectiveSystem : EntitySystem
     }
 
     /// <summary>
+    /// Checks if a given entity has a completed objective of a specific type.
+    /// </summary>
+    public bool HasCompletedObjectiveOfType<T>([NotNullWhen(true)] EntityUid? potentialHolder) where T : Component
+    {
+        if (potentialHolder == null)
+            return false;
+
+        return GetObjectives<T>(potentialHolder.Value).Any(o => IsCompleted(o.Owner));
+    }
+
+    /// <summary>
     /// Checks if a given entity has the given objective assigned to them.
     /// Unlike <see cref="TryFindObjectiveHolder"/>, this works for any type of inherited ownership, not just direct holding.
     /// </summary>

--- a/Resources/Prototypes/_ES/Objectives/parasite.yml
+++ b/Resources/Prototypes/_ES/Objectives/parasite.yml
@@ -16,7 +16,7 @@
   parent: ESBaseSecretIdentityObjective
   id: ESObjectiveParasiteDie
   name: Be killed
-  description: Once someone kills you, the parasites in your body will respond to their brain hormones and launch into action.
+  description: Once someone not of our kind kills you, the parasites in our body will respond to their brain hormones and launch into action.
   components:
   - type: ESObjective
     icon:

--- a/Resources/Prototypes/_ES/Objectives/parasite.yml
+++ b/Resources/Prototypes/_ES/Objectives/parasite.yml
@@ -16,7 +16,7 @@
   parent: ESBaseSecretIdentityObjective
   id: ESObjectiveParasiteDie
   name: Be killed
-  description: Once someone not of our kind kills you, the parasites in our body will respond to their brain hormones and launch into action.
+  description: Once someone not of our kind kills us, the parasites in our body will respond to their brain hormones and launch into action.
   components:
   - type: ESObjective
     icon:

--- a/SpaceStation14.slnx.DotSettings
+++ b/SpaceStation14.slnx.DotSettings
@@ -614,6 +614,7 @@ public sealed partial class $CLASS$ : Shared$CLASS$ {
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bloodloss/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bluespace/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bluespaced/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Burstworm/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bwoink/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=BYOND/@EntryIndexedValue">True</s:Boolean>
     <s:String x:Key="/Default/FilterSettingsManager/AttributeFilterXml/@EntryValue">&lt;data /&gt;</s:String>
@@ -659,6 +660,7 @@ public sealed partial class $CLASS$ : Shared$CLASS$ {
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Grindable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hardcode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hbox/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hemophage/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hotbar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inhand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jitteriness/@EntryIndexedValue">True</s:Boolean>
@@ -669,6 +671,7 @@ public sealed partial class $CLASS$ : Shared$CLASS$ {
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kibibyte/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kibibytes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lacunarity/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Leapleech/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=Lerp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lerping/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=loadout/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

fixes #2105 
fixes thing where a worm could theoretically proc after failing their self damage but before actually dying from that (idk if this ever happened)

in general just more robust checks now and into the future

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Worms no longer proc on being killed by another worm (or if their self damage objective is failed)