### PR TITLE
Warp drive small fixes

### DIFF
--- a/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.SingularityWorld.cs
+++ b/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.SingularityWorld.cs
@@ -40,7 +40,7 @@ public sealed partial class ESWarpDriveSystem
 
     private void OnWarpDriveTeleport(Entity<ESWarpDriveComponent> ent, ref PortalTeleportedEvent args)
     {
-        if (HasComp<GhostComponent>(ent))
+        if (HasComp<GhostComponent>(args.Entity))
             return;
 
         var teleport = EnsureComp<ESSingularityWorldTeleportedEntityComponent>(args.Entity);

--- a/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.cs
+++ b/Content.Server/_ES/WarpDrive/ESWarpDriveSystem.cs
@@ -153,8 +153,6 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
             {
                 SpawnInterruptionObjects(component);
             }
-
-            component.NextInterruptionTime = _timing.CurTime + _random.Next(component.MinRandomInterruptionTime, component.MaxRandomInterruptionTime);
         }
 
         // check if there are any active interrupting entities
@@ -171,8 +169,10 @@ public sealed partial class ESWarpDriveSystem : GameRuleSystem<ESWarpDriveGameRu
         if (interruptions <= 0 && component.Interrupted && component.LastInterruptionTime is { } time)
         {
             component.Interrupted = false;
-            component.AccumulatedInterruptionTime += (_timing.CurTime - time);
+            component.AccumulatedInterruptionTime += _timing.CurTime - time;
             UpdateAppearance(true);
+
+            component.NextInterruptionTime = _timing.CurTime + _random.Next(component.MinRandomInterruptionTime, component.MaxRandomInterruptionTime);
 
             _chat.DispatchRoundAnnouncement(Loc.GetString("es-warp-drive-announcement-interruptions-cleared"),
                 Loc.GetString("es-warpdrive-announcer"),


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2106 

fixes an incorrect check for ghosts

delays the next clog time set code until after the warp drive is unclogged. this should mean that you always have _at least_ 5 minutes after unclogging until it happens again. Before, the time would be set when the clog occurs, meaning that if it takes you 4 minutes to unclog it, you'd get another clog 1 minute after. That feels insanely bullshit and punishing so this will hopefully feel better.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

