### PR TITLE
collision electrocution tweaks

### DIFF
--- a/Content.Server/Electrocution/ElectrocutionSystem.cs
+++ b/Content.Server/Electrocution/ElectrocutionSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Server.Administration.Logs;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.Power.Components;
@@ -31,10 +32,9 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using PullableComponent = Content.Shared.Movement.Pulling.Components.PullableComponent;
 using PullerComponent = Content.Shared.Movement.Pulling.Components.PullerComponent;
-// ES START
 using Content.Shared._ES.Sparks;
 using Content.Shared.Interaction.Events;
-// ES END
+using Robust.Shared.Timing;
 
 namespace Content.Server.Electrocution;
 
@@ -59,6 +59,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
     [Dependency] private MetaDataSystem _metaData = default!;
     [Dependency] private TurfSystem _turf = default!;
 // ES START
+    [Dependency] private IGameTiming _timing = default!;
     [Dependency] private ESSparksSystem _esSparks = default!;
 // ES END
 
@@ -68,7 +69,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
 
     // Multiply and shift the log scale for shock damage.
     private const float RecursiveDamageMultiplier = 0.75f;
-    private const float RecursiveTimeMultiplier = 0.8f;
+    private const float RecursiveTimeMultiplier = 1.1f;
 
     private const float ParalyzeTimeMultiplier = 1f;
 
@@ -77,6 +78,8 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
     private const float JitterTimeMultiplier = 0.75f;
     private const float JitterAmplitude = 80f;
     private const float JitterFrequency = 8f;
+
+    private const float ElectrificationDotProductTolerance = -0.5f;
 
     public override void Initialize()
     {
@@ -162,8 +165,32 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
 
     private void OnElectrifiedStartCollide(EntityUid uid, ElectrifiedComponent electrified, ref StartCollideEvent args)
     {
-        if (electrified.OnBump)
-            TryDoElectrifiedAct(uid, args.OtherEntity, 1, electrified);
+        if (!electrified.OnBump)
+            return;
+
+        var normal = args.WorldNormal.Normalized();
+        var otherVelocity = args.OtherBody.LinearVelocity.Normalized();
+
+        // this can be nan for some reason
+        if (!normal.IsValid() || !otherVelocity.IsValid())
+            return;
+
+        if (electrified.LastAttemptedCollisionElectrocutionTime is { } time && time + electrified.MinTimeBetweenCollisionElectrocutions > _timing.CurTime)
+            return;
+
+        // this is kinda jank and should be per-player probably
+        // but all of this stuff is kinda wack idk its like completely non-predicted
+        // any situations where it would actually be bad are like. not really that possible and this easily fixes
+        // pretty much all possible weird collision cheese with a trillion things getting electrocuted at once too
+        electrified.LastAttemptedCollisionElectrocutionTime = _timing.CurTime;
+
+        // body must be moving in the direction of the collision for it to count
+        // so the normal & velocity should be in opposite dirs (<0 dot product)
+        // furthermore they must be moving in almost exactly opposite dirs, low tolerance
+        if (Vector2.Dot(normal, otherVelocity) >= ElectrificationDotProductTolerance)
+            return;
+
+        TryDoElectrifiedAct(uid, args.OtherEntity, 1, electrified);
     }
 
     private void OnElectrifiedAttacked(EntityUid uid, ElectrifiedComponent electrified, AttackedEvent args)
@@ -228,13 +255,15 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
             for (var i = targets.Count - 1; i >= 0; i--)
             {
                 var (entity, depth) = targets[i];
+                // past depth of 1, electrocutions ignore insulation
                 lastRet = TryDoElectrocution(
                     entity,
                     uid,
                     (int) (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth)),
                     TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth)),
                     true,
-                    electrified.SiemensCoefficient
+                    electrified.SiemensCoefficient,
+                    ignoreInsulation: depth > 1
                 );
             }
             return lastRet;
@@ -256,6 +285,7 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
             for (var i = targets.Count - 1; i >= 0; i--)
             {
                 var (entity, depth) = targets[i];
+                // past depth of 1, electrocutions ignore insulation
                 lastRet = TryDoElectrocutionPowered(
                     entity,
                     uid,
@@ -263,7 +293,9 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
                     (int) (electrified.ShockDamage * MathF.Pow(RecursiveDamageMultiplier, depth) * damageScalar),
                     TimeSpan.FromSeconds(electrified.ShockTime * MathF.Pow(RecursiveTimeMultiplier, depth) * timeScalar),
                     true,
-                    electrified.SiemensCoefficient);
+                    electrified.SiemensCoefficient,
+                    ignoreInsulation: depth > 1
+                    );
             }
             return lastRet;
         }
@@ -310,9 +342,10 @@ public sealed partial class ElectrocutionSystem : SharedElectrocutionSystem
         bool refresh,
         float siemensCoefficient = 1f,
         StatusEffectsComponent? statusEffects = null,
-        TransformComponent? sourceTransform = null)
+        TransformComponent? sourceTransform = null,
+        bool ignoreInsulation = false)
     {
-        if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient))
+        if (!DoCommonElectrocutionAttempt(uid, sourceUid, ref siemensCoefficient, ignoreInsulation))
             return false;
 
         if (!DoCommonElectrocution(uid, sourceUid, shockDamage, time, refresh, siemensCoefficient, statusEffects))

--- a/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
+++ b/Content.Shared/Electrocution/Components/ElectrifiedComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Electrocution;
 /// <summary>
 ///     Component for things that shock users on touch.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class ElectrifiedComponent : Component
 {
     [DataField, AutoNetworkedField]
@@ -128,4 +128,15 @@ public sealed partial class ElectrifiedComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool IsWireCut = false;
+
+    /// <summary>
+    ///     Specifically for avoiding doing many collision electrocutions too fast esp if one fails for some reason
+    ///     (eg it doesnt meet the dot product threshold)
+    /// </summary>
+    // todo remove/network later when electrified stuff is predicted better?
+    [DataField, AutoPausedField]
+    public TimeSpan? LastAttemptedCollisionElectrocutionTime;
+
+    [DataField]
+    public TimeSpan MinTimeBetweenCollisionElectrocutions = TimeSpan.FromSeconds(0.5f);
 }


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

compare collision normal and mob velocity to see if theyre walking directly into the thing or just glancing it

built in cooldown for collision electrocutions so they cant retrigger or happen too often generally. can still happen from multiple objects but

always shock past depth 1 of a chained electrocution, no more pulling someone and dragging them into a grille over and over

fixes #957 

not really the most ideal fix (imo itd be best to also require being in contact with it for some amount of time but idk) but i think this will make it feel less stupid hopefully

## Media

https://github.com/user-attachments/assets/8ca4fb93-148b-4039-a1e3-8bf4b8711559



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Getting electrocuted by walking into stuff should happen much less often if you're just walking by it rather than directly into it
- tweak: Chained electrocutions (from pulling) now ignore insulation past a depth of 1