### PR TITLE
set door collision immediately on closing instead of partial close

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -34,25 +34,25 @@ public sealed partial class DoorComponent : Component
     /// Closing time until impassable. Total time is this plus <see cref="CloseTimeTwo"/>.
     /// </summary>
     [DataField]
-    public TimeSpan CloseTimeOne = TimeSpan.FromSeconds(0.4f);
+    public TimeSpan CloseTimeOne = TimeSpan.FromSeconds(0.2f);
 
     /// <summary>
     /// Closing time until fully closed. Total time is this plus <see cref="CloseTimeOne"/>.
     /// </summary>
     [DataField]
-    public TimeSpan CloseTimeTwo = TimeSpan.FromSeconds(0.2f);
+    public TimeSpan CloseTimeTwo = TimeSpan.FromSeconds(0.4f);
 
     /// <summary>
     /// Opening time until passable. Total time is this plus <see cref="OpenTimeTwo"/>.
     /// </summary>
     [DataField]
-    public TimeSpan OpenTimeOne = TimeSpan.FromSeconds(0.4f);
+    public TimeSpan OpenTimeOne = TimeSpan.FromSeconds(0.2f);
 
     /// <summary>
     /// Opening time until fully open. Total time is this plus <see cref="OpenTimeOne"/>.
     /// </summary>
     [DataField]
-    public TimeSpan OpenTimeTwo = TimeSpan.FromSeconds(0.2f);
+    public TimeSpan OpenTimeTwo = TimeSpan.FromSeconds(0.4f);
 
     /// <summary>
     ///     Interval between deny sounds & visuals;

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -468,6 +468,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!SetState(uid, DoorState.Closing, door))
             return;
 
+        SetCollidable(uid, true, door);
+
         if (predicted)
             Audio.PlayPredicted(door.CloseSound, uid, user, AudioParams.Default.WithVolume(-5));
         else if (_net.IsServer)

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -468,7 +468,9 @@ public abstract partial class SharedDoorSystem : EntitySystem
         if (!SetState(uid, DoorState.Closing, door))
             return;
 
-        SetCollidable(uid, true, door);
+        // this is deliebrately not using setcollidable bc i want
+        // occlusion to update later on partialclose, not now.
+        PhysicsSystem.SetCanCollide(uid, true);
 
         if (predicted)
             Audio.PlayPredicted(door.CloseSound, uid, user, AudioParams.Default.WithVolume(-5));
@@ -477,8 +479,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     }
 
     /// <summary>
-    /// Called when the door is partially closed. This is when the door becomes "solid". If this process fails (e.g., a
-    /// mob entered the door as it was closing), then this returns false. Otherwise, returns true;
+    /// Called when the door is partially closed.
     /// </summary>
     public bool OnPartialClose(EntityUid uid, DoorComponent? door = null, PhysicsComponent? physics = null)
     {


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

saw this from upstream or deltav or something idr but had it in mind when i was playing. its annoying to close a door and it does the partial close anim and then someone just walks through it anyway feels very stupid. imo they should immediately close

also edits partial timings

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Doors now have collision immediately upon being closed rather than partway through their animation
