### PR TITLE
Add examine text for item removal speed

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
+using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Implants.Components;
@@ -142,6 +143,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
         SubscribeLocalEvent<StorageComponent, GetVerbsEvent<ActivationVerb>>(AddUiVerb);
         SubscribeLocalEvent<StorageComponent, ComponentGetState>(OnStorageGetState);
         SubscribeLocalEvent<StorageComponent, ComponentInit>(OnComponentInit, before: new[] { typeof(SharedContainerSystem) });
+        SubscribeLocalEvent<StorageComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<StorageComponent, GetVerbsEvent<UtilityVerb>>(AddTransferVerbs);
         SubscribeLocalEvent<StorageComponent, InteractUsingEvent>(OnInteractUsing, after: new[] { typeof(ItemSlotsSystem) });
         SubscribeLocalEvent<StorageComponent, ActivateInWorldEvent>(OnActivate);
@@ -283,6 +285,27 @@ public abstract partial class SharedStorageSystem : EntitySystem
 
         // Make sure the initial starting grid is okay.
         UpdateOccupied((uid, storageComp));
+    }
+
+    private void OnExamined(Entity<StorageComponent> ent, ref ExaminedEvent args)
+    {
+        if (MathHelper.CloseTo(ent.Comp.ItemPickupTimeMultiplier, 1))
+            return;
+
+        if (ent.Comp.ItemPickupTimeMultiplier > 1)
+        {
+            args.PushMarkup(Loc.GetString("es-storage-examine-pickup-speed",
+                ("name", Name(ent)),
+                ("val", false),
+                ("mul", MathF.Round(ent.Comp.ItemPickupTimeMultiplier, 1))));
+        }
+        else
+        {
+            args.PushMarkup(Loc.GetString("es-storage-examine-pickup-speed",
+                ("name", Name(ent)),
+                ("val", true),
+                ("mul", MathF.Round(1f / ent.Comp.ItemPickupTimeMultiplier, 1))));
+        }
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/components/storage-component.ftl
+++ b/Resources/Locale/en-US/components/storage-component.ftl
@@ -11,3 +11,7 @@ comp-storage-window-slots = Slots: { $itemCount }/{ $maxCount }, Max Size: {$siz
 comp-storage-window-dummy = Dummy
 comp-storage-verb-open-storage = Open Storage
 comp-storage-verb-close-storage = Close Storage
+es-storage-examine-pickup-speed = Taking things out of this {$name} is { $val ->
+    [true] [color=lime]{$mul}x faster[/color]
+    *[false] [color=red]{$mul}x slower[/color]
+} than normal.


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2135 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="704" height="240" alt="image" src="https://github.com/user-attachments/assets/33a86949-a5cd-45c6-971d-34e964b53921" />
<img width="765" height="299" alt="image" src="https://github.com/user-attachments/assets/e34e2412-2261-4f0d-835c-9205c60d5b78" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Storage items now have examine text to indicate if they are slower or faster to take items out of.

