### PR TITLE
wall construction tweaks

### DIFF
--- a/Content.Client/Charges/ChargesStatusControl.cs
+++ b/Content.Client/Charges/ChargesStatusControl.cs
@@ -1,0 +1,35 @@
+using Content.Client.Message;
+using Content.Client.Stylesheets;
+using Content.Shared.Charges.Components;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Charges;
+
+public sealed class ChargesStatusControl : Control
+{
+    private readonly Entity<LimitedChargesComponent> _parent;
+    private readonly RichTextLabel _label;
+
+    public ChargesStatusControl(Entity<LimitedChargesComponent> parent)
+    {
+        _parent = parent;
+        _label = new RichTextLabel { StyleClasses = { StyleClass.ItemStatus } };
+        AddChild(_label);
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        if (_parent.Comp.LifeStage > ComponentLifeStage.Running)
+        {
+            _label.Visible = false;
+            return;
+        }
+
+        _label.SetMarkup(Loc.GetString("limited-charges-charge-status-control-label",
+            ("charges", _parent.Comp.LastCharges)));
+    }
+}

--- a/Content.Client/Charges/ChargesSystem.cs
+++ b/Content.Client/Charges/ChargesSystem.cs
@@ -1,5 +1,5 @@
 using Content.Client.Actions;
-using Content.Shared.Actions;
+using Content.Client.Items;
 using Content.Shared.Charges.Components;
 using Content.Shared.Charges.Systems;
 
@@ -11,6 +11,13 @@ public sealed partial class ChargesSystem : SharedChargesSystem
 
     private Dictionary<EntityUid, int> _lastCharges = new();
     private Dictionary<EntityUid, int> _tempLastCharges = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.ItemStatus<LimitedChargesComponent>(ent => new ChargesStatusControl(ent));
+    }
 
     public override void Update(float frameTime)
     {

--- a/Content.IntegrationTests/Tests/Construction/RCDTest.cs
+++ b/Content.IntegrationTests/Tests/Construction/RCDTest.cs
@@ -12,12 +12,8 @@ namespace Content.IntegrationTests.Tests.Construction;
 public sealed class RCDTest : InteractionTest
 {
     private static readonly EntProtoId RCDProtoId = "RCD";
-    private static readonly ProtoId<RCDPrototype> RCDSettingAirlock = "Airlock";
     private static readonly ProtoId<RCDPrototype> RCDSettingPlating = "Plating";
     private static readonly ProtoId<RCDPrototype> RCDSettingFloorSteel = "FloorSteel";
-    private static readonly ProtoId<RCDPrototype> RCDSettingDeconstruct = "Deconstruct";
-    private static readonly ProtoId<RCDPrototype> RCDSettingDeconstructTile = "DeconstructTile";
-    private static readonly ProtoId<RCDPrototype> RCDSettingDeconstructLattice = "DeconstructLattice";
 
     /// <summary>
     /// Tests RCD construction and deconstruction, as well as selecting options from the radial menu.
@@ -42,14 +38,10 @@ public sealed class RCDTest : InteractionTest
         await SetTile(Plating, SEntMan.GetNetCoordinates(pEast), MapData.Grid);
         await SetTile(Lattice, SEntMan.GetNetCoordinates(pWest), MapData.Grid);
 
-        Assert.That(ProtoMan.TryIndex(RCDSettingAirlock, out var settingAirlock), $"RCDPrototype not found: {RCDSettingAirlock}.");
-        Assert.That(settingAirlock.Prototype, Is.Not.Null, $"RCDPrototype has a null spawning prototype.");
         Assert.That(ProtoMan.TryIndex(RCDSettingPlating, out var settingPlating), $"RCDPrototype not found: {RCDSettingPlating}.");
         Assert.That(settingPlating.Prototype, Is.Not.Null, "RCDPrototype has a null spawning prototype.");
         Assert.That(ProtoMan.TryIndex(RCDSettingFloorSteel, out var settingFloorSteel), $"RCDPrototype not found: {RCDSettingFloorSteel}.");
         Assert.That(settingFloorSteel.Prototype, Is.Not.Null, "RCDPrototype has a null spawning prototype.");
-        Assert.That(ProtoMan.TryIndex(RCDSettingDeconstructTile, out var settingDeconstructTile), $"RCDPrototype not found: {RCDSettingDeconstructTile}.");
-        Assert.That(ProtoMan.TryIndex(RCDSettingDeconstructLattice, out var settingDeconstructLattice), $"RCDPrototype not found: {RCDSettingDeconstructLattice}.");
 
         var rcd = await PlaceInHands(RCDProtoId);
 
@@ -73,28 +65,6 @@ public sealed class RCDTest : InteractionTest
         // Check that the failed construction did not cost us any charges.
         newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
         Assert.That(initialCharges, Is.EqualTo(newCharges), "RCD has wrong amount of charges after failing to build something.");
-
-        // Switch to building airlocks.
-        await SetRcdProto(rcd, RCDSettingAirlock);
-
-        // Build an airlock next to the player.
-        await Interact(null, pSouth);
-
-        // Check that there is exactly one airlock.
-        await RunSeconds(settingAirlock.Delay + 1); // wait for the construction to finish
-        await AssertEntityLookup(
-            (settingAirlock.Prototype, 1)
-            );
-
-        // Check that the airlock is in the correct tile.
-        var airlockUid = await FindEntity(settingAirlock.Prototype);
-        var airlockNetUid = FromServer(airlockUid);
-        AssertLocation(airlockNetUid, FromServer(pSouth));
-
-        // Check that the cost of the airlock was subtracted from the current charges.
-        newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
-        Assert.That(initialCharges - settingAirlock.Cost, Is.EqualTo(newCharges), "RCD has wrong amount of charges after building something.");
-        initialCharges = newCharges;
 
         // Switch to building plating.
         await SetRcdProto(rcd, RCDSettingPlating);
@@ -137,50 +107,6 @@ public sealed class RCDTest : InteractionTest
         // Check that the cost of the plating was subtracted from the current charges.
         newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
         Assert.That(initialCharges - settingFloorSteel.Cost, Is.EqualTo(newCharges), "RCD has wrong amount of charges after building something.");
-        initialCharges = newCharges;
-
-        // Switch to deconstruction mode.
-        await SetRcdProto(rcd, RCDSettingDeconstruct);
-
-        // Deconstruct the airlock.
-        Assert.That(SEntMan.TryGetComponent<RCDDeconstructableComponent>(airlockUid, out var airlockComp), "Wall entity did not have the RCDDeconstructableComponent.");
-        await Interact(airlockUid, pSouth);
-        await RunSeconds(airlockComp.Delay + 1); // wait for the deconstruction to finish
-        AssertDeleted(airlockNetUid);
-
-        // Check that the cost of the deconstruction was subtracted from the current charges.
-        newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
-        Assert.That(initialCharges - airlockComp.Cost, Is.EqualTo(newCharges), "RCD has wrong amount of charges after deconstructing something.");
-        initialCharges = newCharges;
-
-        // Deconstruct the steel tile.
-        await Interact(null, pEast);
-        await RunSeconds(settingDeconstructTile.Delay + 1); // wait for the deconstruction to finish
-        await AssertTile(Lattice, FromServer(pEast));
-
-        // Check that the cost of the deconstruction was subtracted from the current charges.
-        newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
-        Assert.That(initialCharges - settingDeconstructTile.Cost, Is.EqualTo(newCharges), "RCD has wrong amount of charges after deconstructing something.");
-        initialCharges = newCharges;
-
-        // Deconstruct the plating.
-        await Interact(null, pWest);
-        await RunSeconds(settingDeconstructTile.Delay + 1); // wait for the deconstruction to finish
-        await AssertTile(Lattice, FromServer(pWest));
-
-        // Check that the cost of the deconstruction was subtracted from the current charges.
-        newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
-        Assert.That(initialCharges - settingDeconstructTile.Cost, Is.EqualTo(newCharges), "RCD has wrong amount of charges after deconstructing something.");
-        initialCharges = newCharges;
-
-        // Deconstruct the lattice.
-        await Interact(null, pWest);
-        await RunSeconds(settingDeconstructLattice.Delay + 1); // wait for the deconstruction to finish
-        await AssertTile(null, FromServer(pWest));
-
-        // Check that the cost of the deconstruction was subtracted from the current charges.
-        newCharges = sCharges.GetCurrentCharges(ToServer(rcd));
-        Assert.That(initialCharges - settingDeconstructLattice.Cost, Is.EqualTo(newCharges), "RCD has wrong amount of charges after deconstructing something.");
 
         // Wait for the visual effect to disappear.
         await RunSeconds(3);

--- a/Content.Shared/Charges/Components/LimitedChargesComponent.cs
+++ b/Content.Shared/Charges/Components/LimitedChargesComponent.cs
@@ -19,6 +19,9 @@ public sealed partial class LimitedChargesComponent : Component
     [DataField, AutoNetworkedField]
     public int MaxCharges = 3;
 
+    [DataField, AutoNetworkedField]
+    public bool DeleteOnEmpty = false;
+
     /// <summary>
     /// Last time charges was changed. Used to derive current charges.
     /// </summary>

--- a/Content.Shared/Charges/Systems/SharedChargesSystem.cs
+++ b/Content.Shared/Charges/Systems/SharedChargesSystem.cs
@@ -138,6 +138,11 @@ public abstract partial class SharedChargesSystem : EntitySystem
 
         action.Comp1.LastCharges = Math.Clamp(action.Comp1.LastCharges + addCharges, 0, action.Comp1.MaxCharges);
         Dirty(action.Owner, action.Comp1);
+
+        if (action.Comp1.LastCharges <= 0 && action.Comp1.DeleteOnEmpty)
+        {
+            PredictedQueueDel(action);
+        }
     }
 
     public bool TryUseCharge(Entity<LimitedChargesComponent?> entity)
@@ -208,6 +213,11 @@ public abstract partial class SharedChargesSystem : EntitySystem
         action.Comp.LastCharges = adjusted;
         action.Comp.LastUpdate = _timing.CurTime;
         Dirty(action);
+
+        if (action.Comp.LastCharges <= 0 && action.Comp.DeleteOnEmpty)
+        {
+            PredictedQueueDel(action);
+        }
     }
 
     /// <summary>

--- a/Content.Shared/Maps/TurfSystem.cs
+++ b/Content.Shared/Maps/TurfSystem.cs
@@ -212,7 +212,7 @@ public static class TurfLookupExtensions
     public static void GetEntitiesInTile(this EntityLookupSystem lookupSystem, TileRef turf, HashSet<EntityUid> intersecting, LookupFlags flags = LookupFlags.Static)
     {
         var bounds = lookupSystem.GetWorldBounds(turf);
-        bounds.Box = bounds.Box.Scale(0.9f); // Otherwise the box can clip into neighboring tiles.
+        bounds.Box = bounds.Box.Scale(0.75f); // Otherwise the box can clip into neighboring tiles.
         lookupSystem.GetEntitiesIntersecting(turf.GridUid, bounds, intersecting, flags);
     }
 

--- a/Content.Shared/_ES/Barricade/Components/ESBarricadeConstructibleComponent.cs
+++ b/Content.Shared/_ES/Barricade/Components/ESBarricadeConstructibleComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Barricade.Components;
+
+/// <summary>
+///     Marks an entity which can always have an airlock-style barricade build on top of it.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESBarricadeConstructibleComponent : Component;

--- a/Content.Shared/_ES/Barricade/Components/ESBarricadeKitComponent.cs
+++ b/Content.Shared/_ES/Barricade/Components/ESBarricadeKitComponent.cs
@@ -9,6 +9,15 @@ namespace Content.Shared._ES.Barricade.Components;
 [Access(typeof(ESBarricadeKitSystem))]
 public sealed partial class ESBarricadeKitComponent : Component
 {
+    /// <summary>
+    ///     Full-tile barricade created when used in hand.
+    /// </summary>
+    [DataField]
+    public EntProtoId TileBarricade = "Barricade";
+
+    /// <summary>
+    ///     Barricade created when used on an airlock.
+    /// </summary>
     [DataField]
     public EntProtoId AirlockBarricade = "BarricadeBlock";
 
@@ -16,5 +25,14 @@ public sealed partial class ESBarricadeKitComponent : Component
     public TimeSpan SetupDelay = TimeSpan.FromSeconds(3f);
 }
 
+public enum ESBarricadeKitBarricadeType
+{
+    Tile,
+    Airlock
+}
+
 [Serializable, NetSerializable]
-public sealed partial class ESBarricadeAirlockDoAfterEvent : SimpleDoAfterEvent;
+public sealed partial class ESBarricadeDoAfterEvent : SimpleDoAfterEvent
+{
+    public ESBarricadeKitBarricadeType Type;
+}

--- a/Content.Shared/_ES/Barricade/ESBarricadeKitSystem.cs
+++ b/Content.Shared/_ES/Barricade/ESBarricadeKitSystem.cs
@@ -84,6 +84,9 @@ public sealed partial class ESBarricadeKitSystem : EntitySystem
 
     private bool CanBarricade(EntityUid target)
     {
+        if (HasComp<ESBarricadeConstructibleComponent>(target))
+            return true;
+
         return HasComp<AirlockComponent>(target) &&
                _door.GetDoorState(target) == DoorState.Closed &&
                !_airlock.IsBarricaded(target);

--- a/Content.Shared/_ES/Barricade/ESBarricadeKitSystem.cs
+++ b/Content.Shared/_ES/Barricade/ESBarricadeKitSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._ES.Barricade.Components;
+using Content.Shared.Charges.Systems;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
@@ -11,6 +12,7 @@ public sealed partial class ESBarricadeKitSystem : EntitySystem
     [Dependency] private SharedAirlockSystem _airlock = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
     [Dependency] private SharedDoorSystem _door = default!;
+    [Dependency] private SharedChargesSystem _charge = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -50,7 +52,7 @@ public sealed partial class ESBarricadeKitSystem : EntitySystem
             return;
 
         PredictedSpawnAtPosition(ent.Comp.AirlockBarricade, Transform(target).Coordinates);
-        PredictedQueueDel(ent);
+        _charge.TryUseCharge(ent.Owner);
         args.Handled = true;
     }
 

--- a/Content.Shared/_ES/Barricade/ESBarricadeKitSystem.cs
+++ b/Content.Shared/_ES/Barricade/ESBarricadeKitSystem.cs
@@ -1,9 +1,11 @@
 using Content.Shared._ES.Barricade.Components;
 using Content.Shared.Charges.Systems;
+using Content.Shared.Coordinates.Helpers;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.Doors.Systems;
 using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
 
 namespace Content.Shared._ES.Barricade;
 
@@ -17,9 +19,18 @@ public sealed partial class ESBarricadeKitSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
+        SubscribeLocalEvent<ESBarricadeKitComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<ESBarricadeKitComponent, AfterInteractEvent>(OnAfterInteract);
-        SubscribeLocalEvent<ESBarricadeKitComponent, ESBarricadeAirlockDoAfterEvent>(OnBarricadeAirlockDoAfter);
-        SubscribeLocalEvent<ESBarricadeKitComponent, DoAfterAttemptEvent<ESBarricadeAirlockDoAfterEvent>>(OnBarricadeAirlockDoAfterAttempt);
+        SubscribeLocalEvent<ESBarricadeKitComponent, ESBarricadeDoAfterEvent>(OnBarricadeDoAfter);
+        SubscribeLocalEvent<ESBarricadeKitComponent, DoAfterAttemptEvent<ESBarricadeDoAfterEvent>>(OnBarricadeDoAfterAttempt);
+    }
+
+    private void OnUseInHand(Entity<ESBarricadeKitComponent> ent, ref UseInHandEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        args.Handled = StartDoafter(ent, ESBarricadeKitBarricadeType.Tile, args.User, null);
     }
 
     private void OnAfterInteract(Entity<ESBarricadeKitComponent> ent, ref AfterInteractEvent args)
@@ -27,14 +38,20 @@ public sealed partial class ESBarricadeKitSystem : EntitySystem
         if (args.Handled)
             return;
 
-        if (args.Target.HasValue && CanBarricade(args.Target.Value))
-        {
-            args.Handled = _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager,
-                args.User,
+        args.Handled = StartDoafter(ent, ESBarricadeKitBarricadeType.Airlock, args.User, args.Target);
+    }
+
+    private bool StartDoafter(Entity<ESBarricadeKitComponent> ent, ESBarricadeKitBarricadeType type, EntityUid user, EntityUid? target)
+    {
+        if (target.HasValue && !CanBarricade(target.Value))
+            return false;
+
+        return _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager,
+                user,
                 ent.Comp.SetupDelay,
-                new ESBarricadeAirlockDoAfterEvent(),
+                new ESBarricadeDoAfterEvent() { Type = type },
                 ent,
-                args.Target.Value,
+                target ?? user,
                 ent)
             {
                 BreakOnDamage = true,
@@ -43,22 +60,25 @@ public sealed partial class ESBarricadeKitSystem : EntitySystem
                 DuplicateCondition = DuplicateConditions.SameTool,
                 AttemptFrequency = AttemptFrequency.EveryTick,
             });
-        }
     }
 
-    private void OnBarricadeAirlockDoAfter(Entity<ESBarricadeKitComponent> ent, ref ESBarricadeAirlockDoAfterEvent args)
+    private void OnBarricadeDoAfter(Entity<ESBarricadeKitComponent> ent, ref ESBarricadeDoAfterEvent args)
     {
         if (args.Handled || args.Cancelled || args.Target is not { } target)
             return;
 
-        PredictedSpawnAtPosition(ent.Comp.AirlockBarricade, Transform(target).Coordinates);
+        var proto = args.Type == ESBarricadeKitBarricadeType.Airlock
+            ? ent.Comp.AirlockBarricade
+            : ent.Comp.TileBarricade;
+
+        PredictedSpawnAtPosition(proto, Transform(target).Coordinates.SnapToGrid(entMan: EntityManager));
         _charge.TryUseCharge(ent.Owner);
         args.Handled = true;
     }
 
-    private void OnBarricadeAirlockDoAfterAttempt(Entity<ESBarricadeKitComponent> ent, ref DoAfterAttemptEvent<ESBarricadeAirlockDoAfterEvent> args)
+    private void OnBarricadeDoAfterAttempt(Entity<ESBarricadeKitComponent> ent, ref DoAfterAttemptEvent<ESBarricadeDoAfterEvent> args)
     {
-        if (args.Event.Target is null || !CanBarricade(args.Event.Target.Value))
+        if (args.Event.Type == ESBarricadeKitBarricadeType.Airlock && (args.Event.Target is null || !CanBarricade(args.Event.Target.Value)))
             args.Cancel();
     }
 

--- a/Resources/Locale/en-US/limited-charges/limited-charges.ftl
+++ b/Resources/Locale/en-US/limited-charges/limited-charges.ftl
@@ -3,6 +3,8 @@ limited-charges-charges-remaining = {$charges ->
     *[other] It has [color=fuchsia]{$charges}[/color] charges remaining.
 }
 
+limited-charges-charge-status-control-label = Charges: [color=fuchsia]{$charges}[/color]
+
 limited-charges-max-charges = It's at [color=green]maximum[/color] charges.
 limited-charges-recharging = {$seconds ->
     [one] There is [color=yellow]{$seconds}[/color] second left until the next charge.

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -288,18 +288,12 @@
     - Grille
     - Window
     - WindowDirectional
-    - WindowReinforcedDirectional
-    - ReinforcedWindow
-    - Airlock
-    - AirlockGlass
-    - Firelock
     - TubeLight
     - BulbLight
     - LVCable
     - MVCable
     - HVCable
     - CableTerminal
-    - Deconstruct
   - type: LimitedCharges
     maxCharges: 30
   - type: Sprite

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -1190,9 +1190,6 @@
     sprite: Structures/Walls/wood.rsi
   - type: Icon
     sprite: Structures/Walls/wood.rsi
-  - type: Construction
-    graph: Barricade
-    node: woodWall
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Windows/base_window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/base_window.yml
@@ -2,7 +2,7 @@
 # DO NOT add things to this unless they are properties you want all windows having.
 - type: entity
   id: BaseWindow
-  parent: BaseStructure 
+  parent: BaseStructure
   description: Don't smudge up the glass down there.
   abstract: true
   placement:
@@ -63,6 +63,7 @@
     trackAllDamage: true
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
+  - type: ESBarricadeConstructible
 
 # Directional
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -52,6 +52,9 @@
   id: Barricade
   parent: BaseBarricade
   components:
+  - type: Construction
+    graph: Barricade
+    node: barricadefull
   - type: Tag
     tags:
     - Wooden
@@ -73,6 +76,9 @@
   - type: Sprite
     sprite: Structures/barricades.rsi
     state: barricade
+  - type: Construction
+    graph: BarricadeCovering
+    node: barricadecover
   - type: ESAirlockBlockOpen
   - type: WallMount
     arc: 360
@@ -89,6 +95,9 @@
     sprite: Structures/barricades.rsi
     state: barricade_directional
     noRot: false #Results in smoother rotation when turning the camera, the sprite's dirs are just it rotated anyways so there's no reason to not set this.
+  - type: Construction
+    graph: BarricadeDirectional
+    node: barricadefull
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Structures/barricades.yml
+++ b/Resources/Prototypes/Entities/Structures/barricades.yml
@@ -52,9 +52,6 @@
   id: Barricade
   parent: BaseBarricade
   components:
-  - type: Construction
-    graph: Barricade
-    node: barricadefull
   - type: Tag
     tags:
     - Wooden
@@ -76,9 +73,6 @@
   - type: Sprite
     sprite: Structures/barricades.rsi
     state: barricade
-  - type: Construction
-    graph: BarricadeCovering
-    node: barricadecover
   - type: ESAirlockBlockOpen
   - type: WallMount
     arc: 360
@@ -95,9 +89,6 @@
     sprite: Structures/barricades.rsi
     state: barricade_directional
     noRot: false #Results in smoother rotation when turning the camera, the sprite's dirs are just it rotated anyways so there's no reason to not set this.
-  - type: Construction
-    graph: BarricadeDirectional
-    node: barricadefull
   - type: Physics
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -3,33 +3,6 @@
   id: Invalid   # Hidden prototype - do not add to RCDs
   mode: Invalid
 
-- type: rcd
-  id: Deconstruct
-  name: rcd-component-deconstruct
-  category: Main
-  sprite: /Textures/Interface/Radial/RCD/deconstruct.png
-  mode: Deconstruct
-  prototype: EffectRCDDeconstructPreview
-  rotation: Camera
-
-- type: rcd
-  id: DeconstructLattice   # Hidden prototype - do not add to RCDs
-  name: rcd-component-deconstruct
-  mode: Deconstruct
-  cost: 2
-  delay: 0
-  rotation: Camera
-  fx: EffectRCDConstruct0
-
-- type: rcd
-  id: DeconstructTile      # Hidden prototype - do not add to RCDs
-  name: rcd-component-deconstruct
-  mode: Deconstruct
-  cost: 4
-  delay: 4
-  rotation: Camera
-  fx: EffectRCDDeconstruct4
-
 # Flooring
 - type: rcd
   id: Plating
@@ -116,72 +89,6 @@
     - IsWindow
   rotation: User
   fx: EffectRCDConstruct1
-
-- type: rcd
-  id: ReinforcedWindow
-  category: WindowsAndGrilles
-  sprite: /Textures/Interface/Radial/RCD/window_reinforced.png
-  mode: ConstructObject
-  prototype: ReinforcedWindow
-  cost: 4
-  delay: 3
-  collisionMask: Impassable
-  rules:
-    - IsWindow
-  rotation: User
-  fx: EffectRCDConstruct3
-
-- type: rcd
-  id: WindowReinforcedDirectional
-  category: WindowsAndGrilles
-  sprite: /Textures/Interface/Radial/RCD/directional_reinforced.png
-  mode: ConstructObject
-  prototype: WindowReinforcedDirectional
-  cost: 3
-  delay: 2
-  collisionMask: Impassable
-  collisionBounds: "-0.23,-0.49,0.23,-0.36"
-  rules:
-    - IsWindow
-  rotation: User
-  fx: EffectRCDConstruct2
-
-# Airlocks
-- type: rcd
-  id: Airlock
-  category: Airlocks
-  sprite: /Textures/Interface/Radial/RCD/airlock.png
-  mode: ConstructObject
-  prototype: Airlock
-  cost: 4
-  delay: 4
-  collisionMask: FullTileMask
-  rotation: Camera
-  fx: EffectRCDConstruct4
-
-- type: rcd
-  id: AirlockGlass
-  category: Airlocks
-  sprite: /Textures/Interface/Radial/RCD/glass_airlock.png
-  mode: ConstructObject
-  prototype: AirlockGlass
-  cost: 4
-  delay: 4
-  collisionMask: FullTileMask
-  rotation: Camera
-  fx: EffectRCDConstruct4
-
-- type: rcd
-  id: Firelock
-  category: Airlocks
-  sprite: /Textures/Interface/Radial/RCD/firelock.png
-  mode: ConstructObject
-  prototype: Firelock
-  cost: 4
-  delay: 3
-  collisionMask: FullTileMask
-  rotation: Camera
-  fx: EffectRCDConstruct3
 
 # Lighting
 - type: rcd

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/barricades.yml
@@ -13,38 +13,6 @@
               doAfter: 3
     - node: barricadefull
       entity: Barricade
-      edges:
-        - to: start
-          completed:
-            - !type:SpawnPrototype
-              prototype: MaterialWoodPlank1
-              amount: 3 #returns 1 less as one breaks
-            - !type:DeleteEntity {}
-          conditions:
-            - !type:EntityAnchored
-              anchored: true
-          steps:
-            - tool: Prying
-              doAfter: 10
-        - to: woodWall
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          steps:
-            - material: WoodPlank
-              amount: 2
-              doAfter: 2
-    - node: woodWall
-      entity: WallWood
-      edges:
-      - to: barricadefull
-        completed:
-        - !type:GivePrototype
-          prototype: MaterialWoodPlank1
-          amount: 2
-        steps:
-        - tool: Prying
-          doAfter: 8
 
 - type: constructionGraph
   id: BarricadeDirectional
@@ -59,19 +27,6 @@
               doAfter: 3
     - node: barricadefull
       entity: BarricadeDirectional
-      edges:
-        - to: start
-          completed:
-            - !type:SpawnPrototype
-              prototype: MaterialWoodPlank1
-              amount: 3 #returns 1 less as one breaks
-            - !type:DeleteEntity {}
-          conditions:
-            - !type:EntityAnchored
-              anchored: true
-          steps:
-            - tool: Prying
-              doAfter: 8
 
 - type: constructionGraph
   id: BarricadeCovering
@@ -86,16 +41,3 @@
               doAfter: 3
     - node: barricadecover
       entity: BarricadeBlock
-      edges:
-        - to: start
-          completed:
-            - !type:GivePrototype
-              prototype: MaterialWoodPlank1
-              amount: 2 #returns 1 less as one breaks
-            - !type:DeleteEntity { }
-          conditions:
-            - !type:EntityAnchored
-              anchored: true
-          steps:
-            - tool: Prying
-              doAfter: 8

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -51,19 +51,6 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: WoodWall
-  graph: Barricade
-  startNode: start
-  targetNode: woodWall
-  category: construction-category-structures
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canRotate: false
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
   id: UraniumWall
   graph: Girder
   startNode: start

--- a/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/maintenance_loot.yml
@@ -152,9 +152,6 @@
     - id: EmergencyOxygenTank
     - id: SprayPainterAmmo
 
-    - id: ESKitBarricade
-      weight: 0.5
-
     - group:
       - id: GlowstickGreen
       - id: GlowstickBlue
@@ -183,6 +180,8 @@
   id: ESMaintLootUncommon
   table:
     group:
+    - id: ESKitBarricade
+      weight: 2 # common for now?
     - id: FireBombEmpty
     - id: HydroponicsToolHatchet
     - id: Multitool

--- a/Resources/Prototypes/_ES/Entities/Objects/Materials/kits.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Materials/kits.yml
@@ -16,7 +16,7 @@
   parent: BaseItem
   id: ESKitBarricade
   name: barricade kit
-  description: It's well understood that barricading hallways and airlocks with wooden planks is enough to defend against any threat.
+  description: It's well understood that barricading hallways, airlocks and windows with wooden planks is enough to defend against any threat.
   components:
   - type: Sprite
     sprite: _ES/Objects/Materials/kits.rsi
@@ -29,4 +29,3 @@
   - type: LimitedCharges
     maxCharges: 3
     deleteOnEmpty: true
-

--- a/Resources/Prototypes/_ES/Entities/Objects/Materials/kits.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Materials/kits.yml
@@ -26,3 +26,7 @@
     shape:
     - 0,0,2,3
   - type: ESBarricadeKit
+  - type: LimitedCharges
+    maxCharges: 3
+    deleteOnEmpty: true
+

--- a/Resources/Prototypes/_ES/Lathe/Recipes/tools.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/tools.yml
@@ -30,5 +30,5 @@
   result: ESKitBarricade
   completetime: 5
   materials:
-    Wood: 500
-    Steel: 250
+    Wood: 400
+    Steel: 200

--- a/Resources/Prototypes/_ES/Lathe/Recipes/tools.yml
+++ b/Resources/Prototypes/_ES/Lathe/Recipes/tools.yml
@@ -30,5 +30,5 @@
   result: ESKitBarricade
   completetime: 5
   materials:
-    Wood: 200
-    Steel: 100
+    Wood: 500
+    Steel: 250


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

rcd can no longer decon tiles or create firelocks/reinforced windows/airlocks (theyre basically just walls i think)

barricade kit now has charges (3 by default)

barricade kit can now barricade windows and create fulltile barricades

added itemstatus for limited charges stuff

barricade removed pryability

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="383" height="237" alt="image" src="https://github.com/user-attachments/assets/2612ebe4-4621-4edb-9bf6-4e7700ab0770" />
<img width="320" height="311" alt="image" src="https://github.com/user-attachments/assets/64b86a21-a271-4513-a24c-81ba04076c23" />
<img width="435" height="380" alt="image" src="https://github.com/user-attachments/assets/fdac2e76-8941-4368-80e7-ea98be399d04" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Barricade kits can also barricade windows and create tile barricades when used in hand
- tweak: Items that use charges (RCD barricade kit etc) now have itemstatus showing the charge count 
- remove: Barricades are no longer deconstructible by prying