### PR TITLE
changelog fix

### DIFF
--- a/Content.Benchmarks/GasReactionBenchmark.cs
+++ b/Content.Benchmarks/GasReactionBenchmark.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Content.IntegrationTests;
 using Content.IntegrationTests.Pair;
-using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Atmos.Reactions;
 using Content.Shared.Atmos;


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

:cl:
- add: Rather than instantly being transported to the lobby, a short little post-death sequence will play out when you die
- tweak: Use of the ghost command is now only allowed if you are dead (and want to expedite the death cutscene for some reason)
- add: A cinematic will now play when the nuke is detonated.
