### PR TITLE
Change leapleech leeches to use bespoke conversion code

### DIFF
--- a/Content.Server/_ES/SecretIdentity/Leapleech/Components/ESLeapleechWormComponent.cs
+++ b/Content.Server/_ES/SecretIdentity/Leapleech/Components/ESLeapleechWormComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared._ES.SecretIdentity;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._ES.SecretIdentity.Leapleech.Components;
+
+[RegisterComponent]
+[Access(typeof(ESLeapleechSystem))]
+public sealed partial class ESLeapleechWormComponent : Component
+{
+    [DataField]
+    public ProtoId<ESSecretIdentityPrototype> Identity = "Leapleech";
+
+    [DataField]
+    public ProtoId<ESOrganizationPrototype> IgnoreOrganization = "Parasite";
+}

--- a/Content.Server/_ES/SecretIdentity/Leapleech/ESLeapleechSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Leapleech/ESLeapleechSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
 using Content.Shared.Throwing;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Server.Audio;
 using Robust.Shared.Utility;
 
@@ -37,6 +38,8 @@ public sealed partial class ESLeapleechSystem : ESBaseParasiteSystem<ESLeapleech
 
         SubscribeLocalEvent<ESLeapleechComponent, ESDamageTakenEvent>(OnDamageTaken);
         SubscribeLocalEvent<ESLeapleechComponent, ESLeapLeechBurstTimerEvent>(OnBurstTimer);
+
+        SubscribeLocalEvent<ESLeapleechWormComponent, MeleeHitEvent>(OnMeleeHit);
     }
 
     private void OnComponentStartup(Entity<ESLeapleechComponent> ent, ref ComponentStartup args)
@@ -109,6 +112,21 @@ public sealed partial class ESLeapleechSystem : ESBaseParasiteSystem<ESLeapleech
     private void OnBurstTimer(Entity<ESLeapleechComponent> ent, ref ESLeapLeechBurstTimerEvent args)
     {
         Burst(ent);
+    }
+
+    private void OnMeleeHit(Entity<ESLeapleechWormComponent> ent, ref MeleeHitEvent args)
+    {
+        foreach (var hit in args.HitEntities)
+        {
+            if (!Mind.TryGetMind(hit, out var mind))
+                continue;
+
+            if (SecretIdentity.GetOrganizationOrNull(mind.Value.AsNullable()) == ent.Comp.IgnoreOrganization)
+                continue;
+
+            SecretIdentity.ChangeSecretIdentity(mind.Value, ent.Comp.Identity);
+            QueueDel(ent);
+        }
     }
 
     private void Burst(Entity<ESLeapleechComponent> ent)

--- a/Resources/Prototypes/_ES/Entities/Mobs/NPC/worm.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/NPC/worm.yml
@@ -68,8 +68,4 @@
   - type: EmitSoundOnLand
     sound:
       collection: FootstepSnake
-  - type: TriggerOnMeleeHit
-    targetIsUser: true
-  - type: DeleteOnTrigger
-  - type: ESChangeSecretIdentityOnTrigger
-    secretIdentity: Leapleech
+  - type: ESLeapleechWorm


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2037 

there were still edge cases where someone's secret identity would change but the AI wouldn't replan so instead of trying to make it turn on a dime lets just allow it to fuck up once and not instantly follow through with all the logic.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed edge case where multiple leapleeches would bite a single player simultaneously.
