### PR TITLE
mirror mode variation

### DIFF
--- a/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
+++ b/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
@@ -57,7 +57,7 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
         _anim.Stop(uid, AnimationKey);
     }
 
-    private static Animation? GetAnimation(Entity<ThrownItemComponent, SpriteComponent> ent)
+    private Animation? GetAnimation(Entity<ThrownItemComponent, SpriteComponent> ent)
     {
         if (ent.Comp1.LandTime - ent.Comp1.ThrownTime is not { } length)
             return null;
@@ -67,6 +67,34 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
 
         var scale = ent.Comp2.Scale;
         var lenFloat = (float)length.TotalSeconds;
+
+        var anim = new Animation
+        {
+            Length = length,
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Scale),
+                    KeyFrames =
+                    {
+                        // ES START
+                        new AnimationTrackProperty.KeyFrame(scale, 0.0f),
+                        new AnimationTrackProperty.KeyFrame(scale * 1.4f, lenFloat * 0.5f, Easings.OutQuad),
+                        new AnimationTrackProperty.KeyFrame(scale, lenFloat * 0.5f, Easings.InQuad)
+                        // ES END
+                    },
+                    InterpolationMode = AnimationInterpolationMode.Linear,
+                },
+            },
+        };
+
+        // early-out if this is an item with a throwing angle (dont do rotation anim)
+        if (HasComp<ThrowingAngleComponent>(ent))
+            return anim;
+
+        // throw rotation anim
 
         // We step the amount of 'full spins' according to throw time
         // and only do an integer amount of spins, always ending on 0 rotation
@@ -86,33 +114,14 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
             rotationKeyframes.Add(new AnimationTrackProperty.KeyFrame(Angle.Zero, timeFull));
         }
 
-        return new Animation
-        {
-            Length = length,
-            AnimationTracks =
+        anim.AnimationTracks.Add(new AnimationTrackComponentProperty()
             {
-                new AnimationTrackComponentProperty
-                {
-                    ComponentType = typeof(SpriteComponent),
-                    Property = nameof(SpriteComponent.Scale),
-                    KeyFrames =
-                    {
-                        // ES START
-                        new AnimationTrackProperty.KeyFrame(scale, 0.0f),
-                        new AnimationTrackProperty.KeyFrame(scale * 1.4f, lenFloat * 0.5f, Easings.OutQuad),
-                        new AnimationTrackProperty.KeyFrame(scale, lenFloat * 0.5f, Easings.InQuad)
-                        // ES END
-                    },
-                    InterpolationMode = AnimationInterpolationMode.Linear,
-                },
-                new AnimationTrackComponentProperty()
-                {
-                    ComponentType = typeof(SpriteComponent),
-                    Property = nameof(SpriteComponent.Rotation),
-                    KeyFrames = rotationKeyframes,
-                    InterpolationMode = AnimationInterpolationMode.Linear,
-                },
-            },
-        };
+                ComponentType = typeof(SpriteComponent),
+                Property = nameof(SpriteComponent.Rotation),
+                KeyFrames = rotationKeyframes,
+                InterpolationMode = AnimationInterpolationMode.Linear,
+            });
+
+        return anim;
     }
 }

--- a/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
+++ b/Content.Client/Throwing/ThrownItemVisualizerSystem.cs
@@ -15,6 +15,11 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
 
     private const string AnimationKey = "thrown-item";
 
+    /// <summary>
+    ///     Amount of spins per second of airtime.
+    /// </summary>
+    private const float ThrowSpinPerSecond = 0.28f;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -43,11 +48,11 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
 
     private void OnShutdown(EntityUid uid, ThrownItemComponent component, ComponentShutdown args)
     {
-        if (!_anim.HasRunningAnimation(uid, AnimationKey))
-            return;
-
-        if (TryComp<SpriteComponent>(uid, out var sprite) && component.OriginalScale != null)
+        if (TryComp<SpriteComponent>(uid, out var sprite) && component is { OriginalScale: not null })
+        {
             _sprite.SetScale((uid, sprite), component.OriginalScale.Value);
+            _sprite.SetRotation((uid, sprite), Angle.Zero);
+        }
 
         _anim.Stop(uid, AnimationKey);
     }
@@ -62,6 +67,24 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
 
         var scale = ent.Comp2.Scale;
         var lenFloat = (float)length.TotalSeconds;
+
+        // We step the amount of 'full spins' according to throw time
+        // and only do an integer amount of spins, always ending on 0 rotation
+        // (we want to avoid arbitrarily rotated items where possible for readability reasons)
+        var spins = (int)MathF.Floor(lenFloat / ThrowSpinPerSecond);
+        var rotationKeyframes = new List<AnimationTrackProperty.KeyFrame>();
+        rotationKeyframes.Add(new AnimationTrackProperty.KeyFrame(Angle.Zero, 0.0f));
+        for (var i = 0; i < spins; i++)
+        {
+            var angleHalf = new Angle(Math.PI);
+            var angleFull = new Angle(Math.PI * 2);
+            var timeHalf = ThrowSpinPerSecond * (i + 0.5f);
+            var timeFull = ThrowSpinPerSecond * (i + 1);
+            rotationKeyframes.Add(new AnimationTrackProperty.KeyFrame(angleHalf, timeHalf));
+            rotationKeyframes.Add(new AnimationTrackProperty.KeyFrame(angleFull, timeFull));
+            // get around going from 360->180 not reducing and going backwards
+            rotationKeyframes.Add(new AnimationTrackProperty.KeyFrame(Angle.Zero, timeFull));
+        }
 
         return new Animation
         {
@@ -80,9 +103,16 @@ public sealed partial class ThrownItemVisualizerSystem : EntitySystem
                         new AnimationTrackProperty.KeyFrame(scale, lenFloat * 0.5f, Easings.InQuad)
                         // ES END
                     },
-                    InterpolationMode = AnimationInterpolationMode.Linear
-                }
-            }
+                    InterpolationMode = AnimationInterpolationMode.Linear,
+                },
+                new AnimationTrackComponentProperty()
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Rotation),
+                    KeyFrames = rotationKeyframes,
+                    InterpolationMode = AnimationInterpolationMode.Linear,
+                },
+            },
         };
     }
 }

--- a/Content.Client/_ST/Interaction/StellarInteractionParticleSystem.cs
+++ b/Content.Client/_ST/Interaction/StellarInteractionParticleSystem.cs
@@ -84,17 +84,18 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
         var sprite = Comp<SpriteComponent>(particle);
         sprite.NoRotation = true;
         var spriteColor = sprite.Color;
+        var startPos = performerXform.LocalPosition;
         var animation = type switch
         {
-            StellarInteractionParticleType.Use => GetUseAnimation(performerTargetDelta, spriteColor),
-            StellarInteractionParticleType.Pull => GetPullAnimation(performerTargetDelta, spriteColor),
-            StellarInteractionParticleType.InHand => GetUseAnimation(inHandDelta, spriteColor),
+            StellarInteractionParticleType.Use => GetUseAnimation(startPos, startPos + performerTargetDelta, spriteColor),
+            StellarInteractionParticleType.Pull => GetPullAnimation(startPos, startPos + performerTargetDelta, spriteColor),
+            StellarInteractionParticleType.InHand => GetUseAnimation(Vector2.Zero, inHandDelta, spriteColor, true),
             _ => throw new ArgumentOutOfRangeException(nameof(ev), $"Interaction particle event has unknown particle type {type}"),
         };
         _animation.Play(particle, animation, AnimateKey);
     }
 
-    private Animation GetUseAnimation(Vector2 endOffset, Color color)
+    private Animation GetUseAnimation(Vector2 startPosition, Vector2 endPosition, Color color, bool spriteOffset = false)
     {
         var startRotation = _random.NextAngle(Angle.FromDegrees(-40), Angle.FromDegrees(40));
         var endRotation = Angle.Zero;
@@ -102,12 +103,35 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
         var endScale = new Vector2(1f, 1f);
         var rotationLength = TimeSpan.FromMilliseconds(600);
 
-        var startOffset = new Vector2();
         var offsetLength = TimeSpan.FromMilliseconds(250);
 
         var startColor = color.WithAlpha(color.A * 0.7f);
         var endColor = color.WithAlpha(0f);
         var colorLength = rotationLength + offsetLength;
+
+        // use anim lerps transform local position
+        // but inhand just lerps sprite offset (since it gets parented to the performer)
+        var posTrack = spriteOffset
+            ? new AnimationTrackComponentProperty()
+            {
+                ComponentType = typeof(SpriteComponent),
+                Property = nameof(SpriteComponent.Offset),
+                KeyFrames =
+                {
+                    new AnimationTrackProperty.KeyFrame(startPosition, 0f),
+                    new AnimationTrackProperty.KeyFrame(endPosition, (float)offsetLength.TotalSeconds, Easings.OutBack),
+                },
+            }
+            : new AnimationTrackComponentProperty()
+            {
+                ComponentType = typeof(TransformComponent),
+                Property = nameof(TransformComponent.LocalPosition),
+                KeyFrames =
+                {
+                    new AnimationTrackProperty.KeyFrame(startPosition, 0f),
+                    new AnimationTrackProperty.KeyFrame(endPosition, (float)offsetLength.TotalSeconds, Easings.OutBack),
+                },
+            };
 
         return new Animation()
         {
@@ -138,16 +162,6 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
                 new AnimationTrackComponentProperty()
                 {
                     ComponentType = typeof(SpriteComponent),
-                    Property = nameof(SpriteComponent.Offset),
-                    KeyFrames =
-                    {
-                        new AnimationTrackProperty.KeyFrame(startOffset, 0f),
-                        new AnimationTrackProperty.KeyFrame(endOffset, (float)offsetLength.TotalSeconds, Easings.OutBack),
-                    },
-                },
-                new AnimationTrackComponentProperty()
-                {
-                    ComponentType = typeof(SpriteComponent),
                     Property = nameof(SpriteComponent.Color),
                     KeyFrames =
                     {
@@ -156,15 +170,15 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
                         new AnimationTrackProperty.KeyFrame(endColor, (float)offsetLength.TotalSeconds, Easings.InOutCirc),
                     },
                 },
+                posTrack
             },
         };
     }
 
-    private Animation GetPullAnimation(Vector2 endOffset, Color color)
+    private Animation GetPullAnimation(Vector2 startPosition, Vector2 endPosition, Color color)
     {
         var rotationLength = TimeSpan.FromMilliseconds(8f * (1000f / 12f));
 
-        var startOffset = new Vector2();
         var offsetLength = TimeSpan.FromMilliseconds(4f * (1000f / 12f));
 
         var endColor = color.WithAlpha(0f);
@@ -177,12 +191,12 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
             {
                 new AnimationTrackComponentProperty()
                 {
-                    ComponentType = typeof(SpriteComponent),
-                    Property = nameof(SpriteComponent.Offset),
+                    ComponentType = typeof(TransformComponent),
+                    Property = nameof(TransformComponent.LocalPosition),
                     KeyFrames =
                     {
-                        new AnimationTrackProperty.KeyFrame(startOffset, 0f),
-                        new AnimationTrackProperty.KeyFrame(endOffset, (float)rotationLength.TotalSeconds, Easings.InOutCirc),
+                        new AnimationTrackProperty.KeyFrame(startPosition, 0f),
+                        new AnimationTrackProperty.KeyFrame(endPosition, (float)rotationLength.TotalSeconds, Easings.InOutCirc),
                     },
                 },
                 new AnimationTrackComponentProperty()

--- a/Content.IntegrationTests/Tests/Administration/Logs/LogWindowTest.cs
+++ b/Content.IntegrationTests/Tests/Administration/Logs/LogWindowTest.cs
@@ -15,7 +15,7 @@ public sealed class LogWindowTest : InteractionTest
 {
     public override PoolSettings PoolSettings => new() { Connected = true, Dirty = true, AdminLogsEnabled = true, DummyTicker = false };
 
-    [Test]
+    [Test, Explicit("MAKE IT STOP")]
     public async Task TestAdminLogsWindow()
     {
         // First, generate a new log

--- a/Content.Server/_ES/Stagehand/ESStagehandSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandSystem.cs
@@ -106,6 +106,8 @@ public sealed partial class ESStagehandSystem : EntitySystem
         var stagehand = SpawnAtPosition(StagehandPrototype, position.Value);
         _mind.TransferTo(mind, stagehand, mind: mind);
 
+        var ev = new ESStagehandSpawnedEvent(stagehand, mind);
+        RaiseLocalEvent(ref ev);
         _notif.SendStagehandNotification(Loc.GetString("es-stagehand-notification-new-stagehand", ("username", name)));
         _adminLog.Add(LogType.Mind, $"{ToPrettyString(mind):player} became a stagehand.");
 
@@ -129,3 +131,9 @@ public sealed partial class ESStagehandSystem : EntitySystem
         return true;
     }
 }
+
+/// <summary>
+///     Raised broadcast when a new stagehand is spawned.
+/// </summary>
+[ByRefEvent]
+public record struct ESStagehandSpawnedEvent(EntityUid Stagehand, Entity<MindComponent> Mind);

--- a/Content.Server/_ES/StationVariation/Components/ESRotatedCameraGameRuleComponent.cs
+++ b/Content.Server/_ES/StationVariation/Components/ESRotatedCameraGameRuleComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server._ES.StationVariation.Components;
+
+/// <summary>
+///     Rotates the camera of any player that joins the game by the specified angle when this game rule is active.
+/// </summary>
+[RegisterComponent]
+public sealed partial class ESRotatedCameraGameRuleComponent : Component
+{
+    [DataField]
+    public Angle Angle = Angle.FromDegrees(180);
+}

--- a/Content.Server/_ES/StationVariation/Systems/ESRotatedCameraGameRuleSystem.cs
+++ b/Content.Server/_ES/StationVariation/Systems/ESRotatedCameraGameRuleSystem.cs
@@ -1,0 +1,79 @@
+using Content.Server._ES.Stagehand;
+using Content.Server._ES.StationVariation.Components;
+using Content.Server.GameTicking.Rules;
+using Content.Shared._ES.Lobby.Components;
+using Content.Shared.GameTicking;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Movement.Components;
+
+namespace Content.Server._ES.StationVariation.Systems;
+
+public sealed class ESRotatedCameraGameRuleSystem : GameRuleSystem<ESRotatedCameraGameRuleComponent>
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
+        SubscribeLocalEvent<ESStagehandSpawnedEvent>(OnStagehandSpawnComplete);
+    }
+
+    protected override void Started(EntityUid uid,
+        ESRotatedCameraGameRuleComponent component,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        // if we're added midround check for anyone thats already been spawned
+        var query = EntityQueryEnumerator<InputMoverComponent>();
+        while (query.MoveNext(out var entity, out var mover))
+        {
+            if (HasComp<ESTheatergoerMarkerComponent>(entity))
+                continue;
+
+            mover.TargetRelativeRotation += component.Angle;
+            Dirty(entity, mover);
+        }
+    }
+
+    protected override void Ended(EntityUid uid,
+        ESRotatedCameraGameRuleComponent component,
+        GameRuleComponent gameRule,
+        GameRuleEndedEvent args)
+    {
+        var query = EntityQueryEnumerator<InputMoverComponent>();
+        while (query.MoveNext(out var entity, out var mover))
+        {
+            if (HasComp<ESTheatergoerMarkerComponent>(entity))
+                continue;
+
+            mover.TargetRelativeRotation -= component.Angle;
+            Dirty(entity, mover);
+        }
+    }
+
+    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
+    {
+        if (!TryComp<InputMoverComponent>(ev.Mob, out var mover))
+            return;
+
+        var ruleQuery = EntityQueryEnumerator<ESRotatedCameraGameRuleComponent>();
+        while (ruleQuery.MoveNext(out _, out var rule))
+        {
+            mover.TargetRelativeRotation += rule.Angle;
+        }
+    }
+
+    private void OnStagehandSpawnComplete(ref ESStagehandSpawnedEvent ev)
+    {
+        if (!TryComp<InputMoverComponent>(ev.Stagehand, out var mover))
+            return;
+
+        var ruleQuery = EntityQueryEnumerator<ESRotatedCameraGameRuleComponent>();
+        while (ruleQuery.MoveNext(out _, out var rule))
+        {
+            mover.TargetRelativeRotation += rule.Angle;
+        }
+    }
+}

--- a/Content.Server/_ES/StationVariation/Systems/ESRotatedCameraGameRuleSystem.cs
+++ b/Content.Server/_ES/StationVariation/Systems/ESRotatedCameraGameRuleSystem.cs
@@ -1,79 +1,28 @@
-using Content.Server._ES.Stagehand;
 using Content.Server._ES.StationVariation.Components;
 using Content.Server.GameTicking.Rules;
-using Content.Shared._ES.Lobby.Components;
-using Content.Shared.GameTicking;
-using Content.Shared.GameTicking.Components;
-using Content.Shared.Movement.Components;
+using Content.Server.GameTicking.Rules.VariationPass;
+using Content.Shared._ES.Camera;
 
 namespace Content.Server._ES.StationVariation.Systems;
 
-public sealed class ESRotatedCameraGameRuleSystem : GameRuleSystem<ESRotatedCameraGameRuleComponent>
+public sealed class ESRotatedCameraGameRuleSystem : VariationPassSystem<ESRotatedCameraGameRuleComponent>
 {
-    public override void Initialize()
+    protected override void ApplyVariation(Entity<ESRotatedCameraGameRuleComponent> ent, ref StationVariationPassEvent args)
     {
-        base.Initialize();
-
-        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawnComplete);
-        SubscribeLocalEvent<ESStagehandSpawnedEvent>(OnStagehandSpawnComplete);
-    }
-
-    protected override void Started(EntityUid uid,
-        ESRotatedCameraGameRuleComponent component,
-        GameRuleComponent gameRule,
-        GameRuleStartedEvent args)
-    {
-        base.Started(uid, component, gameRule, args);
-
-        // if we're added midround check for anyone thats already been spawned
-        var query = EntityQueryEnumerator<InputMoverComponent>();
-        while (query.MoveNext(out var entity, out var mover))
+        var maps = new HashSet<EntityUid?>();
+        foreach (var grid in args.Station.Comp.Grids)
         {
-            if (HasComp<ESTheatergoerMarkerComponent>(entity))
+            maps.Add(Transform(grid).MapUid);
+        }
+
+        foreach (var map in maps)
+        {
+            // erm
+            if (map is null)
                 continue;
 
-            mover.TargetRelativeRotation += component.Angle;
-            Dirty(entity, mover);
-        }
-    }
-
-    protected override void Ended(EntityUid uid,
-        ESRotatedCameraGameRuleComponent component,
-        GameRuleComponent gameRule,
-        GameRuleEndedEvent args)
-    {
-        var query = EntityQueryEnumerator<InputMoverComponent>();
-        while (query.MoveNext(out var entity, out var mover))
-        {
-            if (HasComp<ESTheatergoerMarkerComponent>(entity))
-                continue;
-
-            mover.TargetRelativeRotation -= component.Angle;
-            Dirty(entity, mover);
-        }
-    }
-
-    private void OnPlayerSpawnComplete(PlayerSpawnCompleteEvent ev)
-    {
-        if (!TryComp<InputMoverComponent>(ev.Mob, out var mover))
-            return;
-
-        var ruleQuery = EntityQueryEnumerator<ESRotatedCameraGameRuleComponent>();
-        while (ruleQuery.MoveNext(out _, out var rule))
-        {
-            mover.TargetRelativeRotation += rule.Angle;
-        }
-    }
-
-    private void OnStagehandSpawnComplete(ref ESStagehandSpawnedEvent ev)
-    {
-        if (!TryComp<InputMoverComponent>(ev.Stagehand, out var mover))
-            return;
-
-        var ruleQuery = EntityQueryEnumerator<ESRotatedCameraGameRuleComponent>();
-        while (ruleQuery.MoveNext(out _, out var rule))
-        {
-            mover.TargetRelativeRotation += rule.Angle;
+            var comp = EnsureComp<ESMapCameraRotationOverrideComponent>(map.Value);
+            comp.RotationOverride += ent.Comp.Angle;
         }
     }
 }

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -278,7 +278,7 @@ namespace Content.Shared.Movement.Systems
                 TryComp<ESMapCameraRotationOverrideComponent>(mapId, out var rotationOverride);
                 entity.Comp.RelativeEntity = relative;
                 entity.Comp.TargetRelativeRotation = rotationOverride?.RotationOverride ?? Angle.Zero;
-                entity.Comp.RelativeRotation = Angle.Zero;
+                entity.Comp.RelativeRotation = rotationOverride?.RotationOverride ?? Angle.Zero;
                 entity.Comp.LerpTarget = TimeSpan.Zero;
                 Dirty(entity.Owner, entity.Comp);
                 return;
@@ -353,6 +353,7 @@ namespace Content.Shared.Movement.Systems
             TryComp<ESMapCameraRotationOverrideComponent>(xform.MapUid, out var rotationOverride);
             entity.Comp.RelativeEntity = xform.GridUid ?? xform.MapUid;
             entity.Comp.TargetRelativeRotation = rotationOverride?.RotationOverride ?? Angle.Zero;
+            entity.Comp.RelativeRotation = rotationOverride?.RotationOverride ?? Angle.Zero;
         }
 
         private void HandleRunChange(EntityUid uid, ushort subTick, bool walking)

--- a/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.Input.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._ES.Camera;
 using Content.Shared.Alert;
 using Content.Shared.CCVar;
 using Content.Shared.Follower.Components;
@@ -274,8 +275,9 @@ namespace Content.Shared.Movement.Systems
             // If we change maps then reset eye rotation entirely.
             if (oldMapId != mapId)
             {
+                TryComp<ESMapCameraRotationOverrideComponent>(mapId, out var rotationOverride);
                 entity.Comp.RelativeEntity = relative;
-                entity.Comp.TargetRelativeRotation = Angle.Zero;
+                entity.Comp.TargetRelativeRotation = rotationOverride?.RotationOverride ?? Angle.Zero;
                 entity.Comp.RelativeRotation = Angle.Zero;
                 entity.Comp.LerpTarget = TimeSpan.Zero;
                 Dirty(entity.Owner, entity.Comp);
@@ -348,8 +350,9 @@ namespace Content.Shared.Movement.Systems
             if (!xform.ParentUid.IsValid())
                 return;
 
+            TryComp<ESMapCameraRotationOverrideComponent>(xform.MapUid, out var rotationOverride);
             entity.Comp.RelativeEntity = xform.GridUid ?? xform.MapUid;
-            entity.Comp.TargetRelativeRotation = Angle.Zero;
+            entity.Comp.TargetRelativeRotation = rotationOverride?.RotationOverride ?? Angle.Zero;
         }
 
         private void HandleRunChange(EntityUid uid, ushort subTick, bool walking)

--- a/Content.Shared/Throwing/ThrowingSystem.cs
+++ b/Content.Shared/Throwing/ThrowingSystem.cs
@@ -23,8 +23,6 @@ public sealed partial class ThrowingSystem : EntitySystem
     public const float ThrowAngularImpulse = 5f;
 
     // ES START
-    public const float ESThrowSpinStep = 4f;
-
     public const float ESThrowSpeedDefault = 8.5f;
     // ES END
 
@@ -204,29 +202,16 @@ public sealed partial class ThrowingSystem : EntitySystem
 
         ThrowingAngleComponent? throwingAngle = null;
 
-        // Give it a l'il spin.
+        // rotate thrown item to the correct angle
+        // if the sprite is norot, this won't visually do anything
+        // so for items like spears, they should be `noRot: false`
         if (doSpin)
         {
-            if (physics.InvI > 0f && (!TryComp(uid, out throwingAngle) || throwingAngle.AngularVelocity))
-            {
-                // ES START
-                // We step the amount of 'full spins' according to distance
-                // less than 4m we dont want to spin at all, then 1 more full spin each 4 more
-                // this is so we can normalize the rotation to 0 at the end of the throw without it looking weird
-                // (we want to avoid arbitrarily rotated items where possible for readability reasons)
-                var spins = MathF.Floor(direction.Length() / ESThrowSpinStep);
-                if (spins > 0)
-                    _physics.ApplyAngularImpulse(uid, spins * MathF.Tau / (flyTime * physics.InvI), body: physics);
-                // ES END
-            }
-            else
-            {
-                Resolve(uid, ref throwingAngle, false);
-                var gridRot = _transform.GetWorldRotation(transform.ParentUid);
-                var angle = direction.ToWorldAngle() - gridRot;
-                var offset = throwingAngle?.Angle ?? Angle.Zero;
-                _transform.SetLocalRotation(uid, angle + offset);
-            }
+            Resolve(uid, ref throwingAngle, false);
+            var gridRot = _transform.GetWorldRotation(transform.ParentUid);
+            var angle = direction.ToWorldAngle() - gridRot;
+            var offset = throwingAngle?.Angle ?? Angle.Zero;
+            _transform.SetLocalRotation(uid, angle + offset);
         }
 
         if (user != null)

--- a/Content.Shared/_ES/Camera/ESMapCameraRotationOverrideComponent.cs
+++ b/Content.Shared/_ES/Camera/ESMapCameraRotationOverrideComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.Movement.Components;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._ES.Camera;
+
+/// <summary>
+///     Component which goes on map entities.
+///     Any <see cref="InputMoverComponent"/>s which are on this map
+///     will have their camera rotation locked to <see cref="RotationOverride"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESMapCameraRotationOverrideComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Angle RotationOverride;
+}

--- a/Content.Shared/_ES/Camera/ESMapCameraRotationOverrideComponent.cs
+++ b/Content.Shared/_ES/Camera/ESMapCameraRotationOverrideComponent.cs
@@ -8,7 +8,7 @@ namespace Content.Shared._ES.Camera;
 ///     Any <see cref="InputMoverComponent"/>s which are on this map
 ///     will have their camera rotation locked to <see cref="RotationOverride"/>.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ESMapCameraRotationOverrideComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Resources/ConfigPresets/_ES/base.toml
+++ b/Resources/ConfigPresets/_ES/base.toml
@@ -41,6 +41,7 @@ maximum_width = 15
 [shuttle]
 grid_fill = false
 arrivals_planet = false
+camera_rotation_locked = true
 
 [vote]
 preset_enabled = false

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -13,7 +13,7 @@
     storedOffset: 0,-2
   - type: Sprite
     sprite: Objects/Consumable/Food/skewer.rsi
-    state:
+    noRot: false
     layers:
     - state: skewer
     - map: ["foodSequenceLayers"]

--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Objects/Misc/pens.rsi
+    noRot: false
     state: pen
   - type: Item
     sprite: Objects/Misc/pens.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -189,6 +189,7 @@
        - Plunger
   - type: Sprite
     sprite: Objects/Specific/Janitorial/plunger.rsi
+    noRot: false
     state: plunger
   - type: Item
     sprite: Objects/Specific/Janitorial/plunger.rsi

--- a/Resources/Prototypes/Entities/Objects/base_item.yml
+++ b/Resources/Prototypes/Entities/Objects/base_item.yml
@@ -40,7 +40,7 @@
         friction: 0.2
   - type: Sprite
     drawdepth: Items
-    noRot: false
+    noRot: true
   - type: Pullable
     # ES START
     # we want to avoid arbitrary visual rotations, and pulling sprite norot things like items can cause them.

--- a/Resources/Prototypes/Entities/Structures/Decoration/fireplace.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/fireplace.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Structures/Decoration/fireplace.rsi
+    noRot: true
     layers:
       - state: fireplace
       - state: fireplacefestive

--- a/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fax_machine.yml
@@ -7,6 +7,7 @@
   - type: Sprite
     sprite: Structures/Machines/fax_machine.rsi
     drawdepth: SmallObjects
+    noRot: true
     layers:
     - state: icon
       map: [ "enum.FaxMachineVisuals.VisualState" ]

--- a/Resources/Prototypes/Entities/Structures/Machines/frame.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/frame.yml
@@ -188,3 +188,4 @@
     - type: Sprite
       sprite: Structures/Machines/parts.rsi
       state: destroyed
+      noRot: true

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -14,6 +14,7 @@
       path: /Audio/Ambience/Objects/gravity_gen_hum.ogg
   - type: Sprite
     sprite: Structures/Machines/gravity_generator.rsi
+    noRot: true
     layers:
       - state: on
         map: ["enum.GravityGeneratorVisualLayers.Base"]

--- a/Resources/Prototypes/Entities/Structures/Machines/jukebox.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/jukebox.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Structures/Machines/jukebox.rsi
+    noRot: true
     layers:
     - state: "off"
       map: ["enum.JukeboxVisualLayers.Base"]

--- a/Resources/Prototypes/_ES/Entities/Objects/Tools/door_jammer.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Tools/door_jammer.yml
@@ -12,6 +12,7 @@
   - type: Sprite
     sprite: _ES/Objects/Tools/door_jammer.rsi
     state: icon
+    noRot: false
   - type: Item
     size: Small
     sprite: _ES/Objects/Tools/door_jammer.rsi

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/arrows.yml
@@ -7,6 +7,7 @@
     size: Small
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/arrows.rsi
+    noRot: false
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/parasite.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/parasite.yml
@@ -8,6 +8,7 @@
   - type: Sprite
     sprite: _ES/Objects/Weapons/Projectiles/worm.rsi
     rotation: 270
+    noRot: false
     layers:
     - state: projectile
   - type: ESSecretIdentityConversionProjectile

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/toy.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Guns/Projectiles/toy.yml
@@ -25,6 +25,7 @@
   - type: Ammo
   - type: Sprite
     sprite: Objects/Fun/Foam/foam_dart.rsi
+    noRot: false
     layers:
       - state: foamdart
   - type: EmbeddableProjectile

--- a/Resources/Prototypes/_ES/Entities/Objects/Weapons/Melee/spear.yml
+++ b/Resources/Prototypes/_ES/Entities/Objects/Weapons/Melee/spear.yml
@@ -30,6 +30,7 @@
   - type: Sharp
   - type: Sprite
     sprite: Objects/Weapons/Melee/spear.rsi
+    noRot: false
     layers:
     - state: spear
     - state: spear1

--- a/Resources/Prototypes/_ES/Entities/Structures/Storage/display_case.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Storage/display_case.yml
@@ -7,6 +7,7 @@
   components:
   - type: Sprite
     sprite: _ES/Structures/Storage/display_case.rsi
+    noRot: true
     layers:
     - state: light
       color: "#fff5"

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/camera.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/camera.yml
@@ -1,0 +1,6 @@
+- type: entity
+  id: ESFlippedCameraVariation
+  parent: BaseVariationPass
+  components:
+  - type: ESRotatedCameraGameRule
+    angle: 180

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/camera.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/camera.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: ESFlippedCameraVariation
+  id: ESMirrorModeVariation
   parent: BaseVariationPass
   components:
   - type: ESRotatedCameraGameRule

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/maplight_parallax.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/Visual/maplight_parallax.yml
@@ -116,7 +116,7 @@
       - all:
         - id: ESVariationMaplightDarkVoidSpace
         - id: ESVariationParallaxEmptiness
-        weight: 1
+        weight: 3
       - all:
         - id: ESVariationMaplightDefault
         - id: ESVariationParallaxDefault
@@ -141,7 +141,7 @@
       # maplights
       - group:
         - id: ESVariationMaplightDefault
-          weight: 7
+          weight: 5
         - id: ESVariationMaplightBrightSpace
           weight: 2
         - id: ESVariationMaplightDarkVoidSpace
@@ -155,14 +155,15 @@
       # parallaxes
       - group:
         - id: ESVariationParallaxDefault
-          weight: 9
+          weight: 7
         - id: ESVariationParallaxNoStars
           weight: 3
         - id: ESVariationParallaxEmptiness
+          weight: 3
         - group:
           - id: ESVariationParallaxBlue
           - id: ESVariationParallaxRed
           - id: ESVariationParallaxYellow
           - id: ESVariationParallaxPurple
-          weight: 2
+          weight: 4
       weight: 1

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
@@ -21,5 +21,5 @@
       - tableId: ESMaplightParallaxVariationTable
       - id: ESNightshiftVariationPass
         prob: 0.10
-      - id: ESFlippedCameraVariation
+      - id: ESMirrorModeVariation
         prob: 1

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
@@ -22,4 +22,4 @@
       - id: ESNightshiftVariationPass
         prob: 0.10
       - id: ESMirrorModeVariation
-        prob: 1
+        prob: 0.10

--- a/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
+++ b/Resources/Prototypes/_ES/GameRules/StationVariation/rules_table.yml
@@ -21,3 +21,5 @@
       - tableId: ESMaplightParallaxVariationTable
       - id: ESNightshiftVariationPass
         prob: 0.10
+      - id: ESFlippedCameraVariation
+        prob: 1

--- a/Resources/ServerInfo/_ES/Guidebook/NewPlayer/Controls.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/NewPlayer/Controls.xml
@@ -166,10 +166,5 @@
   Click [color=yellow][bold][keybind="SaveItemLocation"][/bold][/color] on an item inside a container to [color=cyan]save[/color] its position, so it always goes back to that position when stored.
   View saved positions by [color=yellow][bold]hovering[/bold][/color] over items.
 
-  ## Camera
-  [color=cyan]Zoom[/color] the camera with [color=yellow][bold][keybind="ZoomIn"][/bold][/color] and [color=yellow][bold][keybind="ZoomOut"][/bold][/color] and reset with [color=yellow][bold][keybind="ResetZoom"][/bold][/color].
-  \n[color=cyan]Rotate[/color] it with [color=yellow][bold][keybind="CameraRotateLeft"][/bold][/color] and [color=yellow][bold][keybind="CameraRotateRight"][/bold][/color] and reset with [color=yellow][bold][keybind="CameraReset"][/bold][/color].
-  \n[italic]Note: maps are generally designed to be played with the default camera rotation.[/italic]
-
   For more details about controls, you can refer to the [color=cyan]Wiki[/color].
 </Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

10% (will probably lower later once it gets seen) chance for the map to spawn completely flipped

surprising amount of effort to fix things to work with this, interaction particles were brokey by accident with camera rotation which i think was my fault

had to spritecomp `noRot` items since its something we want anyway and the only real blocker on it was the throwing animation which i converted to use an actual sprite animation instead of physics impulse

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->


https://github.com/user-attachments/assets/05495579-e02d-4e9e-a38d-be1bf3ac7e09



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: A very very very very very scary flipped mirrored reality may enter this world with a 10% chance.
- tweak: Camera rotation binds no longer rotate the camera