### PR TITLE
Miasma fixes of various nature

### DIFF
--- a/Content.Server/_ES/Filth/Components/ESMiasmaGeneratorRuleComponent.cs
+++ b/Content.Server/_ES/Filth/Components/ESMiasmaGeneratorRuleComponent.cs
@@ -1,6 +1,4 @@
-using Content.Shared._ES.Core.Timer.Components;
 using Content.Shared.EntityTable.EntitySelectors;
-using Robust.Shared.Map;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server._ES.Filth.Components;
@@ -21,15 +19,4 @@ public sealed partial class ESMiasmaGeneratorRuleComponent : Component
 
     [DataField]
     public int TilesPerEvent = 100;
-}
-
-public sealed partial class ESMiasmaSpawnTimerEvent : ESEntityTimerEvent
-{
-    [DataField]
-    public EntityCoordinates Coordinates;
-
-    public ESMiasmaSpawnTimerEvent(EntityCoordinates coordinates)
-    {
-        Coordinates = coordinates;
-    }
 }

--- a/Content.Server/_ES/Filth/ESMiasmaGeneratorRule.cs
+++ b/Content.Server/_ES/Filth/ESMiasmaGeneratorRule.cs
@@ -3,7 +3,6 @@ using Content.Server._ES.SpawnRegion;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.GameTicking.Rules;
 using Content.Server.Station.Systems;
-using Content.Shared._ES.Core.Timer;
 using Content.Shared.Atmos;
 using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
@@ -21,28 +20,9 @@ public sealed partial class ESMiasmaGeneratorRule : GameRuleSystem<ESMiasmaGener
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private EntityTableSystem _entityTable = default!;
-    [Dependency] private ESEntityTimerSystem _entityTimer = default!;
     [Dependency] private MapSystem _map = default!;
     [Dependency] private ESSpawnRegionSystem _spawnRegion = default!;
     [Dependency] private StationSystem _station = default!;
-
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<ESMiasmaGeneratorRuleComponent, ESMiasmaSpawnTimerEvent>(OnSpawnTimer);
-    }
-
-    private void OnSpawnTimer(Entity<ESMiasmaGeneratorRuleComponent> ent, ref ESMiasmaSpawnTimerEvent args)
-    {
-        if (!args.Coordinates.IsValid(EntityManager))
-            return;
-
-        foreach (var spawn in _entityTable.GetSpawns(ent.Comp.SpawnTable))
-        {
-            SpawnAtPosition(spawn, args.Coordinates);
-        }
-    }
 
     protected override void Added(EntityUid uid,
         ESMiasmaGeneratorRuleComponent component,
@@ -67,13 +47,14 @@ public sealed partial class ESMiasmaGeneratorRule : GameRuleSystem<ESMiasmaGener
                 if (!_spawnRegion.TryGetRandomCoords(
                         validCoords,
                         out var coords,
+                        minPlayerDistance: 4f,
                         checkPlayerLOS: false))
                     break;
 
-                _entityTimer.SpawnTimer(
-                    uid,
-                    _random.Next(TimeSpan.Zero, component.UpdateRate),
-                    new ESMiasmaSpawnTimerEvent(coords.Value));
+                foreach (var spawn in _entityTable.GetSpawns(component.SpawnTable))
+                {
+                    SpawnAtPosition(spawn, coords.Value);
+                }
             }
         }
     }

--- a/Content.Shared/_ES/Filth/Components/ESDiseaseCloudComponent.cs
+++ b/Content.Shared/_ES/Filth/Components/ESDiseaseCloudComponent.cs
@@ -11,5 +11,5 @@ public sealed partial class ESDiseaseCloudComponent : Component
     public DamageSpecifier DiseaseDamage = new();
 
     [DataField]
-    public SoundSpecifier? DiseaseSound = new SoundCollectionSpecifier("BoxingHit");
+    public SoundSpecifier? DiseaseSound = new SoundCollectionSpecifier("GenericHit");
 }

--- a/Content.Shared/_ES/Filth/Components/ESMiasmaSourceComponent.cs
+++ b/Content.Shared/_ES/Filth/Components/ESMiasmaSourceComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._ES.Filth.Components;
 public sealed partial class ESMiasmaSourceComponent : Component
 {
     [DataField]
-    public float MolPerSecond = 0.02f;
+    public float MolPerSecond = 0.06f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan NextUpdate;

--- a/Content.Shared/_ES/Filth/ESDiseaseCloudSystem.cs
+++ b/Content.Shared/_ES/Filth/ESDiseaseCloudSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.Medical;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
@@ -17,11 +18,12 @@ public sealed partial class ESDiseaseCloudSystem : EntitySystem
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private InventorySystem _inventory = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private VomitSystem _vomit = default!;
 
     // TODO: make this the disease susceptible component once we support that
-    [Dependency] private EntityQuery<MobStateComponent> _mobState;
+    [Dependency] private EntityQuery<MobStateComponent> _mobStateQuery;
 
     private readonly List<string> _protectionSlots = new() { "head", "outerClothing" };
 
@@ -37,7 +39,7 @@ public sealed partial class ESDiseaseCloudSystem : EntitySystem
         if (_net.IsClient)
             return;
 
-        if (!args.OtherFixture.Hard || !_mobState.HasComp(args.OtherEntity))
+        if (!args.OtherFixture.Hard || !_mobStateQuery.TryComp(args.OtherEntity, out var mob) || !_mobState.IsAlive(args.OtherEntity, mob))
             return;
 
         if (TerminatingOrDeleted(ent) || EntityManager.IsQueuedForDeletion(ent))
@@ -46,7 +48,7 @@ public sealed partial class ESDiseaseCloudSystem : EntitySystem
         if (!HasProtection(args.OtherEntity))
         {
             _damageable.TryChangeDamage(args.OtherEntity, ent.Comp.DiseaseDamage, true);
-            _vomit.Vomit(args.OtherEntity, hungerAdded: -2);
+            _vomit.Vomit(args.OtherEntity);
             _popup.PopupEntity(Loc.GetString("es-disease-cloud-hit", ("entity", args.OtherEntity)), args.OtherEntity, PopupType.MediumCaution);
         }
         else

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -64,7 +64,7 @@
       60: 0.7
       80: 0.5
   - type: ESMiasmaSource
-    molPerSecond: 0.005 # 1/4 base rate
+    molPerSecond: 0.015 # 1/4 base rate
 
 - type: entity
   parent:

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -15,7 +15,7 @@
   standsout: true
   physicalDesc: reagent-physical-desc-ferrous
   puddleGas:
-    Miasma: 0.00001
+    Miasma: 0.0002
   metabolisms:
     Drink:
       effects:
@@ -76,7 +76,7 @@
   color: "#87ab08"
   physicalDesc: reagent-physical-desc-pungent
   puddleGas:
-    Miasma: 0.00005
+    Miasma: 0.001
   slipData:
     requiredSlipSpeed: 4.0 #It's not as slippery as water
   friction: 0.4

--- a/Resources/Prototypes/_ES/Entities/Mobs/NPC/miasma.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/NPC/miasma.yml
@@ -49,7 +49,7 @@
   - type: ESDiseaseCloud
     diseaseDamage:
       types:
-        Poison: 2.5
+        Poison: 7.5
   - type: MovementSpeedModifier
     baseAcceleration: 3.5
     friction: 0.75

--- a/Resources/Prototypes/_ES/Entities/Mobs/NPC/miasma.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/NPC/miasma.yml
@@ -14,17 +14,24 @@
   - type: Input
     context: "human"
   - type: Physics
-    bodyType: Kinematic
+    bodyType: KinematicController
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeCircle
+          radius: 0.45
+        density: 50
+        mask:
+        - MobMask
+        layer:
+        - MobLayer
+      smacker:
+        shape:
+          !type:PhysShapeCircle
           radius: 0.35
         density: 50
         hard: false
-        mask:
-        - Impassable
         layer:
         - Impassable
   - type: InputMover
@@ -38,19 +45,20 @@
         0.1
   - type: NpcFactionMember
     factions:
-    - AllHostile
+    - SimpleHostile
   - type: ESDiseaseCloud
     diseaseDamage:
       types:
-        Poison: 10
+        Poison: 2.5
   - type: MovementSpeedModifier
     baseAcceleration: 3.5
-    baseSprintSpeed : 5
+    friction: 0.75
+    baseSprintSpeed : 4
   - type: NoSlip
   - type: MovementAlwaysTouching
   - type: CanMoveInAir
-  #- type: ESTimedDespawn
-  #  lifetime: 15.0
+  - type: ESTimedDespawn
+    lifetime: 10.0
   - type: ESTimedDespawnSpriteFade
     fadeTime: 1.0
   - type: ESTimedDespawnLightFade

--- a/Resources/Prototypes/_ES/Entities/Mobs/NPC/miasma.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/NPC/miasma.yml
@@ -69,3 +69,4 @@
     falloff: 40
     color: "#eec7ff"
     castShadows: false
+  - type: ESViewconeOccludable

--- a/Resources/Prototypes/_ES/GameRules/miasma.yml
+++ b/Resources/Prototypes/_ES/GameRules/miasma.yml
@@ -3,10 +3,11 @@
   parent: BaseGameRule
   components:
   - type: ESMiasmaGeneratorRule
+    tilesPerEvent: 200
     spawnTable:
       group:
       - id: ESMobMiasmaCloud
-        weight: 95
+        weight: 97.5
       - group:
         - id: MobCockroach
           weight: 4
@@ -14,4 +15,4 @@
           - id: MobMouse
           - id: MobMouse1
           - id: MobMouse2
-        weight: 5
+        weight: 2.5


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2266 
Closes #2255 
Closes #2256 

changes:
- live tweaks from playtest to miasma spawn rate and pest odds
- stop delaying cloud spawns cuz it fucks up the distance checks in spawn region
- better hit sound for clouds (WHAT WERE THEY THNKINGN)
- unpunishify vomiting as much
- stop hitting dead animals
- stop chasing animals
- stop clouds clipping through walls
- stop clouds from being literally impossible to dodge
- 3x miasma generation for mobs
- 20x miasma generation for puddles

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Adjusted miasma clouds and pests to spawn less frequently.
- tweak: Made miasma clouds easier to dodge and circle around.
- fix: Fixed issues where miasma clouds would go through walls, chase down random animals, and beat on dead pests.
- tweak: Greatly increased the amount of miasma created from bodies, blood, and vomit.
