### PR TITLE
We're killing assistants

### DIFF
--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -309,7 +309,18 @@ public sealed partial class StationJobsSystem
             foreach (var station in givenStations)
             {
                 if (stationJobs[station].Count == 0)
-                    continue;
+                {
+                    var overflows = GetOverflowJobs(station).ToList();
+
+                    // Stations with no overflow slots should simply get skipped over.
+                    if (overflows.Count == 0)
+                        continue;
+
+                    // If the overflow exists, put them in as it.
+                    assignedJobs.Add(player, (_random.Pick(overflows), station));
+                    break;
+                }
+
                 var job = _random.PickAndTake(stationJobs[station]);
 
                 // If the overflow exists, put them in as it.

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -282,6 +282,20 @@ public sealed partial class StationJobsSystem
         var givenStations = stations.ToList();
         if (givenStations.Count == 0)
             return; // Don't attempt to assign them if there are no stations.
+
+        // nasty linq statement but i just want a list for every pickable job on station.
+        var stationJobs = stations
+            .Select(s =>
+            {
+                var comp = Comp<StationJobsComponent>(s);
+                var jobs = comp.JobList.Where(p => p.Value.HasValue)
+                    .SelectMany(pair => Enumerable.Repeat(pair.Key, pair.Value!.Value))
+                    .ToList();
+
+                return (s, jobs);
+            })
+            .ToDictionary();
+
         // For players without jobs, give them the overflow job if they have that set...
         foreach (var player in allPlayersToAssign)
         {
@@ -290,27 +304,16 @@ public sealed partial class StationJobsSystem
                 continue;
             }
 
-            var profile = profiles[player];
-            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow)
-            {
-                assignedJobs.Add(player, (null, EntityUid.Invalid));
-                continue;
-            }
-
             _random.Shuffle(givenStations);
 
             foreach (var station in givenStations)
             {
-                // Pick a random overflow job from that station
-                var overflows = GetOverflowJobs(station).ToList();
-                _random.Shuffle(overflows);
-
-                // Stations with no overflow slots should simply get skipped over.
-                if (overflows.Count == 0)
+                if (stationJobs[station].Count == 0)
                     continue;
+                var job = _random.PickAndTake(stationJobs[station]);
 
                 // If the overflow exists, put them in as it.
-                assignedJobs.Add(player, (overflows[0], givenStations[0]));
+                assignedJobs.Add(player, (job, station));
                 break;
             }
         }

--- a/Content.Server/Station/Systems/StationJobsSystem.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.cs
@@ -46,7 +46,7 @@ public sealed partial class StationJobsSystem : EntitySystem
             .Sum();
 
         ent.Comp.OverflowJobs = ent.Comp.SetupAvailableJobs
-            .Where(x => x.Value[0] < 0)
+            .Where(x => x.Value[0] < 0 || x.Value[1] < 0)
             .Select(x => x.Key)
             .ToHashSet();
     }

--- a/Content.Server/_ES/Station/ESStationSystem.cs
+++ b/Content.Server/_ES/Station/ESStationSystem.cs
@@ -213,9 +213,6 @@ public sealed partial class ESStationSystem : ESSharedStationSystem
                 {
                     var count = counts[0];
 
-                    if (count == 0)
-                        continue;
-
                     if (!_availableRoundstartJobs.TryGetValue(job, out var value))
                         value = 0;
                     _availableRoundstartJobs[job] = value + count;

--- a/Resources/Prototypes/_ES/Maps/toast.yml
+++ b/Resources/Prototypes/_ES/Maps/toast.yml
@@ -35,7 +35,7 @@
           #other (2+)
           ESClown: [ 1, 1 ]
           ESReporter: [ 1, 1 ]
-          ESAssistant: [ -1, -1 ]
           ESBartender: [ 1, 1 ]
           ESChef: [ 1, 1 ]
           ESRatman: [ 1, 0 ] # not latejoinable
+          ESAssistant: [ 0, -1 ] # not rollable round start


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2273 

- Removes roundstart assistant slots from toast
- Make failing to roll a selected job randomly assign you to a job

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Failing to roll one of your preferred jobs will now assign you to a random job instead of always defaulting to assistant.