### PR TITLE
marauder changes round 2

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/spray_painter.yml
@@ -17,19 +17,15 @@
         type: SprayPainterBoundUserInterface
   - type: SprayPainter
     colorPalette:
-      red: '#FF1212FF'
-      yellow: '#B3A234FF'
-      brown: '#947507FF'
-      green: '#3AB334FF'
-      cyan: '#03FCD3FF'
-      blue: '#0335FCFF'
-      white: '#FFFFFFFF'
-      black: '#333333FF'
-      # standard atmos pipes
-      waste: '#990000'
-      distro: '#0055cc'
-      air: '#03fcd3'
-      mix: '#947507'
+      red: '#FF1212'
+      yellow: '#B3A234'
+      brown: '#947507'
+      green: '#3AB334'
+      cyan: '#03fCD3'
+      blue: '#0055CC'
+      white: '#FFFFFF'
+      black: '#333333'
+      crimson: '#990000'
   - type: LimitedCharges
     maxCharges: 15
     lastCharges: 15

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -66,9 +66,8 @@
     all:
     - id: ESWeaponRevolver357
     - id: ESSpeedLoader357
-    - id: ESDoorJammer
-      amount: 2
-    - id: ESClothingOuterArmorSecurity
+    - id: ESWeaponKnife
+    - id: StimulantPen
 
 # Subverter
 - type: entity

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -64,8 +64,9 @@
   id: ESTraitorCacheMarauder
   table:
     all:
-    - id: EnergySword
-    - id: StimulantPen
+    - id: ESWeaponRevolver357
+    - id: ESSpeedLoader357
+    - id: ESDoorJammer
       amount: 2
     - id: ESClothingOuterArmorSecurity
 

--- a/Resources/Prototypes/_ES/Catalog/Tables/traitor.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/traitor.yml
@@ -24,14 +24,12 @@
       weight: 0.5
     - id: SleepyPen
       weight: 0.5
-    - id: StimulantPen
+    - id: StimulantPen # currently unused but its a fun item anyways. so it can stay here
       weight: 0.5
     - id: C4
       weight: 0.5
     - id: ExGrenade
       weight: 0.5
-    - id: EnergySword
-      weight: 0.1
     - group:
       - id: ESWeaponRevolver357
       - id: ESWeaponPistol9mm

--- a/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Assassin.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Assassin.xml
@@ -15,7 +15,7 @@
     </Box>
 
 ### Silenced 9mm Handgun
-    A run-of-the-mill pistol with a silencer on it. While a lot quieter then a non-silenced guns, it still makes a good bit of noise when hitting players, so be careful!
+    A run-of-the-mill pistol with a silencer on it. While a lot quieter then a non-silenced gun, it still makes a good bit of noise when hitting players, so be careful!
 
 ### Knockout Medipen
     Injects 10 units of chloral hydrate and 5 units of mute toxin in to the target, making them slow, unable to speak, and drowsy enough to fall asleep after about 18 seconds.

--- a/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Infiltrator.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Infiltrator.xml
@@ -2,7 +2,7 @@
 # Infiltrator
     <ESGuideSecretIdentityEmbed SecretIdentity="Infiltrator"/>
 
-    Infiltrators are a critical member of the team with a kit meant for breaking and entering, usually to steal valuable items or sabotage machines.
+    Infiltrators are a critical member of the team with a kit meant to facilitate easy breaking-and-entering, perfect for reaching difficult-to-get items or machines that need to be sabotaged.
 
 
 ## Tools of the Trade
@@ -15,13 +15,14 @@
     </Box>
 
 ### EMAG
-    Can be used to open any airlock or locker, damaging them in the process and bolting open airlocks.
+    Can be used to open any airlock or locker, damaging them in the process and bolting open airlocks. It only has a few uses, so make sure to make them count!
 
 ### C4
     Blows up whatever is on the tile it's on, and not much else. Great for breaching, but not that good at damaging players. Must be planted to arm; cannot be manually activated like other explosives.
 
 ### Chameleon Kit
-    Special clothing that can change its appearance to look like almost any other piece of clothing. Don't forget that the bag is also a part of the kit, too.
+    Special clothing that can change its appearance to look like almost any other piece of clothing. Useful for losing heat after taking suspicious actions.
+	Don't forget that the bag is also a part of the kit, too!
 
     <ESGuideTipsEmbed SecretIdentity="Infiltrator"/>
 </Document>

--- a/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Marauder.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Marauder.xml
@@ -2,27 +2,26 @@
 # Marauder
     <ESGuideSecretIdentityEmbed SecretIdentity="Marauder"/>
 
-    Marauders are a heavy-hitting force-of-nature, and the strongest traitor mask in terms of direct attack power. Their kit makes them highly effective in combat.
+    Marauders are a heavy-hitting force-of-nature, and the strongest traitor mask in terms of direct attack power. Their kit makes them highly effective at more up-front assassinations.
 
 ## Tools of the Trade
-    Their cache contains an energy sword, two stimulant medipens, and an armor vest.
+    Their cache contains a .357 revolver, a spare .357 speedloader, two door jammers, and an armor vest.
 
     <Box>
-        <GuideEntityEmbed Entity="EnergySword"/>
-        <GuideEntityEmbed Entity="StimulantPen"/>
+        <GuideEntityEmbed Entity="ESWeaponRevolver357"/>
+        <GuideEntityEmbed Entity="ESSpeedLoader357"/>
+        <GuideEntityEmbed Entity="ESDoorJammer"/>
         <GuideEntityEmbed Entity="ESClothingOuterArmorSecurity"/>
     </Box>
 
-### Energy Sword
-    A top-of-the-line melee weapon with a blade made of pure plasma. It's concealable and does enough damage on hit to break in to structures like lockers and crates. Be careful when using it, as it makes an incredibly loud and distinctive sound.
+### .357 Revolver
+    One of the best ranged weapons around due to its small size and high damage that cleaves through armor. Thanks to this weapon, Marauders are particularly good at direct fire towards armored targets.
 
-### Stimulant Medipen
-    A one-time-use medipen that increases your movement speed, along with suppressing pain & cleansing any chloral hydrate from your system. It's best used mid-combat, as it flushes out of your system quickly.
-
-	<GuideReagentEmbed Reagent="Stimulants"/>
+### Door Jammer
+    When thrown at a door, causes it to be bolted until the door jammer is removed. Perfect for locking targets in a room and preventing their escape, or stopping persuers.
 
 ### Armor Vest
-	Helps mitigate some of the damage you're inevitably going to be taking by engaging in melee combat. Be mindful that armor is rare, so wearing it is often suspicious.
+	Helps mitigate some of the damage you're inevitably going to be taking by engaging in loud combat. Be mindful that armor is rare, so wearing it is often suspicious.
 
     <ESGuideTipsEmbed SecretIdentity="Marauder"/>
 </Document>

--- a/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Marauder.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Marauder.xml
@@ -5,23 +5,25 @@
     Marauders are a heavy-hitting force-of-nature, and the strongest traitor mask in terms of direct attack power. Their kit makes them highly effective at more up-front assassinations.
 
 ## Tools of the Trade
-    Their cache contains a .357 revolver, a spare .357 speedloader, two door jammers, and an armor vest.
+    Their cache contains a .357 revolver, a spare .357 speedloader, a knife, and a stimulant medipen.
 
     <Box>
         <GuideEntityEmbed Entity="ESWeaponRevolver357"/>
         <GuideEntityEmbed Entity="ESSpeedLoader357"/>
-        <GuideEntityEmbed Entity="ESDoorJammer"/>
-        <GuideEntityEmbed Entity="ESClothingOuterArmorSecurity"/>
+        <GuideEntityEmbed Entity="ESWeaponKnife"/>
+        <GuideEntityEmbed Entity="StimulantPen"/>
     </Box>
 
 ### .357 Revolver
     One of the best ranged weapons around due to its small size and high damage that cleaves through armor. Thanks to this weapon, Marauders are particularly good at direct fire towards armored targets.
 
-### Door Jammer
-    When thrown at a door, causes it to be bolted until the door jammer is removed. Perfect for locking targets in a room and preventing their escape, or stopping persuers.
+### Knife
+    A fantastic tool for killing people who are in its range without needing to waste ammo. It's particularly useful at being able to speed up the death of downed targets.
 
-### Armor Vest
-	Helps mitigate some of the damage you're inevitably going to be taking by engaging in loud combat. Be mindful that armor is rare, so wearing it is often suspicious.
+### Stimulant Medipen
+    A one-time-use medipen that increases your movement speed, along with suppressing pain & cleansing any chloral hydrate from your system. It's best used mid-combat, as it flushes out of your system quickly.
+
+	<GuideReagentEmbed Reagent="Stimulants"/>
 
     <ESGuideTipsEmbed SecretIdentity="Marauder"/>
 </Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
the marauder kit no longer has the esword. they have their revolver and again ammo but instead of the grenade and knife they get 2 door jammers. hopefully this makes them more interesting to play like the traitor other masks

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The marauder kit has been reverted to the previous version. They now also get two door jammers instead of a knife and grenade, now.
