### PR TITLE
minor audio tweaks

### DIFF
--- a/Content.Client/_ES/Audio/ESAudioOverrideSystem.cs
+++ b/Content.Client/_ES/Audio/ESAudioOverrideSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Shared._ES.Audio;
 using Robust.Client;
 using Robust.Client.Audio;
 using Robust.Shared;
@@ -27,6 +28,10 @@ public sealed partial class ESAudioOverrideSystem : EntitySystem
     [Dependency] private IBaseClient _baseClient = default!;
 
     private ProtoId<AudioPresetPrototype> _reverbPreset = "Room";
+
+    private const float OccludedSoundAmount = 1f;
+    private const float OcclusionVolumeAdjust = -6.5f;
+    private const float MinOcclusionPenetration = 0.8f;
 
     // ReSharper disable once InconsistentNaming
     // for vv testing purposes
@@ -87,6 +92,8 @@ public sealed partial class ESAudioOverrideSystem : EntitySystem
             component.Started = true;
             component.StartPlaying();
         }
+
+        component.Velocity = Vector2.Zero;
 
         // If it's global but on another map (that isn't nullspace) then stop playing it.
         if (component.Global)
@@ -158,6 +165,11 @@ public sealed partial class ESAudioOverrideSystem : EntitySystem
         {
             var occlusion = GetOcclusion(listener, delta, distance, parentUid);
             component.Occlusion = occlusion;
+            if (component.Occlusion > 0f)
+            {
+                component.Volume = component.Params.Volume + OcclusionVolumeAdjust;
+                Log.Info($"occlusion set vol to {component.Volume}");
+            }
         }
 
         // Update audio positions.
@@ -169,15 +181,13 @@ public sealed partial class ESAudioOverrideSystem : EntitySystem
     /// </summary>
     public float GetOcclusion(MapCoordinates listener, Vector2 delta, float distance, EntityUid? ignoredEnt = null)
     {
-        float occlusion = 0;
+        if (distance <= 0.1)
+            return 0f;
 
-        if (distance > 0.1)
-        {
-            var rayLength = MathF.Min(distance, _maxRayLength);
-            var ray = new CollisionRay(listener.Position, delta / distance, _originalAudio.OcclusionCollisionMask);
-            occlusion = _physics.IntersectRayPenetration(listener.MapId, ray, rayLength, ignoredEnt);
-        }
+        var rayLength = MathF.Min(distance, _maxRayLength);
+        var ray = new CollisionRay(listener.Position, delta / distance, _originalAudio.OcclusionCollisionMask);
+        var penetration = _physics.IntersectRayPenetration(listener.MapId, ray, rayLength, ignoredEnt);
 
-        return occlusion;
+        return penetration < MinOcclusionPenetration ? 0f : OccludedSoundAmount;
     }
 }

--- a/Content.Client/_ES/Audio/ESAudioOverrideSystem.cs
+++ b/Content.Client/_ES/Audio/ESAudioOverrideSystem.cs
@@ -168,7 +168,6 @@ public sealed partial class ESAudioOverrideSystem : EntitySystem
             if (component.Occlusion > 0f)
             {
                 component.Volume = component.Params.Volume + OcclusionVolumeAdjust;
-                Log.Info($"occlusion set vol to {component.Volume}");
             }
         }
 

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._ES.Audio;
 using Content.Shared.Climbing.Events;
 using Content.Shared.GameTicking;
 using Content.Shared.Hands.Components;
@@ -6,6 +7,7 @@ using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Rotation;
+using Robust.Shared.Audio.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
@@ -126,24 +128,7 @@ public sealed partial class StandingStateSystem : EntitySystem
         // Change collision masks to allow going under certain entities like flaps and tables
         ChangeLayers((uid, standingState));
 
-        // check if component was just added or streamed to client
-        // if true, no need to play sound - mob was down before player could seen that
-        if (standingState.LifeStage <= ComponentLifeStage.Starting)
-            return true;
-
-        if (playSound)
-        {
-            // ES START
-            // yeah sorry. i dont really think theres any better way to do this without kind of making the flow of events unparsable
-            // and opening us up to weird ordering issues eventually
-            // at least this is easy to understand (this is to make it not THUD after sleeping everyone roundstart)
-            if (_timing.CurTime < (_ticker.RoundStartTimeSpan + TimeSpan.FromSeconds(5)))
-                return true;
-            // ES END
-
-            _audio.PlayPredicted(standingState.DownSound, uid, uid);
-        }
-
+        // Fuck this stupid ass sound
         return true;
     }
 

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESSharedSecretIdentityCacheSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESSharedSecretIdentityCacheSystem.cs
@@ -138,7 +138,7 @@ public abstract partial class ESSharedSecretIdentityCacheSystem : EntitySystem
         var cache = PredictedSpawnAtPosition(ent.Comp.CacheLoot, pos);
         PredictedQueueDel(ent);
         _popup.PopupEntity(Loc.GetString("es-ceiling-cache-popup"), ent);
-        _audio.PlayPredicted(ent.Comp.RevealSound, pos, user);
+        _audio.PlayPredicted(ent.Comp.RevealSound, pos, user, ent.Comp.RevealSound?.Params.WithMaxDistance(1.5f).WithVolume(-3f));
 
         if (ent.Comp.MindId.HasValue)
         {


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

occlusion no longer scales based on ray pen
instead its just constnat + also lowers volume so its more obvious when a sound is occluded

cache spawner sound is now way shorter distance yo could hear taht shti thru walls and its a miracle no one abused that i think

had more tweaks but opted not to go for it. also want to turn off reverb if a sound is occluded

removed standing state down sound. i dont car anymore. i think it was playing b4 because it would load in before the client actually got the new round start time from the server and idk i dont car

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Occluded sounds are now quieter and more consistent
- tweak: Removed standing state down sound (no more roundstart thunk spam)
