### PR TITLE
Fix subverter chips not having an announcement

### DIFF
--- a/Content.Client/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Client/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._ES.Stagehand;
+
+namespace Content.Client._ES.Stagehand;
+
+public sealed class ESStagehandNotificationsSystem : ESSharedStagehandNotificationsSystem;

--- a/Content.Server/_ES/SecretIdentity/ESSecretIdentitySystem.cs
+++ b/Content.Server/_ES/SecretIdentity/ESSecretIdentitySystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Station.Systems;
 using Content.Shared._ES.Auditions.Components;
 using Content.Shared._ES.SecretIdentity;
 using Content.Shared._ES.SecretIdentity.Components;
+using Content.Shared._ES.Stagehand;
 using Content.Shared.Chat;
 using Content.Shared.EntityTable;
 using Content.Shared.GameTicking;
@@ -335,7 +336,7 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
         }
         ApplySecretIdentity(mind, secretIdentityId, organization);
 
-        if (mind.Comp.OwnedEntity is { } owned)
+        if (!eraseHistory && mind.Comp.OwnedEntity is { } owned)
         {
             var msg = Loc.GetString("es-stagehand-notification-secret-identity-change",
                 ("player", _stagehandNotifications.WrapEntityName(owned)),

--- a/Content.Server/_ES/SecretIdentity/Tragedian/ESCallStagehandsActionSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Tragedian/ESCallStagehandsActionSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server._ES.Stagehand;
 using Content.Shared._ES.SecretIdentity.Tragedian;
+using Content.Shared._ES.Stagehand;
 using Content.Shared._ES.Stagehand.Components;
 using Content.Shared.Follower;
 

--- a/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
+++ b/Content.Server/_ES/Stagehand/ESStagehandNotificationsSystem.cs
@@ -1,15 +1,12 @@
 using Content.Server.Chat.Managers;
-using Content.Server.Mind;
 using Content.Shared._ES.KillTracking.Components;
 using Content.Shared._ES.Objectives;
 using Content.Shared._ES.Objectives.Components;
+using Content.Shared._ES.Stagehand;
 using Content.Shared._ES.Stagehand.Components;
 using Content.Shared.Chat;
 using Content.Shared.Mind;
-using Content.Shared.Mind.Components;
 using JetBrains.Annotations;
-using Robust.Server.Player;
-using Robust.Shared.GameObjects.Components.Localization;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 
@@ -18,12 +15,10 @@ namespace Content.Server._ES.Stagehand;
 /// <summary>
 ///     Handles sending stagehand notifications for various non-stagehand events ingame: objective completions, deaths, etc.
 /// </summary>
-public sealed partial class ESStagehandNotificationsSystem : EntitySystem
+public sealed partial class ESStagehandNotificationsSystem : ESSharedStagehandNotificationsSystem
 {
     [Dependency] private ESSharedObjectiveSystem _objectives = default!;
     [Dependency] private IChatManager _chat = default!;
-    [Dependency] private IPlayerManager _player = default!;
-    [Dependency] private MindSystem _mind = default!;
 
     public override void Initialize()
     {
@@ -35,7 +30,7 @@ public sealed partial class ESStagehandNotificationsSystem : EntitySystem
 
     private void OnKillReported(ref ESPlayerKilledEvent ev)
     {
-        if (!_mind.TryGetMind(ev.Killed, out _))
+        if (!Mind.TryGetMind(ev.Killed, out _))
             return;
 
         string? msg = null;
@@ -102,79 +97,12 @@ public sealed partial class ESStagehandNotificationsSystem : EntitySystem
     }
 
     /// <summary>
-    /// Version of <see cref="WrapEntityNameWithUsername"/> that formats relevant IC info into a name without giving a username.
-    /// </summary>
-    /// <remarks>
-    /// Use when displaying an entity name but without the context of the username.
-    /// </remarks>
-    public string WrapEntityName(Entity<MindContainerComponent?> entity)
-    {
-        // Default case: basic entities display their entity name
-        if (!Resolve(entity, ref entity.Comp, false) ||
-            !_mind.TryGetMind(entity, out var mind, entity))
-        {
-            return Name(entity);
-        }
-
-        var entityName = Name(entity);
-        var characterName = mind.Value.Comp.CharacterName ?? string.Empty;
-
-        // If our name matches our body, just display the simple name.
-        if (entityName.Equals(characterName, StringComparison.InvariantCulture))
-        {
-            return entityName;
-        }
-
-        if (TryComp<GrammarComponent>(entity, out var grammar) && grammar.ProperNoun == true)
-        {
-            return Loc.GetString("es-stagehand-notification-wrap-entity-body-player-swap",
-                ("character", characterName),
-                ("body", entityName));
-        }
-
-        return Loc.GetString("es-stagehand-notification-wrap-entity-body-mob-swap",
-            ("character", characterName),
-            ("body", entityName));
-    }
-
-    /// <summary>
-    ///     Returns a string formatted like "entity name (players username)", for use in passing to <see cref="SendStagehandNotification"/>.
-    /// </summary>
-    /// <remarks>
-    ///     You should **not** use this for all instances where an entity is mentioned.
-    ///     Only reveal player usernames when they are dead, or about to die.
-    /// </remarks>
-    public string WrapEntityNameWithUsername(Entity<ActorComponent?> entity)
-    {
-        string? username;
-        if (Resolve(entity, ref entity.Comp, false))
-        {
-            username = entity.Comp.PlayerSession.Name;
-        }
-        // try to get session from their mind
-        else if (_mind.TryGetMind(entity, out var mind)
-            && mind.Value.Comp.UserId is { } id
-            && _player.TryGetPlayerData(id, out var sess))
-        {
-            username = sess.UserName;
-        }
-        else
-        {
-            return WrapEntityName(entity.Owner);
-        }
-
-        return Loc.GetString("es-stagehand-notification-wrap-entity-username",
-            ("entity", WrapEntityName(entity.Owner)),
-            ("username", username));
-    }
-
-    /// <summary>
     ///     Sends a notification message to all currently active stagehands, formatted correctly.
     /// </summary>
     /// <param name="msg">An already-resolved string to use as the message.</param>
     /// <param name="severity">The severity of this notification, defaulting to medium (regular size)</param>
     [PublicAPI]
-    public void SendStagehandNotification(string msg, ESStagehandNotificationSeverity severity = ESStagehandNotificationSeverity.Medium)
+    public override void SendStagehandNotification(string msg, ESStagehandNotificationSeverity severity = ESStagehandNotificationSeverity.Medium)
     {
         var stagehands = new List<INetChannel>();
         var query = EntityQueryEnumerator<ESStagehandComponent, ActorComponent>();
@@ -193,14 +121,4 @@ public sealed partial class ESStagehandNotificationsSystem : EntitySystem
         var wrappedMsg = Loc.GetString(locId, ("message", msg));
         _chat.ChatMessageToMany(ChatChannel.Server, msg, wrappedMsg, default, false, true, stagehands, Color.Plum);
     }
-}
-
-/// <summary>
-///     Determines the font size and styling of the message sent to stagehands.
-/// </summary>
-public enum ESStagehandNotificationSeverity : byte
-{
-    Low,
-    Medium,
-    High
 }

--- a/Content.Shared/_ES/SecretIdentity/Cycle/ESActionChangeSecretIdentitySystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Cycle/ESActionChangeSecretIdentitySystem.cs
@@ -24,8 +24,7 @@ public sealed partial class ESActionChangeSecretIdentitySystem : EntitySystem
         if (!_mind.TryGetMind(args.Performer, out var mind, out var mindComp))
             return;
 
-        _secretIdentity.RemoveSecretIdentity((mind, mindComp));
-        _secretIdentity.ApplySecretIdentity((mind, mindComp), args.SecretIdentity);
+        _secretIdentity.ChangeSecretIdentity((mind, mindComp), args.SecretIdentity);
 
         args.Handled = true;
     }

--- a/Content.Shared/_ES/SecretIdentity/Traitor/Components/ESAddSecretIdentityOnUseComponent.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/Components/ESAddSecretIdentityOnUseComponent.cs
@@ -41,6 +41,9 @@ public sealed partial class ESAddSecretIdentityOnUseComponent : Component
     public ProtoId<ESSecretIdentityPrototype> SecretIdentityToAdd;
 
     [DataField]
+    public LocId StagehandNotification = "es-subverter-chip-announcement";
+
+    [DataField]
     public LocId UsedMessage = "es-subverter-chip-used";
 
     [DataField]

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESAddSecretIdentityOnUseSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESAddSecretIdentityOnUseSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Shared._ES.SecretIdentity.Traitor.Components;
 using Content.Shared._ES.SecretIdentity.Traitor.Events;
+using Content.Shared._ES.Stagehand;
 using Content.Shared._Offbrand.Wounds;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration.Systems;
@@ -23,6 +24,7 @@ public sealed partial class ESAddSecretIdentityOnUseSystem : EntitySystem
     [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private RejuvenateSystem _rejuv = default!;
     [Dependency] private HealthRankingSystem _health = default!;
+    [Dependency] private ESSharedStagehandNotificationsSystem _stagehandNotifications = default!;
 
     public override void Initialize()
     {
@@ -98,8 +100,13 @@ public sealed partial class ESAddSecretIdentityOnUseSystem : EntitySystem
         if (_secretIdentity.GetOrganizationOrNull((mind, mindComponent)) == toAddOrganization)
             return;
 
-        _secretIdentity.RemoveSecretIdentity((mind, mindComponent));
-        _secretIdentity.ApplySecretIdentity((mind, mindComponent), ent.Comp.SecretIdentityToAdd);
+        var msg = Loc.GetString(ent.Comp.StagehandNotification,
+            ("player", _stagehandNotifications.WrapEntityName(args.User)),
+            ("item", ent.Owner),
+            ("target", _stagehandNotifications.WrapEntityName(target)));
+
+        _stagehandNotifications.SendStagehandNotification(msg);
+        _secretIdentity.ChangeSecretIdentity((mind, mindComponent), ent.Comp.SecretIdentityToAdd);
 
         ent.Comp.Used = true;
         Dirty(ent);

--- a/Content.Shared/_ES/Stagehand/ESSharedStagehandNotificationsSystem.cs
+++ b/Content.Shared/_ES/Stagehand/ESSharedStagehandNotificationsSystem.cs
@@ -1,0 +1,97 @@
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Robust.Shared.GameObjects.Components.Localization;
+using Robust.Shared.Player;
+
+namespace Content.Shared._ES.Stagehand;
+
+public abstract partial class ESSharedStagehandNotificationsSystem : EntitySystem
+{
+    [Dependency] private ISharedPlayerManager _player = default!;
+    [Dependency] protected SharedMindSystem Mind = default!;
+
+    /// <summary>
+    /// Version of <see cref="WrapEntityNameWithUsername"/> that formats relevant IC info into a name without giving a username.
+    /// </summary>
+    /// <remarks>
+    /// Use when displaying an entity name but without the context of the username.
+    /// </remarks>
+    public string WrapEntityName(Entity<MindContainerComponent?> entity)
+    {
+        // Default case: basic entities display their entity name
+        if (!Resolve(entity, ref entity.Comp, false) ||
+            !Mind.TryGetMind(entity, out var mind, entity))
+        {
+            return Name(entity);
+        }
+
+        var entityName = Name(entity);
+        var characterName = mind.Value.Comp.CharacterName ?? string.Empty;
+
+        // If our name matches our body, just display the simple name.
+        if (entityName.Equals(characterName, StringComparison.InvariantCulture))
+        {
+            return entityName;
+        }
+
+        if (TryComp<GrammarComponent>(entity, out var grammar) && grammar.ProperNoun == true)
+        {
+            return Loc.GetString("es-stagehand-notification-wrap-entity-body-player-swap",
+                ("character", characterName),
+                ("body", entityName));
+        }
+
+        return Loc.GetString("es-stagehand-notification-wrap-entity-body-mob-swap",
+            ("character", characterName),
+            ("body", entityName));
+    }
+
+    /// <summary>
+    ///     Returns a string formatted like "entity name (players username)", for use in passing to <see cref="SendStagehandNotification"/>.
+    /// </summary>
+    /// <remarks>
+    ///     You should **not** use this for all instances where an entity is mentioned.
+    ///     Only reveal player usernames when they are dead, or about to die.
+    /// </remarks>
+    public string WrapEntityNameWithUsername(Entity<ActorComponent?> entity)
+    {
+        string? username;
+        if (Resolve(entity, ref entity.Comp, false))
+        {
+            username = entity.Comp.PlayerSession.Name;
+        }
+        // try to get session from their mind
+        else if (Mind.TryGetMind(entity, out var mind)
+            && mind.Value.Comp.UserId is { } id
+            && _player.TryGetPlayerData(id, out var sess))
+        {
+            username = sess.UserName;
+        }
+        else
+        {
+            return WrapEntityName(entity.Owner);
+        }
+
+        return Loc.GetString("es-stagehand-notification-wrap-entity-username",
+            ("entity", WrapEntityName(entity.Owner)),
+            ("username", username));
+    }
+
+    public virtual void SendStagehandNotification(
+        string msg,
+        ESStagehandNotificationSeverity severity = ESStagehandNotificationSeverity.Medium)
+    {
+
+    }
+
+}
+
+/// <summary>
+///     Determines the font size and styling of the message sent to stagehands.
+/// </summary>
+public enum ESStagehandNotificationSeverity : byte
+{
+    Low,
+    Medium,
+    High
+}

--- a/Resources/Locale/en-US/_ES/secret-identities/traitor/subverter.ftl
+++ b/Resources/Locale/en-US/_ES/secret-identities/traitor/subverter.ftl
@@ -1,5 +1,6 @@
 ﻿es-subverter-chip-used = It's already been used!
-es-subverter-chip-implanting = Implanting subversion chip!
+es-subverter-chip-implanting = Implanting subversion chip!\
+es-subverter-chip-announcement = {$player} used {INDEFINITE($item)} {$item} on {$target}.
 es-subverter-chip-examined-usable = [color=green]This chip has not been used.[/color]
 es-subverter-chip-examined-used = [color=red]This chip has been used![/color]
 es-subverter-chip-not-crit = Target aware!

--- a/Resources/Locale/en-US/_ES/secret-identities/traitor/subverter.ftl
+++ b/Resources/Locale/en-US/_ES/secret-identities/traitor/subverter.ftl
@@ -1,5 +1,5 @@
 ﻿es-subverter-chip-used = It's already been used!
-es-subverter-chip-implanting = Implanting subversion chip!\
+es-subverter-chip-implanting = Implanting subversion chip!
 es-subverter-chip-announcement = {$player} used {INDEFINITE($item)} {$item} on {$target}.
 es-subverter-chip-examined-usable = [color=green]This chip has not been used.[/color]
 es-subverter-chip-examined-used = [color=red]This chip has been used![/color]


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2268 

catching this during a round was lowkey a miracle

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="864" height="128" alt="image" src="https://github.com/user-attachments/assets/08898f7a-7930-4e28-ab1c-7b2c3502888f" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Stagehands are now notified when a subverter chip is used.
