### PR TITLE
degradation event nerf

### DIFF
--- a/Resources/Prototypes/_ES/GameRules/degradation_events.yml
+++ b/Resources/Prototypes/_ES/GameRules/degradation_events.yml
@@ -8,7 +8,7 @@
     earliestStart: 0
     reoccurrenceDelay: 0
     occursDuringRoundEnd: false
-    weight: 10
+    weight: 3
 
 - type: entityTable
   id: ESDegradationEvents
@@ -89,8 +89,6 @@
   - type: ESDegradationEvent
     component: ESRadioScrambler
     degradeImmediately: true # Doesn't react to anything
-  - type: StationEvent
-    weight: 20
 
 - type: entity
   parent: ESBaseDegradationEvent


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
traitor degredation events are now very rare (in theory.) this is untested but hopefully should work

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Traitor-related degradation events are now much rarer