### PR TITLE
End tragedian votes before round end

### DIFF
--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -547,6 +547,9 @@ namespace Content.Server.GameTicking
             // Log end of round
             _adminLogger.Add(LogType.EmergencyShuttle, LogImpact.High, $"Round ended, showing summary");
 
+            var beforeEv = new ESBeforeRoundEndEvent();
+            RaiseLocalEvent(ref beforeEv);
+
             //Tell every client the round has ended.
             var gamemodeTitle = CurrentPreset != null ? Loc.GetString(CurrentPreset.ModeTitle) : string.Empty;
 
@@ -1042,6 +1045,12 @@ namespace Content.Server.GameTicking
             Forced = forced;
         }
     }
+
+    /// <summary>
+    /// Raised before all other round-end logic
+    /// </summary>
+    [ByRefEvent]
+    public readonly record struct ESBeforeRoundEndEvent;
 
     /// <summary>
     ///     Event raised to allow subscribers to add text to the round end summary screen.

--- a/Content.Server/_ES/Voting/ESVoteSystem.cs
+++ b/Content.Server/_ES/Voting/ESVoteSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
+using Content.Server.GameTicking;
 using Content.Shared._ES.Voting;
 using Content.Shared._ES.Voting.Components;
 using Content.Shared.Administration;
@@ -26,6 +27,7 @@ public sealed partial class ESVoteSystem : ESSharedVoteSystem
         base.Initialize();
 
         SubscribeLocalEvent<GameRuleComponent, ESSynchronizedVotesPostCompletedEvent>(OnPostCompleted);
+        SubscribeLocalEvent<ESBeforeRoundEndEvent>(OnBeforeRoundEnd);
     }
 
     private void OnPostCompleted(Entity<GameRuleComponent> ent, ref ESSynchronizedVotesPostCompletedEvent args)
@@ -35,6 +37,20 @@ public sealed partial class ESVoteSystem : ESSharedVoteSystem
         Comp<GameRuleComponent>(ent).Added = true;
         var ev = new GameRuleAddedEvent(ent, Prototype(ent)!.ID);
         RaiseLocalEvent(ent, ref ev, true);
+    }
+
+    private void OnBeforeRoundEnd(ref ESBeforeRoundEndEvent ev)
+    {
+        var votes = new List<Entity<ESVoteComponent>>();
+        foreach (var ent in EntityQueryEnumerator<ESEndBeforeRoundEndVoteComponent, ESVoteComponent>())
+        {
+            votes.Add((ent, ent.Comp2));
+        }
+
+        foreach (var vote in votes)
+        {
+            EndVote(vote);
+        }
     }
 
     protected override void SendVoteStartAnnouncement(Entity<ESVoteComponent> ent)

--- a/Content.Shared/_ES/Voting/Components/ESEndBeforeRoundEndVoteComponent.cs
+++ b/Content.Shared/_ES/Voting/Components/ESEndBeforeRoundEndVoteComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._ES.Voting.Components;
+
+[RegisterComponent]
+public sealed partial class ESEndBeforeRoundEndVoteComponent : Component;

--- a/Resources/Prototypes/_ES/Objectives/Crew/tragedian.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/tragedian.yml
@@ -34,3 +34,4 @@
     strategy: HighestValue
     multiVote: false
   - type: ESBooleanVote
+  - type: ESEndBeforeRoundEndVote


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2293 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Tragedian votes now end early if they would otherwise end after the end of the round.