### PR TITLE
Cryohusk fixes

### DIFF
--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Actions;
 using Content.Server.Humanoid;
 using Content.Server.Inventory;
 using Content.Server.Polymorph.Components;
+using Content.Shared._Offbrand.Wounds;
 using Content.Shared.Buckle;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage.Components;
@@ -31,6 +32,7 @@ public sealed partial class PolymorphSystem : EntitySystem
     [Dependency] private IGameTiming _gameTiming = default!;
     [Dependency] private ActionsSystem _actions = default!;
     [Dependency] private AudioSystem _audio = default!;
+    [Dependency] private BrainDamageSystem _brainDamage = default!;
     [Dependency] private SharedBuckleSystem _buckle = default!;
     [Dependency] private ContainerSystem _container = default!;
     [Dependency] private DamageableSystem _damageable = default!;
@@ -167,10 +169,11 @@ public sealed partial class PolymorphSystem : EntitySystem
     /// </summary>
     /// <param name="uid">The entity that will be transformed</param>
     /// <param name="protoId">The id of the polymorph prototype</param>
-    public EntityUid? PolymorphEntity(EntityUid uid, ProtoId<PolymorphPrototype> protoId)
+    /// <param name="transferDamageOverride">Overrides damage transfer on the config</param>
+    public EntityUid? PolymorphEntity(EntityUid uid, ProtoId<PolymorphPrototype> protoId, bool? transferDamageOverride = null)
     {
         var config = _proto.Index(protoId).Configuration;
-        return PolymorphEntity(uid, config);
+        return PolymorphEntity(uid, config, transferDamageOverride);
     }
 
     /// <summary>
@@ -178,8 +181,9 @@ public sealed partial class PolymorphSystem : EntitySystem
     /// </summary>
     /// <param name="uid">The entity that will be transformed</param>
     /// <param name="configuration">The new polymorph configuration</param>
+    /// <param name="transferDamageOverride">Overrides damage transfer on the config</param>
     /// <returns>The new entity, or null if the polymorph failed.</returns>
-    public EntityUid? PolymorphEntity(EntityUid uid, PolymorphConfiguration configuration)
+    public EntityUid? PolymorphEntity(EntityUid uid, PolymorphConfiguration configuration, bool? transferDamageOverride = null)
     {
         // If they're morphed, check their current config to see if they can be
         // morphed again
@@ -218,15 +222,6 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (_container.TryGetContainingContainer((uid, targetTransformComp, null), out var cont))
             _container.Insert(child, cont);
 
-        //Transfers all damage from the original to the new one
-        if (configuration.TransferDamage &&
-            TryComp<DamageableComponent>(child, out var damageParent) &&
-            _mobThreshold.GetScaledDamage(uid, child, out var damage) &&
-            damage != null)
-        {
-            _damageable.SetDamage((child, damageParent), damage);
-        }
-
         if (configuration.Inventory == PolymorphInventoryChange.Transfer)
         {
             _inventory.TransferEntityInventories(uid, child);
@@ -260,10 +255,26 @@ public sealed partial class PolymorphSystem : EntitySystem
             _humanoid.CloneAppearance(uid, child);
         }
 
+        _identity.QueueIdentityUpdate(child, doNow: true);
+
+        //Transfers all damage from the original to the new one
+        if (transferDamageOverride ?? configuration.TransferDamage)
+        {
+            if (TryComp<DamageableComponent>(child, out var damageParent) &&
+                _mobThreshold.GetScaledDamage(uid, child, out var damage) &&
+                damage != null)
+            {
+                _damageable.SetDamage((child, damageParent), damage);
+            }
+
+            if (_mobState.IsDead(uid))
+            {
+                _brainDamage.KillBrain(child);
+            }
+        }
+
         if (_mindSystem.TryGetMind(uid, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, child, mind: mind);
-
-        _identity.QueueIdentityUpdate(child, doNow: true);
 
         if (configuration.PolymorphPopup != null)
         {

--- a/Content.Server/_ES/Cryohusk/ESCryohuskSystem.cs
+++ b/Content.Server/_ES/Cryohusk/ESCryohuskSystem.cs
@@ -7,7 +7,6 @@ using Content.Server.Polymorph.Systems;
 using Content.Shared._ES.Cryohusk;
 using Content.Shared._ES.Cryohusk.Components;
 using Content.Shared._ES.Stagehand;
-using Content.Shared._Offbrand.Wounds;
 using Content.Shared.Access.Components;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration;
@@ -29,7 +28,6 @@ public sealed partial class ESCryohuskSystem : ESSharedCryohuskSystem
     [Dependency] private ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private AudioSystem _audio = default!;
-    [Dependency] private BrainDamageSystem _brainDamage = default!;
     [Dependency] private ContainerSystem _container = default!;
     [Dependency] private MindSystem _mind = default!;
     [Dependency] private MobStateSystem _mobState = default!;
@@ -56,15 +54,7 @@ public sealed partial class ESCryohuskSystem : ESSharedCryohuskSystem
         if (!Resolve(target, ref target.Comp))
             return;
 
-        if (_mind.TryGetMind(target, out var mind))
-        {
-            foreach (var objective in _objective.GetObjectives<ESCryohuskObjectiveComponent>(mind.Value.Owner))
-            {
-                _objective.AdjustObjectiveCounter(objective.Owner);
-            }
-        }
-
-        if (_polymorph.PolymorphEntity(target, target.Comp.CryohuskPolymorph) is not { } husk)
+        if (_polymorph.PolymorphEntity(target, target.Comp.CryohuskPolymorph, transferDamageOverride: transferDeath) is not { } husk)
             return;
 
         foreach (var uid in GetRecursiveContainedEntities(husk))
@@ -73,16 +63,19 @@ public sealed partial class ESCryohuskSystem : ESSharedCryohuskSystem
                 EnsureComp<ESCryohuskIdCardComponent>(uid);
         }
 
-        if (_mobState.IsDead(target) && transferDeath)
+        if (_mind.TryGetMind(husk, out var mind))
         {
-            _brainDamage.KillBrain(husk);
-        }
+            if (!_mobState.IsDead(target) || !transferDeath)
+            {
+                var msg = Loc.GetString("es-cryohusk-convert-stagehand-notif",
+                    ("player", _stagehandNotifications.WrapEntityName(target.Owner)));
+                _stagehandNotifications.SendStagehandNotification(msg);
+            }
 
-        if (_mind.TryGetMind(target, out _) && !_mobState.IsDead(target))
-        {
-            var msg = Loc.GetString("es-cryohusk-convert-stagehand-notif",
-                ("player", _stagehandNotifications.WrapEntityName(target.Owner)));
-            _stagehandNotifications.SendStagehandNotification(msg);
+            foreach (var objective in _objective.GetObjectives<ESCryohuskObjectiveComponent>(mind.Value.Owner))
+            {
+                _objective.AdjustObjectiveCounter(objective.Owner);
+            }
         }
 
         _audio.PlayPvs(target.Comp.FreezeSound, husk);

--- a/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
+++ b/Content.Server/_ES/Mind/ESAutoGhostSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._ES.Mind;
 using Content.Shared._ES.Viewcone.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Gibbing;
+using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
@@ -83,11 +84,11 @@ public sealed partial class ESAutoGhostSystem : EntitySystem
     private void AutoGhost(EntityUid uid)
     {
         // Don't ghost the brainless.
-        if (!_mind.TryGetMind(uid, out _, out _))
+        if (!_mind.TryGetMind(uid, out var mind))
             return;
 
-        var ev = new AutoGhostAttemptEvent(uid);
-        RaiseLocalEvent(uid, ref ev, true);
+        var ev = new AutoGhostAttemptEvent(uid, mind.Value);
+        RaiseLocalEvent(mind.Value, ref ev, true);
         if (ev.Cancelled)
             return;
 
@@ -106,4 +107,4 @@ public sealed partial class ESAutoGhostSystem : EntitySystem
 ///     Raised directed and broadcast to check if autoghost + the death cutscene should happen.
 /// </summary>
 [ByRefEvent]
-public record struct AutoGhostAttemptEvent(EntityUid User, bool Cancelled = false);
+public record struct AutoGhostAttemptEvent(EntityUid User, Entity<MindComponent> Mind, bool Cancelled = false);

--- a/Content.Server/_ES/SecretIdentity/Cyrojunkie/ESCryoJunkieSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Cyrojunkie/ESCryoJunkieSystem.cs
@@ -1,6 +1,6 @@
 ﻿using Content.Server._ES.Cryohusk;
+using Content.Server._ES.Mind;
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.Ghost;
 using Content.Shared._ES.Core.Timer;
 using Content.Shared._ES.SecretIdentity.Cyrojunkie.Components;
 using Content.Shared.Atmos;
@@ -16,7 +16,7 @@ public sealed partial class ESCryoJunkieSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<ESCryoJunkieMindComponent, GhostAttemptHandleEvent>(OnGhostAttempt);
+        SubscribeLocalEvent<ESCryoJunkieMindComponent, AutoGhostAttemptEvent>(OnGhostAttempt);
         SubscribeLocalEvent<MindContainerComponent, ESCyroJunkieTimerEvent>(OnCyroJunkieTimer);
     }
 
@@ -28,16 +28,14 @@ public sealed partial class ESCryoJunkieSystem : EntitySystem
         _cryo.Cryohusk(ent.Owner, transferDeath: false);
     }
 
-    private void OnGhostAttempt(Entity<ESCryoJunkieMindComponent> ent, ref GhostAttemptHandleEvent args)
+    private void OnGhostAttempt(Entity<ESCryoJunkieMindComponent> ent, ref AutoGhostAttemptEvent args)
     {
         if (args.Mind.Comp.CurrentEntity == null)
             return;
 
         _entityTimer.SpawnTimer((EntityUid)args.Mind.Comp.CurrentEntity, ent.Comp.HuskDelay, new ESCyroJunkieTimerEvent());
 
-        args.Result = true;
-        args.Handled = true;
-
+        args.Cancelled = true;
         RemComp(ent, ent.Comp);
     }
 }

--- a/Content.Server/_ES/SecretIdentity/Phantom/ESReincarnateSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Phantom/ESReincarnateSystem.cs
@@ -1,7 +1,7 @@
 using System.Linq;
+using Content.Server._ES.Mind;
 using Content.Server._ES.Objectives;
 using Content.Server.GameTicking;
-using Content.Server.Ghost;
 using Content.Server.Mind;
 using Content.Shared._ES.Auditions.Components;
 using Content.Shared._ES.SecretIdentity.Phantom.Components;
@@ -21,10 +21,10 @@ public sealed partial class ESReincarnateSystem : EntitySystem
     /// <inheritdoc/>
     public override void Initialize()
     {
-        SubscribeLocalEvent<ESReincarnateMindComponent, GhostAttemptHandleEvent>(OnGhostAttempt);
+        SubscribeLocalEvent<ESReincarnateMindComponent, AutoGhostAttemptEvent>(OnGhostAttempt);
     }
 
-    private void OnGhostAttempt(Entity<ESReincarnateMindComponent> ent, ref GhostAttemptHandleEvent args)
+    private void OnGhostAttempt(Entity<ESReincarnateMindComponent> ent, ref AutoGhostAttemptEvent args)
     {
         if (!TryComp<MindComponent>(ent, out var mindComp) ||
             !TryComp<ESCharacterComponent>(ent, out var character))
@@ -48,9 +48,8 @@ public sealed partial class ESReincarnateSystem : EntitySystem
         var ghost = SpawnAtPosition(ent.Comp.ReincarnateEntity, coords);
         _metaData.SetEntityName(ghost, Loc.GetString(ent.Comp.Name, ("name", character.Name)));
         _mind.TransferTo(ent, ghost, createGhost: false, mind: mindComp);
-        args.Result = true;
-        args.Handled = true;
 
+        args.Cancelled = true;
         RemCompDeferred(ent, ent.Comp);
     }
 }

--- a/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Crew/Cryojunkie.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Crew/Cryojunkie.xml
@@ -8,13 +8,13 @@
     <ESGuideObjectiveEmbed Objective="ESObjectiveCryohusk"/>
   </Box>
 
-  Once they die, they'll turn into a cryohusk with a burst of cryogas after a 30-second delay.
+  30 seconds after they die, they'll transform into a cryohusk accompanied by a large burst of cryogas (potentially creating even more cryohusks).
 
   <Box>
     <GuideEntityEmbed Entity="ESMobCryohusk" Caption="cryohusk"/>
   </Box>
 
-  Be careful at this point, since another death will not lead to another revival.
+  After this, another death will be final and they will not revive again.
 
   <ESGuideTipsEmbed SecretIdentity="Cryojunkie"/>
 </Document>


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2320 
Closes #2316 
Closes #2313 

fixes cryohusk announcements generally just not working and being weird.

also fixes mask abilities that happen after death happening after the death anim

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Living bodies and cryojunkies now create stagehand announcements.
- fix: Dead bodies getting cryohusked no longer plays death announcements to stagehands.
- fix: Phantoms and Cryojunkies no longer play the death animation before doing their behavior.
