### PR TITLE
Cannibal Fixes

### DIFF
--- a/Content.Server/_ES/Coroner/ESCoronerSystem.cs
+++ b/Content.Server/_ES/Coroner/ESCoronerSystem.cs
@@ -1,10 +1,10 @@
 using System.Linq;
+using Content.Server._ES.SecretIdentity;
 using Content.Server.GameTicking;
 using Content.Server.Mind;
 using Content.Shared._ES.Auditions;
 using Content.Shared._ES.Coroner;
 using Content.Shared._ES.SecretIdentity;
-using Content.Shared._ES.SecretIdentity.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Robust.Shared.ColorNaming;
@@ -23,6 +23,7 @@ public sealed partial class ESCoronerSystem : ESSharedCoronerSystem
     [Dependency] private ESCluesSystem _clues = default!;
     [Dependency] private GameTicker _gameTicker = default!;
     [Dependency] private MindSystem _mind = default!;
+    [Dependency] private ESSecretIdentitySystem _secretIdentity = default!;
 
     protected override FormattedMessage GetReport(EntityUid target)
     {
@@ -43,9 +44,11 @@ public sealed partial class ESCoronerSystem : ESSharedCoronerSystem
             timeOfDeath = mind.TimeOfDeath.Value;
         var time = (timeOfDeath - _gameTicker.RoundStartTimeSpan).ToString("hh\\:mm\\:ss");
 
-        var secretIdentity = TryComp<ESBodyLastSecretIdentityComponent>(target, out var bodyLastSecretIdentity)
-            ? _prototype.Index(bodyLastSecretIdentity.LastSecretIdentity)
-            : _random.Pick(_prototype.EnumeratePrototypes<ESSecretIdentityPrototype>().Where(p => !p.Abstract).ToList());
+        var secretIdentity = _random.Pick(_prototype.EnumeratePrototypes<ESSecretIdentityPrototype>()
+            .Where(p => !p.Abstract)
+            .ToList());
+        if (_secretIdentity.TryGetLastSecretIdentity(target, out var bodyLastSecretIDentity))
+            secretIdentity = _prototype.Index(bodyLastSecretIDentity.Value);
 
         msg.AddMarkupPermissive(Loc.GetString("es-coroner-report-paper",
             ("name", name),

--- a/Content.Shared/_ES/SecretIdentity/Cannibal/ESCannibalSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Cannibal/ESCannibalSystem.cs
@@ -41,11 +41,15 @@ public sealed partial class ESCannibalSystem : EntitySystem
 
     private void OnCannibalizeTargetAction(ESCannibalizeTargetActionEvent args)
     {
+        // Can't predict due to needing to check for secret identities and whatnot
+        if (_net.IsClient)
+            return;
+
         if (args.Performer == args.Target)
             return;
 
         if (!_mind.TryGetMind(args.Performer, out _) ||
-            _mind.GetMind(args.Target) is null || // We use this check since getting the mind fails on client due to infosec.
+            !_secretIdentity.TryGetLastSecretIdentity(args.Target, out _) ||
             !HasComp<ESCryohuskableComponent> (args.Target))
         {
             _popup.PopupEntity(Loc.GetString("es-cannibal-popup-invalid"), args.Performer, args.Performer);
@@ -58,10 +62,7 @@ public sealed partial class ESCannibalSystem : EntitySystem
             return;
         }
 
-        EntityUid? sound = null;
-
-        if (_net.IsServer)
-            sound = _audio.PlayPvs(EatSound, args.Performer)?.Entity;
+        var sound = _audio.PlayPvs(EatSound, args.Performer)?.Entity;
 
         args.Handled = _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager,
             args.Performer,
@@ -90,7 +91,6 @@ public sealed partial class ESCannibalSystem : EntitySystem
         }
 
         if (!_mind.TryGetMind(args.User, out var mind) ||
-            _mind.GetMind(target) is null ||
             !HasComp<ESCryohuskableComponent> (target))
         {
             return;

--- a/Content.Shared/_ES/SecretIdentity/Cannibal/ESCannibalSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Cannibal/ESCannibalSystem.cs
@@ -45,7 +45,7 @@ public sealed partial class ESCannibalSystem : EntitySystem
             return;
 
         if (!_mind.TryGetMind(args.Performer, out _) ||
-            !_mind.TryGetMind(args.Target, out _) ||
+            _mind.GetMind(args.Target) is null || // We use this check since getting the mind fails on client due to infosec.
             !HasComp<ESCryohuskableComponent> (args.Target))
         {
             _popup.PopupEntity(Loc.GetString("es-cannibal-popup-invalid"), args.Performer, args.Performer);
@@ -90,8 +90,7 @@ public sealed partial class ESCannibalSystem : EntitySystem
         }
 
         if (!_mind.TryGetMind(args.User, out var mind) ||
-            !_mind.TryGetMind(target, out var targetMind) ||
-            !_secretIdentity.TryGetSecretIdentity(targetMind.Value.AsNullable(), out var secretIdentity) ||
+            _mind.GetMind(target) is null ||
             !HasComp<ESCryohuskableComponent> (target))
         {
             return;
@@ -102,7 +101,13 @@ public sealed partial class ESCannibalSystem : EntitySystem
             ("other", _stagehandNotifications.WrapEntityName(target)));
         _stagehandNotifications.SendStagehandNotification(msg);
 
-        _secretIdentity.ChangeSecretIdentity(mind.Value, secretIdentity.Value);
+        // This happens separately with tolerance due to this check failing
+        // on the client due to the S.I. not being networked.
+        if (_secretIdentity.TryGetLastSecretIdentity(target, out var secretIdentity))
+        {
+            _secretIdentity.ChangeSecretIdentity(mind.Value, secretIdentity.Value);
+        }
+
         _hunger.ModifySatiety(args.User, 4); // feeling full :-)
         _cryohusk.Cryohusk(target);
     }

--- a/Content.Shared/_ES/SecretIdentity/Components/ESBodyLastSecretIdentityComponent.cs
+++ b/Content.Shared/_ES/SecretIdentity/Components/ESBodyLastSecretIdentityComponent.cs
@@ -7,12 +7,12 @@ namespace Content.Shared._ES.SecretIdentity.Components;
 /// If a mind with a secret identity inhabits a body, this component will be updated to store that information.
 /// </summary>
 [RegisterComponent]
-[Access(typeof(ESSharedSecretIdentitySystem))]
+[Access(typeof(ESSharedSecretIdentitySystem), Other = AccessPermissions.None)]
 public sealed partial class ESBodyLastSecretIdentityComponent : Component
 {
     /// <summary>
     /// The last secret identity that this body had.
     /// </summary>
     [DataField]
-    public ProtoId<ESSecretIdentityPrototype> LastSecretIdentity;
+    public ProtoId<ESSecretIdentityPrototype>? LastSecretIdentity;
 }

--- a/Content.Shared/_ES/SecretIdentity/ESSharedSecretIdentitySystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/ESSharedSecretIdentitySystem.cs
@@ -218,6 +218,23 @@ public abstract partial class ESSharedSecretIdentitySystem : EntitySystem
     }
 
     /// <summary>
+    /// Variant of <see cref="TryGetSecretIdentity(EntityUid, out ProtoId{ESSecretIdentityPrototype}?)"/> that does not involve the mind.
+    /// So in situations like a phantom where the mind has left the body, this will still return the correct result.
+    /// </summary>
+    /// <remarks>
+    /// Will never return a secret identity for the client.
+    /// </remarks>
+    public bool TryGetLastSecretIdentity(Entity<ESBodyLastSecretIdentityComponent?> ent, [NotNullWhen(true)] out ProtoId<ESSecretIdentityPrototype>? prototype)
+    {
+        prototype = null;
+        if (!Resolve(ent, ref ent.Comp, false))
+            return false;
+
+        prototype = ent.Comp.LastSecretIdentity;
+        return prototype is not null;
+    }
+
+    /// <summary>
     /// Helper version of <see cref="TryGetSecretIdentity(Robust.Shared.GameObjects.EntityUid,out Robust.Shared.Prototypes.ProtoId{Content.Shared._ES.SecretIdentity.ESSecretIdentityPrototype}?)"/> that returns the organization.
     /// </summary>
     public bool TryGetOrganization(EntityUid uid, [NotNullWhen(true)] out ProtoId<ESOrganizationPrototype>? organization)
@@ -364,7 +381,10 @@ public abstract partial class ESSharedSecretIdentitySystem : EntitySystem
 
         foreach (var entity in _lookup.GetEntitiesInRange<ESBodyLastSecretIdentityComponent>(_xform.GetMapCoordinates(ent, xform), range))
         {
-            var secretIdentity = PrototypeManager.Index(entity.Comp.LastSecretIdentity);
+            if (!TryGetLastSecretIdentity(entity.AsNullable(), out var secretIdentityId))
+                continue;
+
+            var secretIdentity = PrototypeManager.Index(secretIdentityId);
             var organization = secretIdentity.Organization;
 
             if (ent.Comp.NonHostileOrganizations != null && ent.Comp.NonHostileOrganizations.Contains(organization))

--- a/Content.Shared/_ES/Trigger/Systems/ESChangeSecretIdentityOnTriggerSystem.cs
+++ b/Content.Shared/_ES/Trigger/Systems/ESChangeSecretIdentityOnTriggerSystem.cs
@@ -1,15 +1,12 @@
 ﻿using Content.Shared._ES.SecretIdentity;
-using Content.Shared._ES.SecretIdentity.Components;
 using Content.Shared._ES.Trigger.Component;
 using Content.Shared.Mind;
 using Content.Shared.Trigger;
-using Robust.Shared.Prototypes;
 
 namespace Content.Shared._ES.Trigger.Systems;
 
 public sealed partial class ESChangeSecretIdentityOnTriggerSystem : XOnTriggerSystem<ESChangeSecretIdentityOnTriggerComponent>
 {
-    [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private ESSharedSecretIdentitySystem _secretIdentity = default!;
     [Dependency] private SharedMindSystem _mind = default!;
 
@@ -23,13 +20,7 @@ public sealed partial class ESChangeSecretIdentityOnTriggerSystem : XOnTriggerSy
 
         if (!ent.Comp.SameOrganizationConversion)
         {
-            if (!TryComp<ESBodyLastSecretIdentityComponent>(args.User, out var secretIdentity))
-                return;
-
-            var secretIdentityPrototype = _prototype.Index(ent.Comp.SecretIdentity);
-            var lastSecretIdentityPrototype = _prototype.Index(secretIdentity.LastSecretIdentity);
-
-            if (secretIdentityPrototype.Organization == lastSecretIdentityPrototype.Organization)
+            if (_secretIdentity.GetSecretIdentityOrNull(mind.Value.AsNullable()) == ent.Comp.SecretIdentity)
                 return;
         }
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2318 

- Fixes cannibal popups mispredicting due to mind network shenanigans
- Allows cannibals to eat phantom corpses and other previously-mind-having entities
- updates last body S.I. code for more modern preferences of mine

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed mispredicting popup when cannibals would try and eat a body.
- tweak: Cannibals can now eat the dead bodies of Phantoms in order to copy their secret identity.
