### PR TITLE
Halve Arms Dealer Caches

### DIFF
--- a/Resources/Prototypes/_ES/Objectives/Crew/arms_dealer.yml
+++ b/Resources/Prototypes/_ES/Objectives/Crew/arms_dealer.yml
@@ -12,5 +12,5 @@
   - type: ESHoldSummonableObjective
   - type: ESCounterObjective
     title: es-arms-dealer-objective-title
-    target: 5
-    maxTarget: 8
+    target: 2
+    maxTarget: 4

--- a/Resources/Prototypes/_ES/SecretIdentities/crew.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/crew.yml
@@ -13,7 +13,7 @@
   - type: ESSecretIdentityCacheSpawner
     cacheProto:
       id: ESCrateCacheCrewArmsDealer
-      amount: 6
+      amount: 3
 
 - type: esSecretIdentity
   id: Arsonist


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
resolves #2352

caches 6 -> 3
objective goal 6-8 -> 2-4

didn't feel like making the new objective so just did this instead

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Arms Dealer has less caches and by extension, half as many guns
