### PR TITLE
Very small fire nerfs

### DIFF
--- a/Content.Shared/Atmos/Components/FlammableComponent.cs
+++ b/Content.Shared/Atmos/Components/FlammableComponent.cs
@@ -145,7 +145,7 @@ namespace Content.Shared.Atmos.Components
         ///     How much smoke will be created through this entity burning.
         /// </summary>
         [DataField]
-        public float SmokeMolsReleasedPerStack = 0.01f;
+        public float SmokeMolsReleasedPerStack = 0.006f;
 
         /// <summary>
         ///     Multiplier on fire energy released into the atmosphere.

--- a/Content.Shared/_ES/Sparks/ESSparksSystem.cs
+++ b/Content.Shared/_ES/Sparks/ESSparksSystem.cs
@@ -117,6 +117,6 @@ public sealed partial class ESSparksSystem : EntitySystem
         }
 
         if (_random.Prob(tileFireChance))
-            _tileFire.TryDoTileFire(coordinates, user, _random.Next(1, 4));
+            _tileFire.TryDoTileFire(coordinates, user, _random.Next(1, 2));
     }
 }

--- a/Content.Shared/_ES/Sparks/ESSparksSystem.cs
+++ b/Content.Shared/_ES/Sparks/ESSparksSystem.cs
@@ -117,6 +117,6 @@ public sealed partial class ESSparksSystem : EntitySystem
         }
 
         if (_random.Prob(tileFireChance))
-            _tileFire.TryDoTileFire(coordinates, user, _random.Next(1, 2));
+            _tileFire.TryDoTileFire(coordinates, user, _random.Next(1, 3));
     }
 }

--- a/Resources/Prototypes/_ES/Entities/Effects/tile_fires.yml
+++ b/Resources/Prototypes/_ES/Entities/Effects/tile_fires.yml
@@ -38,7 +38,7 @@
     sprintSpeedModifier: 0.8
   - type: Flammable
     firestacksOnIgnite: 0.0
-    firestackFade: 0.32
+    firestackFade: 0.24
     onFire: true
     fireStacks: 3
     minimumFireStacks: 0

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -142,7 +142,7 @@
 # ES START
   fireChance: 0.8
   minFireLevel: 1
-  maxFireLevel: 3
+  maxFireLevel: 2
   fireSpread: true
 # ES END
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
want some minor relief since fires tend to kinda max out rooms and get bad very quickly (esp smoke i feel like smoke piles up way faster than i would expect)

changes:
- normal explosions make slightly smaller fires
- 2/3 smoke from fires
- 3/4 growth rate

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Fires now spread slower and produce slightly less smoke.

