### PR TITLE
heater/scrubber megabuffs + cryogas tweaks

### DIFF
--- a/Content.IntegrationTests/Tests/Movement/PullingTest.cs
+++ b/Content.IntegrationTests/Tests/Movement/PullingTest.cs
@@ -48,7 +48,7 @@ public sealed class PullingTest : MovementTest
 
         // Move in the other direction
         await Move(DirectionFlag.East, 2);
-        Assert.That(Delta(), Is.InRange(-1.3f, -0.9f));
+        Assert.That(Delta(), Is.InRange(-1.3f, -0.8f));
         Assert.That(puller.Pulling, Is.EqualTo(STarget));
         Assert.That(pullable.Puller, Is.EqualTo(SPlayer));
         Assert.That(pullable.BeingPulled, Is.True);
@@ -58,7 +58,7 @@ public sealed class PullingTest : MovementTest
         // Stop pulling
         await PressKey(ContentKeyFunctions.ReleasePulledObject);
         await RunTicks(5);
-        Assert.That(Delta(), Is.InRange(-1.3f, -0.9f));
+        Assert.That(Delta(), Is.InRange(-1.3f, -0.8f));
         Assert.That(puller.Pulling, Is.Null);
         Assert.That(pullable.Puller, Is.Null);
         Assert.That(pullable.BeingPulled, Is.False);

--- a/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
@@ -23,9 +23,7 @@ namespace Content.Server.Atmos.Portable
         [DataField("filterGases")]
         public HashSet<Gas> FilterGases = new()
         {
-// ES START
             Gas.Smoke,
-// ES END
             Gas.CarbonDioxide,
             Gas.Plasma,
             Gas.Tritium,
@@ -42,13 +40,13 @@ namespace Content.Server.Atmos.Portable
         /// Maximum internal pressure before it refuses to take more.
         /// </summary>
         [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public float MaxPressure = 2500;
+        public float MaxPressure = 10000;
 
         /// <summary>
         /// The speed at which gas is scrubbed from the environment.
         /// </summary>
         [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public float TransferRate = 800;
+        public float TransferRate = 4000;
 
         #region GuidebookData
 

--- a/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
+++ b/Content.Server/Atmos/Portable/PortableScrubberComponent.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Atmos.Portable
         /// The speed at which gas is scrubbed from the environment.
         /// </summary>
         [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public float TransferRate = 4000;
+        public float TransferRate = 5600;
 
         #region GuidebookData
 

--- a/Content.Server/Atmos/Portable/SpaceHeaterComponent.cs
+++ b/Content.Server/Atmos/Portable/SpaceHeaterComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class SpaceHeaterComponent : Component
     ///     The power level the space heater is currently set to. Possible values : Low, Medium, High
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public SpaceHeaterPowerLevel PowerLevel = SpaceHeaterPowerLevel.Medium;
+    public SpaceHeaterPowerLevel PowerLevel = SpaceHeaterPowerLevel.High;
 
     /// <summary>
     ///     Maximum target temperature the device can be set to
@@ -43,11 +43,11 @@ public sealed partial class SpaceHeaterComponent : Component
     [DataField("heatingCoefficientOfPerformance")]
     [ViewVariables(VVAccess.ReadWrite)]
     // ES START
-    public float HeatingCp = 10f;
+    public float HeatingCp = 60f;
 
     [DataField("coolingCoefficientOfPerformance")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public float CoolingCp = -14.9f;
+    public float CoolingCp = -40f;
     // ES END
 
     /// <summary>

--- a/Content.Server/Atmos/Portable/SpaceHeaterComponent.cs
+++ b/Content.Server/Atmos/Portable/SpaceHeaterComponent.cs
@@ -47,7 +47,7 @@ public sealed partial class SpaceHeaterComponent : Component
 
     [DataField("coolingCoefficientOfPerformance")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public float CoolingCp = -50f;
+    public float CoolingCp = -70f;
     // ES END
 
     /// <summary>

--- a/Content.Server/Atmos/Portable/SpaceHeaterComponent.cs
+++ b/Content.Server/Atmos/Portable/SpaceHeaterComponent.cs
@@ -43,11 +43,11 @@ public sealed partial class SpaceHeaterComponent : Component
     [DataField("heatingCoefficientOfPerformance")]
     [ViewVariables(VVAccess.ReadWrite)]
     // ES START
-    public float HeatingCp = 60f;
+    public float HeatingCp = 120f;
 
     [DataField("coolingCoefficientOfPerformance")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public float CoolingCp = -40f;
+    public float CoolingCp = -50f;
     // ES END
 
     /// <summary>

--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -28,9 +28,9 @@ public sealed partial class PullerComponent : Component
     // slight base slowdown since we dont really have mass-slowdown anymore
     // and this balances it so you dont run the same speed as people not pulling things
     // Before changing how this is updated, please see SharedPullerSystem.RefreshMovementSpeed
-    public float WalkSpeedModifier => Pulling == null ? 1f : 0.7f;
+    public float WalkSpeedModifier => Pulling == null ? 1f : 0.9f;
 
-    public float SprintSpeedModifier => Pulling == null ? 1f : 0.7f;
+    public float SprintSpeedModifier => Pulling == null ? 1f : 0.9f;
     // ES END
 
     /// <summary>

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -99,7 +99,7 @@
   molarMass: 50
   gasOverlaySprite: /Textures/_ES/Effects/atmospherics.rsi
   gasOverlayState: cryogas
-  gasMolesVisible: 0.6
+  gasMolesVisible: 0.5
   color: 3a758c
   reagent: Cryogas
   pricePerMole: 1

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -21,9 +21,8 @@
 - type: gasReaction
   id: FrezonCoolant
   priority: 1
-  minimumTemperature: 23.15
+  minimumTemperature: 213.15
   minimumRequirements:
-    Nitrogen: 0.01
-    Cryogas: 0.01
+    Cryogas: 0.5
   effects:
   - !type:FrezonCoolantReaction {}

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: PortableScrubber
-  parent: [BaseMachinePowered, SmallConstructibleMachine, StructureWheeled, StructureQuickAnchor]
+  parent: [StructureQuickAnchor, BaseMachinePowered, SmallConstructibleMachine, StructureWheeled]
   name: portable scrubber
   description: It scrubs, portably!
   components:
@@ -101,7 +101,7 @@
 
 - type: entity
   id: SpaceHeater
-  parent: [BaseMachinePowered, ConstructibleMachine, StructureQuickAnchor]
+  parent: [StructureQuickAnchor, BaseMachinePowered, ConstructibleMachine]
   name: space heater
   description: A bluespace technology device that alters local temperature. Commonly referred to as a "Space Heater".
   suffix: Unanchored

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/portable.yml
@@ -1,6 +1,6 @@
 - type: entity
   id: PortableScrubber
-  parent: [BaseMachinePowered, SmallConstructibleMachine, StructureWheeled]
+  parent: [BaseMachinePowered, SmallConstructibleMachine, StructureWheeled, StructureQuickAnchor]
   name: portable scrubber
   description: It scrubs, portably!
   components:
@@ -101,7 +101,7 @@
 
 - type: entity
   id: SpaceHeater
-  parent: [BaseMachinePowered, ConstructibleMachine]
+  parent: [BaseMachinePowered, ConstructibleMachine, StructureQuickAnchor]
   name: space heater
   description: A bluespace technology device that alters local temperature. Commonly referred to as a "Space Heater".
   suffix: Unanchored

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -261,7 +261,7 @@
     Runs off welding fuel and is rated for up to 8 kW.
     Rated ages 3 and up.
 # ES Start
-  parent: [PortableGeneratorBase, StructureWheeled]
+  parent: [PortableGeneratorBase, StructureWheeled, StructureQuickAnchor]
 # ES End
   id: PortableGeneratorJrPacman
   suffix: Welding Fuel, 8 kW

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -261,7 +261,7 @@
     Runs off welding fuel and is rated for up to 8 kW.
     Rated ages 3 and up.
 # ES Start
-  parent: [PortableGeneratorBase, StructureWheeled, StructureQuickAnchor]
+  parent: [StructureQuickAnchor, PortableGeneratorBase, StructureWheeled]
 # ES End
   id: PortableGeneratorJrPacman
   suffix: Welding Fuel, 8 kW

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -24,10 +24,8 @@
       WaterVapor: stationWaterVapor
       Miasma: stationMiasma
       NitrousOxide: stationNO
-      Cryogas: danger
-      # ES START
+      Cryogas: ESStationCryogas
       Smoke: ESStationSmoke
-      # ES END
 
 - type: entity
   id: AirSensor

--- a/Resources/Prototypes/Entities/Structures/base_structure.yml
+++ b/Resources/Prototypes/Entities/Structures/base_structure.yml
@@ -68,3 +68,10 @@
   components:
     - type: TileFrictionModifier
       modifier: 0.4
+
+- type: entity
+  id: StructureQuickAnchor # es
+  abstract: true
+  components: # just fast to anchor rn but eventually have like a click-to-anchor thing probably.
+  - type: Anchorable
+    delay: 0.5

--- a/Resources/Prototypes/_ES/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/_ES/Atmospherics/thresholds.yml
@@ -1,6 +1,13 @@
 - type: alarmThreshold
   id: ESStationSmoke
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.05
+    threshold: 0.01
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.5
+
+- type: alarmThreshold
+  id: ESStationCryogas
+  upperBound: !type:AlarmThresholdSetting
+    threshold: 0.005
+  upperWarnAround: !type:AlarmThresholdSetting
+    threshold: 0.75


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

i am sick and tired!

mostly #2191 besides anchor on click
fixes #2409 
fixes #2391 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Cryogas now only cools the air above a certain mol threshold (corresponds to when its visible)
- tweak: Portable scrubbers are ~7x more powerful
- tweak: Space heaters are ~5-12x more powerful
- tweak: Pulling speed debuff is much lower
- tweak: Scrubbers, space heaters, and JR pacmans are 4x faster to anchor/unanchor