### PR TITLE
Remove butchering from humanoids

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -279,11 +279,6 @@
     normalBodyTemperature: 310.15
     thermalRegulationTemperatureThreshold: 2
   - type: ESMiasmaSource
-  - type: Butcherable
-    butcheringType: Spike # TODO human.
-    spawned:
-      - id: FoodMeat
-        amount: 5
   - type: Respirator
     damage:
       types:

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -10,11 +10,6 @@
     sprite: Mobs/Species/Human/parts.rsi
     state: full
   - type: Thirst
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 5
   - type: HumanoidAppearance
     species: Human
     hideLayersOnEquip:

--- a/Resources/Prototypes/_ES/Entities/Mobs/Species/cryohusk.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Species/cryohusk.yml
@@ -9,11 +9,6 @@
     sprite: _ES/Mobs/Species/cryohusk.rsi
     state: full
   - type: Thirst
-  - type: Butcherable
-    butcheringType: Spike
-    spawned:
-    - id: FoodMeat
-      amount: 5
   - type: HumanoidAppearance
     species: ESCryohusk
   - type: SlurredAccent

--- a/Resources/Prototypes/_ES/Entities/Mobs/Species/monkey.yml
+++ b/Resources/Prototypes/_ES/Entities/Mobs/Species/monkey.yml
@@ -15,7 +15,7 @@
     butcheringType: Spike
     spawned:
     - id: FoodMeat
-      amount: 5
+      amount: 3
 # Monkey Quirks
   - type: Deathgasp
     prototype: MonkeyDeathgasp


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2403

Retains butchering monkeys on spikes cuz that's what they're for and also canonical Experiment torture experience.
Puts monkey meat back down to 3 pieces for old parity since idk i felt like it sue me.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Humans can no longer be put on meat spikes.