### PR TITLE
Halve blood and vomit miasma generation

### DIFF
--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -16,7 +16,7 @@
   standsout: true
   physicalDesc: reagent-physical-desc-ferrous
   puddleGas:
-    Miasma: 0.0002
+    Miasma: 0.0001
   metabolisms:
     Drink:
       effects:
@@ -79,7 +79,7 @@
   puddleSpriteSet: Vomit
   physicalDesc: reagent-physical-desc-pungent
   puddleGas:
-    Miasma: 0.001
+    Miasma: 0.0005
   slipData:
     requiredSlipSpeed: 4.0 #It's not as slippery as water
   friction: 0.4


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2406

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Blood and vomit now produce half as much miasma when on the ground.
