### PR TITLE
notify stagehands on apc bugging

### DIFF
--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESTraitorBugSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESTraitorBugSystem.cs
@@ -146,7 +146,8 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
 
         _notification.SendStagehandNotification(Loc.GetString("es-stagehand-notification-apc-bugged",
             ("buggable", _notification.WrapEntityName(ent.Owner)),
-            ("player", _notification.WrapEntityName(args.User))));
+            ("player", _notification.WrapEntityName(args.User))),
+            ESStagehandNotificationSeverity.Low);
 
         Dirty(ent);
 
@@ -160,7 +161,8 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
 
         _notification.SendStagehandNotification(Loc.GetString("es-stagehand-notification-apc-bug-removed",
             ("buggable", _notification.WrapEntityName(ent.Owner)),
-            ("player", _notification.WrapEntityName(args.User))));
+            ("player", _notification.WrapEntityName(args.User))),
+            ESStagehandNotificationSeverity.Low);
 
         CancelBug(ent.AsNullable());
         args.Handled = true;

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESTraitorBugSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESTraitorBugSystem.cs
@@ -158,7 +158,7 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
         if (args.Cancelled)
             return;
 
-        _notification.SendStagehandNotification(Loc.GetString("es-stagehand-notification-apc-debugged",
+        _notification.SendStagehandNotification(Loc.GetString("es-stagehand-notification-apc-bug-removed",
             ("buggable", _notification.WrapEntityName(ent.Owner)),
             ("player", _notification.WrapEntityName(args.User))));
 

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESTraitorBugSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESTraitorBugSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._ES.SecretIdentity.Traitor.Components;
 using Content.Shared._ES.Objectives;
 using Content.Shared._ES.Objectives.Components;
 using Content.Shared._ES.Sparks;
+using Content.Shared._ES.Stagehand;
 using Content.Shared.Access;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Managers;
@@ -32,6 +33,7 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
     [Dependency] private SharedMindSystem _mind = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private ESSparksSystem _sparks = default!;
+    [Dependency] private ESSharedStagehandNotificationsSystem _notification = default!;
 
     // TODO: This is mostly just a bad hack for the fact that you can't have a nullable value that's easily editable in VV.
     // I would like to not go insane editing all the APCs for this until we have an actual system that does it semi-reasonably.
@@ -141,6 +143,11 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
 
         _appearance.SetData(ent, ESTraitorBugVisuals.Bugged, true);
         ent.Comp.Timer = _entityTimer.SpawnTimer(ent, ent.Comp.BugDuration, new ESTraitorBugTimerEvent());
+
+        _notification.SendStagehandNotification(Loc.GetString("es-stagehand-notification-apc-bugged",
+            ("buggable", _notification.WrapEntityName(ent.Owner)),
+            ("player", _notification.WrapEntityName(args.User))));
+
         Dirty(ent);
 
         args.Handled = true;
@@ -150,6 +157,10 @@ public sealed partial class ESTraitorBugSystem : ESBaseObjectiveSystem<ESTraitor
     {
         if (args.Cancelled)
             return;
+
+        _notification.SendStagehandNotification(Loc.GetString("es-stagehand-notification-apc-debugged",
+            ("buggable", _notification.WrapEntityName(ent.Owner)),
+            ("player", _notification.WrapEntityName(args.User))));
 
         CancelBug(ent.AsNullable());
         args.Handled = true;

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -17,5 +17,5 @@ es-stagehand-notification-secret-identity-change = {$player} donned a new secret
 
 es-stagehand-notification-new-stagehand = {$username} has joined the backstage crew.
 
-es-stagehand-notification-apc-bugged = {$buggable} was bugged by {$player}!
-es-stagehand-notification-apc-debugged = {$buggable} was debugged by {$player}!
+es-stagehand-notification-apc-bugged = {$player} bugged {$buggable}!
+es-stagehand-notification-apc-bug-removed = {$player} removed the bug from {$buggable}!

--- a/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
+++ b/Resources/Locale/en-US/_ES/stagehand/notifications.ftl
@@ -16,3 +16,6 @@ es-stagehand-notification-objective-failed = {$entity} failed their objective "{
 es-stagehand-notification-secret-identity-change = {$player} donned a new secret identity, becoming {INDEFINITE($secretIdentity)} [bold]{$secretIdentity}![/bold]
 
 es-stagehand-notification-new-stagehand = {$username} has joined the backstage crew.
+
+es-stagehand-notification-apc-bugged = {$buggable} was bugged by {$player}!
+es-stagehand-notification-apc-debugged = {$buggable} was debugged by {$player}!


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
title
It uses the name of the APC instead of the nearby station beacons but that shouldnt be an issue
closes #2432 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
<img width="220" height="32" alt="image" src="https://github.com/user-attachments/assets/9d9fe3fe-e3df-4f2e-a148-a5fc014cbb04" />
I probably shouldnt have used experiment for this example but w/ever


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: stagehands will now be notified upon apc bugging/debugging