### PR TITLE
Cargo fix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -289,7 +289,7 @@
   - type: Sprite
     sprite: Structures/Storage/Crates/weapon.rsi
   - type: AccessReader
-    access: [["Armory"]]
+    access: [["Security"]]
 
 - type: entity
   parent: CrateBaseSecure

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/crates.yml
@@ -173,7 +173,7 @@
   parent: CrateWeaponSecure
   id: ESCrateSecurityPistols
   name: pistol crate
-  description: Contains two 9mm pistols and a spare mag for each. Requires Armory access to open.
+  description: Contains two 9mm pistols and a spare mag for each. Requires Security access to open.
   suffix: ES
   components:
   - type: EntityTableContainerFill
@@ -189,7 +189,7 @@
   parent: CrateWeaponSecure
   id: ESCrateSecurityShotgun
   name: shotgun crate
-  description: Contains one shotgun and two boxes of shells. Requires Armory access to open.
+  description: Contains one shotgun and two boxes of shells. Requires Security access to open.
   suffix: ES
   components:
   - type: EntityTableContainerFill
@@ -221,7 +221,7 @@
   parent: CrateWeaponSecure
   id: ESCrateSecurityEnergyRifles
   name: energy rifle crate
-  description: Contains two energy rifles. Requires Armory access to open.
+  description: Contains two energy rifles. Requires Security access to open.
   suffix: ES
   components:
   - type: EntityTableContainerFill


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Cargo security crates containing weapons can now be opened with a security id again.

I was originally going to add some new crates but I had some issues so later maybe.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Cargo weapon crates can be opened with a sec ID again
