### PR TITLE
cooldown circle around mouse

### DIFF
--- a/Content.Client/Cooldown/CooldownGraphic.cs
+++ b/Content.Client/Cooldown/CooldownGraphic.cs
@@ -29,7 +29,6 @@ namespace Content.Client.Cooldown
 
         protected override void Draw(DrawingHandleScreen handle)
         {
-            Span<float> x = new float[10];
             Color color;
 
             var lerp = 1f - MathF.Abs(Progress); // for future bikeshedding purposes

--- a/Content.Client/Hands/ShowHandItemOverlay.cs
+++ b/Content.Client/Hands/ShowHandItemOverlay.cs
@@ -1,6 +1,8 @@
 using System.Numerics;
+using Content.Client.Cooldown;
 using Content.Client.Hands.Systems;
 using Content.Shared.CCVar;
+using Content.Shared.Timing;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
@@ -15,13 +17,16 @@ namespace Content.Client.Hands
 {
     public sealed partial class ShowHandItemOverlay : Overlay
     {
+        [Dependency] private IUserInterfaceManager _ui = default!;
         [Dependency] private IConfigurationManager _cfg = default!;
         [Dependency] private IInputManager _inputManager = default!;
         [Dependency] private IClyde _clyde = default!;
         [Dependency] private IEntityManager _entMan = default!;
 
         private HandsSystem? _hands;
+        private UseDelaySystem? _delay;
         private readonly IRenderTexture _renderBackbuffer;
+        private readonly CooldownGraphic _cooldownGraphic;
 
         public override OverlaySpace Space => OverlaySpace.ScreenSpace;
 
@@ -31,6 +36,14 @@ namespace Content.Client.Hands
         public ShowHandItemOverlay()
         {
             IoCManager.InjectDependencies(this);
+
+            _cooldownGraphic = new()
+            {
+                SetSize = new(64, 64)
+            };
+
+            // mild jank to get it to size correctly since we are rendering this directly.
+            _cooldownGraphic.Arrange(UIBox2.FromDimensions(Vector2.Zero, new Vector2(64, 64)));
 
             _renderBackbuffer = _clyde.CreateRenderTarget(
                 (64, 64),
@@ -82,7 +95,8 @@ namespace Content.Client.Hands
                 return;
 
             var halfSize = _renderBackbuffer.Size / 2;
-            var uiScale = (args.ViewportControl as Control)?.UIScale ?? 1f;
+            var vpControl = args.ViewportControl as Control;
+            var uiScale = vpControl?.UIScale ?? 1f;
 
             screen.RenderInRenderTarget(_renderBackbuffer, () =>
             {
@@ -90,6 +104,23 @@ namespace Content.Client.Hands
             }, Color.Transparent);
 
             screen.DrawTexture(_renderBackbuffer.Texture, mousePos.Position - halfSize + offsetVec, Color.White.WithAlpha(0.75f));
+
+            // render cooldown circle graphic
+            if (!_entMan.TryGetComponent<UseDelayComponent>(handEntity, out var delay))
+                return;
+
+            _delay ??= _entMan.System<UseDelaySystem>();
+            var cooldown = _delay.GetLastEndingDelay((handEntity.Value, delay));
+            if (cooldown.StartTime == cooldown.EndTime || cooldown.Length == TimeSpan.Zero)
+            {
+                return;
+            }
+
+            _cooldownGraphic.FromTime(cooldown.StartTime, cooldown.EndTime);
+            // add child temporarily to get the ui scale to work
+            vpControl?.AddChild(_cooldownGraphic);
+            _ui.RenderControl(args.RenderHandle, _cooldownGraphic, (Vector2i) (mousePos.Position - (_cooldownGraphic.PixelSize) / 2));
+            vpControl?.RemoveChild(_cooldownGraphic);
         }
     }
 }


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->

atm this only renders if you have the show hand item overlay enabled but apparently emo has that turned off so maybe people turn it off??? i wasnt aware people turned it off. do people that turn it off also want this turned off. lets find out(?)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="297" height="370" alt="image" src="https://github.com/user-attachments/assets/b1fd0541-9a39-4117-84c6-1f9bc300b6bf" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Use delay cooldown circle (like extinguishers or tools or whatever) now shows around the cursor also. assuming you have the 'show hand item' option enabled
