### PR TITLE
Fix bleed alert

### DIFF
--- a/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/Body/Systems/SharedBloodstreamSystem.cs
@@ -516,20 +516,29 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
         ent.Comp.BleedAmount = Math.Clamp(ent.Comp.BleedAmount, 0, ent.Comp.MaxBleedAmount);
 
         DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BleedAmount));
+        UpdateBleedAlert(ent);
 
-        // Begin Offbrand
+        return true;
+    }
+
+    public void UpdateBleedAlert(Entity<BloodstreamComponent?> ent)
+    {
+        if (!Resolve(ent, ref ent.Comp))
+            return;
+
         var bleedLevel = EffectiveBleedLevel((ent, ent.Comp));
+
+        // How much we're bleeding out of the max percent.
+        var bleedPercent = bleedLevel / ent.Comp.MaxBleedAmount;
 
         if (bleedLevel == 0)
             _alertsSystem.ClearAlert(ent.Owner, ent.Comp.BleedingAlert);
         else
         {
-            var severity = (short)Math.Clamp(Math.Round(bleedLevel, MidpointRounding.ToZero), 0, 10);
+            var maxSeverity = _alertsSystem.GetMaxSeverity(ent.Comp.BleedingAlert);
+            var severity = (short) Math.Ceiling(bleedPercent * maxSeverity);
             _alertsSystem.ShowAlert(ent.Owner, ent.Comp.BleedingAlert, severity);
         }
-        // End Offbrand
-
-        return true;
     }
 
     /// <summary>

--- a/Content.Shared/_Offbrand/StatusEffects/BleedMultiplierStatusEffectSystem.cs
+++ b/Content.Shared/_Offbrand/StatusEffects/BleedMultiplierStatusEffectSystem.cs
@@ -1,15 +1,30 @@
 using Content.Shared._Offbrand.Wounds;
+using Content.Shared.Body.Systems;
 using Content.Shared.StatusEffectNew;
 
 namespace Content.Shared._Offbrand.StatusEffects;
 
-public sealed class BleedMultiplierStatusEffectSystem : EntitySystem
+public sealed partial class BleedMultiplierStatusEffectSystem : EntitySystem
 {
+    [Dependency] private SharedBloodstreamSystem _bloodstream = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
+        SubscribeLocalEvent<BleedMultiplierStatusEffectComponent, StatusEffectAppliedEvent>(OnApplied);
+        SubscribeLocalEvent<BleedMultiplierStatusEffectComponent, StatusEffectRemovedEvent>(OnRemoved);
         SubscribeLocalEvent<BleedMultiplierStatusEffectComponent, StatusEffectRelayedEvent<ModifyBleedLevelEvent>>(OnGetBleedMultiplier);
+    }
+
+    private void OnApplied(Entity<BleedMultiplierStatusEffectComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        _bloodstream.UpdateBleedAlert(args.Target);
+    }
+
+    private void OnRemoved(Entity<BleedMultiplierStatusEffectComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        _bloodstream.UpdateBleedAlert(args.Target);
     }
 
     private void OnGetBleedMultiplier(Entity<BleedMultiplierStatusEffectComponent> ent, ref StatusEffectRelayedEvent<ModifyBleedLevelEvent> args)

--- a/Content.Shared/_Offbrand/Wounds/WoundableSystem.cs
+++ b/Content.Shared/_Offbrand/Wounds/WoundableSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared.FixedPoint;
 using Content.Shared.HealthExaminable;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Random.Helpers;
+using Content.Shared.StatusEffect;
 using Content.Shared.StatusEffectNew.Components;
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Network;
@@ -23,7 +24,8 @@ public sealed partial class WoundableSystem : EntitySystem
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private INetManager _net = default!;
-    [Dependency] private StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private SharedBloodstreamSystem _bloodstream = default!;
+    [Dependency] private StatusEffectNew.StatusEffectsSystem _statusEffects = default!;
 
     public override void Initialize()
     {
@@ -41,8 +43,20 @@ public sealed partial class WoundableSystem : EntitySystem
 
         SubscribeLocalEvent<PainfulWoundComponent, StatusEffectRelayedEvent<GetPainEvent>>(OnGetPain);
         SubscribeLocalEvent<HealableWoundComponent, StatusEffectRelayedEvent<HealWoundsEvent>>(OnHealHealableWounds);
+        SubscribeLocalEvent<BleedingWoundComponent, StatusEffectAppliedEvent>(OnBleedApplied);
+        SubscribeLocalEvent<BleedingWoundComponent, StatusEffectRemovedEvent>(OnBleedRemoved);
         SubscribeLocalEvent<BleedingWoundComponent, StatusEffectRelayedEvent<GetBleedLevelEvent>>(OnGetBleedLevel);
         SubscribeLocalEvent<ClampableWoundComponent, StatusEffectRelayedEvent<ClampWoundsEvent>>(OnClampWounds);
+    }
+
+    private void OnBleedApplied(Entity<BleedingWoundComponent> ent, ref StatusEffectAppliedEvent args)
+    {
+        _bloodstream.UpdateBleedAlert(args.Target);
+    }
+
+    private void OnBleedRemoved(Entity<BleedingWoundComponent> ent, ref StatusEffectRemovedEvent args)
+    {
+        _bloodstream.UpdateBleedAlert(args.Target);
     }
 
     private void OnShutdown(Entity<WoundableComponent> ent, ref ComponentShutdown args)


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #1679 

adds missing updates for bleed alert.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed the bleed alert getting stuck showing low amounts of bleed after all bleeding stopped.
