### PR TITLE
Parasite Hivemind channel

### DIFF
--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -105,7 +105,7 @@ public sealed partial class TypingIndicatorSystem : SharedTypingIndicatorSystem
             state = _isClientTyping ? TypingIndicatorState.Typing : TypingIndicatorState.Idle;
 
         // send a networked event to server
-        if (_time.ApplyingState)
+        if (!_time.ApplyingState)
             RaisePredictiveEvent(new TypingChangedEvent(state));
     }
 

--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -105,7 +105,8 @@ public sealed partial class TypingIndicatorSystem : SharedTypingIndicatorSystem
             state = _isClientTyping ? TypingIndicatorState.Typing : TypingIndicatorState.Idle;
 
         // send a networked event to server
-        RaisePredictiveEvent(new TypingChangedEvent(state));
+        if (_time.ApplyingState)
+            RaisePredictiveEvent(new TypingChangedEvent(state));
     }
 
     private void OnShowTypingChanged(bool showTyping)

--- a/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
+++ b/Content.Client/Chat/TypingIndicator/TypingIndicatorSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._ES.Chat;
 using Content.Shared.CCVar;
 using Content.Shared.Chat.TypingIndicator;
 using Robust.Client.Player;
@@ -17,6 +18,7 @@ public sealed partial class TypingIndicatorSystem : SharedTypingIndicatorSystem
     private TimeSpan _lastTextChange;
     private bool _isClientTyping;
     private bool _isClientChatFocused;
+    private bool _isValidChannel;
 
     public override void Initialize()
     {
@@ -59,6 +61,19 @@ public sealed partial class TypingIndicatorSystem : SharedTypingIndicatorSystem
         ClientUpdateTyping();
     }
 
+    public void ClientChangedValidChannel(ESChatChannelPrototype prototype)
+    {
+        // don't update it if player don't want to show typing
+        if (!_cfg.GetCVar(CCVars.ChatShowTypingIndicator))
+            return;
+
+        // placeholder until we have more sophisticated behavior.
+        var valid = prototype.GlorfAffected;
+
+        _isValidChannel = valid;
+        ClientUpdateTyping();
+    }
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -86,7 +101,7 @@ public sealed partial class TypingIndicatorSystem : SharedTypingIndicatorSystem
             return;
 
         var state = TypingIndicatorState.None;
-        if (_isClientChatFocused)
+        if (_isClientChatFocused && _isValidChannel)
             state = _isClientTyping ? TypingIndicatorState.Typing : TypingIndicatorState.Idle;
 
         // send a networked event to server

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -453,7 +453,7 @@ public sealed partial class ChatUIController : UIController, IOnSystemChanged<ES
 
     public void UpdateSelectedChannel(ChatBox box)
     {
-        var (prefixChannel, _) = SplitInputContents(box.ChatInput.Input.Text.ToLower());
+        var (prefixChannel, _) = SplitInputContents(box.ChatInput.Input.Text);
 
         if (prefixChannel == null)
             box.ChatInput.ChannelSelector.UpdateChannelSelectButton(_prototypeManager.Index(box.SelectedChannel));
@@ -603,14 +603,24 @@ public sealed partial class ChatUIController : UIController, IOnSystemChanged<ES
         _chats.Remove(chat);
     }
 
-    public void NotifyChatTextChange()
+    public void NotifyChatTextChange(ChatBox box)
     {
+        _typingIndicator?.ClientChangedValidChannel(GetCurrentChatChannel(box));
         _typingIndicator?.ClientChangedChatText();
     }
 
-    public void NotifyChatFocus(bool isFocused)
+    public void NotifyChatFocus(ChatBox box, bool isFocused)
     {
         _typingIndicator?.ClientChangedChatFocus(isFocused);
+    }
+
+    private ESChatChannelPrototype GetCurrentChatChannel(ChatBox box)
+    {
+        var (channel, _) = SplitInputContents(box.ChatInput.Input.Text);
+        if (channel != null)
+            return channel;
+
+        return _prototypeManager.Index(box.SelectedChannel);
     }
 
     public void Repopulate()

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorButton.cs
@@ -10,7 +10,7 @@ public sealed class ChannelSelectorButton : ChatPopupButton<ChannelSelectorPopup
 
     public event Action<ProtoId<ESChatChannelPrototype>>? OnChannelSelect;
 
-    public ProtoId<ESChatChannelPrototype> SelectedChannel { get; private set; }
+    public ProtoId<ESChatChannelPrototype> SelectedChannel { get; private set; } = ESSharedChatSystem.LocalChannel;
 
     private const int SelectorDropdownOffset = 38;
 

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorPopup.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorPopup.cs
@@ -38,7 +38,8 @@ public sealed partial class ChannelSelectorPopup : Popup
         Channels.Clear();
         _channelSelectorHBox.RemoveAllChildren();
 
-        foreach (var channel in _prototype.EnumeratePrototypes<ESChatChannelPrototype>().OrderBy(p => p.Order))
+        var order = _prototype.Index(IESSharedChatManager.ChannelOrder);
+        foreach (var channel in _prototype.EnumeratePrototypes<ESChatChannelPrototype>().OrderBy(p => order.Order.IndexOf(p)))
         {
             if (channel.Abstract)
                 continue;

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -72,6 +72,7 @@ public partial class ChatBox : UIWidget
     private void OnChannelSelect(ProtoId<ESChatChannelPrototype> channel)
     {
         Controller.UpdateSelectedChannel(this);
+        Controller.NotifyChatTextChange(this);
     }
 
     public virtual void Repopulate()
@@ -164,19 +165,19 @@ public partial class ChatBox : UIWidget
         Controller.UpdateSelectedChannel(this);
 
         // Warn typing indicator about change
-        Controller.NotifyChatTextChange();
+        Controller.NotifyChatTextChange(this);
     }
 
     private void OnFocusEnter(LineEditEventArgs args)
     {
         // Warn typing indicator about focus
-        Controller.NotifyChatFocus(true);
+        Controller.NotifyChatFocus(this, true);
     }
 
     private void OnFocusExit(LineEditEventArgs args)
     {
         // Warn typing indicator about focus
-        Controller.NotifyChatFocus(false);
+        Controller.NotifyChatFocus(this, false);
     }
 
     protected override void Dispose(bool disposing)

--- a/Content.Shared/Mind/SharedMindSystem.Relay.cs
+++ b/Content.Shared/Mind/SharedMindSystem.Relay.cs
@@ -1,9 +1,8 @@
+using Content.Shared._ES.Chat;
 using Content.Shared._ES.Objectives.Components;
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.Mind.Components;
-// ES START
 using Content.Shared.Mobs;
-// ES END
 
 namespace Content.Shared.Mind;
 
@@ -17,8 +16,7 @@ public abstract partial class SharedMindSystem : EntitySystem
     {
         // for name modifiers that depend on certain mind roles
         SubscribeLocalEvent<MindContainerComponent, RefreshNameModifiersEvent>(RelayRefToMind);
-
-// ES PATCH START
+        SubscribeLocalEvent<MindContainerComponent, ESGetChatPermissionsEvent>(RelayRefToMind);
         SubscribeLocalEvent<MindContainerComponent, MobStateChangedEvent>(RelayToMind);
 
         SubscribeLocalEvent<MindComponent, MindGotAddedEvent>(ESOnMindGotAdded);
@@ -48,30 +46,41 @@ public abstract partial class SharedMindSystem : EntitySystem
         }
     }
 
-    protected void RelayToMind<T>(EntityUid uid, MindContainerComponent component, T args) where T : notnull
-// ES PATCH END
+    protected void RelayToMind<T>(EntityUid uid, MindContainerComponent component, T args)
     {
         var ev = new MindRelayedEvent<T>(args);
 
         if (TryGetMind(uid, out var mindId, out var mindComp, component))
         {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (mindComp.MindRoleContainer == default)
+                return;
+
             RaiseLocalEvent(mindId, ref ev);
 
             foreach (var role in mindComp.MindRoleContainer.ContainedEntities)
+            {
                 RaiseLocalEvent(role, ref ev);
+            }
         }
     }
 
-    protected void RelayRefToMind<T>(EntityUid uid, MindContainerComponent component, ref T args) where T : class
+    protected void RelayRefToMind<T>(EntityUid uid, MindContainerComponent component, ref T args)
     {
         var ev = new MindRelayedEvent<T>(args);
 
         if (TryGetMind(uid, out var mindId, out var mindComp, component))
         {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (mindComp.MindRoleContainer == default)
+                return;
+
             RaiseLocalEvent(mindId, ref ev);
 
             foreach (var role in mindComp.MindRoleContainer.ContainedEntities)
+            {
                 RaiseLocalEvent(role, ref ev);
+            }
         }
 
         args = ev.Args;

--- a/Content.Shared/_ES/Chat/ESChatChannelOrderPrototype.cs
+++ b/Content.Shared/_ES/Chat/ESChatChannelOrderPrototype.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.Chat;
+
+/// <summary>
+/// Prototype that defines the order of chat channels.
+/// </summary>
+[Prototype("esChatChannelOrder")]
+public sealed partial class ESChatChannelOrderPrototype : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Ordered list of how the channels should appear
+    /// </summary>
+    [DataField]
+    public List<ProtoId<ESChatChannelPrototype>> Order = [];
+}

--- a/Content.Shared/_ES/Chat/ESChatChannelPrototype.cs
+++ b/Content.Shared/_ES/Chat/ESChatChannelPrototype.cs
@@ -24,9 +24,6 @@ public sealed partial class ESChatChannelPrototype : IPrototype, IInheritingProt
     public LocId Name = "generic-unknown-title";
 
     [DataField]
-    public int Order = -1;
-
-    [DataField]
     public Color Color = Color.DarkGray;
 
     [DataField]

--- a/Content.Shared/_ES/Chat/ESSharedChatSystem.Permissions.cs
+++ b/Content.Shared/_ES/Chat/ESSharedChatSystem.Permissions.cs
@@ -1,4 +1,5 @@
 using Content.Shared._ES.Chat.Components;
+using Content.Shared.Mind;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared._ES.Chat;
@@ -9,6 +10,7 @@ public abstract partial class ESSharedChatSystem
     {
         SubscribeLocalEvent<ESChatPermissionsComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<ESChatPermissionsComponent, ESGetChatPermissionsEvent>(OnGetChatPermissions);
+        SubscribeLocalEvent<ESChatPermissionsComponent, MindRelayedEvent<ESGetChatPermissionsEvent>>(OnRelayGetChatPermissions);
     }
 
     private void OnStartup(Entity<ESChatPermissionsComponent> ent, ref ComponentStartup args)
@@ -21,6 +23,14 @@ public abstract partial class ESSharedChatSystem
         foreach (var channel in ent.Comp.InherentChannels)
         {
             args.Channels.Add(channel);
+        }
+    }
+
+    private void OnRelayGetChatPermissions(Entity<ESChatPermissionsComponent> ent, ref MindRelayedEvent<ESGetChatPermissionsEvent> args)
+    {
+        foreach (var channel in ent.Comp.InherentChannels)
+        {
+            args.Args.Channels.Add(channel);
         }
     }
 

--- a/Content.Shared/_ES/Chat/IESSharedChatManager.cs
+++ b/Content.Shared/_ES/Chat/IESSharedChatManager.cs
@@ -13,6 +13,8 @@ public interface IESSharedChatManager
     static readonly ProtoId<ESChatChannelPrototype> ServerChannel = "Server";
     static readonly ProtoId<ESChatChannelPrototype> AdminChannel = "Admin";
 
+    static readonly ProtoId<ESChatChannelOrderPrototype> ChannelOrder = "Default";
+
     int MaxMessageLength { get; protected set; }
 
     event Action<EntityUid, string, ProtoId<ESChatChannelPrototype>>? OnRequestSendChatMessage;

--- a/Content.Shared/_ES/SecretIdentity/ESSecretIdentityPrototype.cs
+++ b/Content.Shared/_ES/SecretIdentity/ESSecretIdentityPrototype.cs
@@ -64,9 +64,11 @@ public sealed partial class ESSecretIdentityPrototype : IPrototype, IInheritingP
     public HashSet<ProtoId<ESTipPrototype>> Tips = new();
 
     [DataField]
+    [AlwaysPushInheritance]
     public ComponentRegistry Components = new();
 
     [DataField]
+    [AlwaysPushInheritance]
     public ComponentRegistry MindComponents = new();
 
     /// <summary>

--- a/Resources/Locale/en-US/_ES/chat/channels.ftl
+++ b/Resources/Locale/en-US/_ES/chat/channels.ftl
@@ -45,6 +45,10 @@ es-chat-filter-name-server = Server
 es-chat-channel-syndie-transponder-fmt-verb = \[Traitor\] [bold]{"{1}"}[/bold] {$verb}, "{"{0}"}"
 es-chat-channel-syndie-transponder-bold-fmt-verb = \[Traitor\] [bold]{"{1}"}[/bold] {$verb}, "[bold]{"{0}"}[/bold]"
 
+es-chat-channel-name-hivemind = Hivemind
+es-chat-channel-parasite-hivemind-fmt-verb = [italic][bold]{"{1}"}[/bold] {$verb} through the wormlink, "{"{0}"}"[/italic]
+es-chat-channel-parasite-hivemind-bold-fmt-verb = [italic][bold]{"{1}"}[/bold] {$verb} through the wormlink, "[bold]{"{0}"}[/bold]"[/italic]
+
 es-chat-channel-speak-fmt-verb = [bold]{"{1}"}[/bold] {$verb}, "{"{0}"}"
 es-chat-channel-speak-bold-fmt-verb = [bold]{"{1}"}[/bold] {$verb}, "[bold]{"{0}"}[/bold]"
 

--- a/Resources/Prototypes/_ES/Chat/Channels/admin.yml
+++ b/Resources/Prototypes/_ES/Chat/Channels/admin.yml
@@ -1,7 +1,6 @@
 - type: esChatChannel
   id: AdminChat
   name: es-chat-channel-name-admin
-  order: 99
   color: HotPink
   textColor: HotPink
   chatProcessor: AdminChatProcessor

--- a/Resources/Prototypes/_ES/Chat/Channels/basic.yml
+++ b/Resources/Prototypes/_ES/Chat/Channels/basic.yml
@@ -1,7 +1,6 @@
 - type: esChatChannel
   id: Speak
   name: es-chat-channel-name-speak
-  order: 1
   chatProcessor: SpeakChatProcessor
   prefixes: [ ">" ]
   filterCategory: Local
@@ -36,7 +35,6 @@
 - type: esChatChannel
   parent: BaseWhisper
   id: Whisper
-  order: 2
   chatProcessor: WhisperChatProcessor
   prefixes: [ "," ]
   focusKey: FocusWhisperChatWindow
@@ -80,7 +78,6 @@
 - type: esChatChannel
   parent: EmoteNoEffect
   id: Emote
-  order: 3
   chatProcessor: EmoteChatProcessor
   prefixes: [ "@", "*" ]
   focusKey: FocusEmote

--- a/Resources/Prototypes/_ES/Chat/Channels/parasite.yml
+++ b/Resources/Prototypes/_ES/Chat/Channels/parasite.yml
@@ -1,0 +1,20 @@
+- type: esChatChannel
+  id: ParasiteHivemind
+  name: es-chat-channel-name-hivemind
+  color: yellowgreen
+  textColor: "#d6ed3e"
+  chatProcessor: ParasiteHivemindChatProcessor
+  prefixes: [ "#h" ]
+  filterCategory: Radio
+# TODO: this would be good to display in world but only if it can be telegraphed distinctively from normal speech
+
+- type: entity
+  id: ParasiteHivemindChatProcessor
+  components:
+  - type: ESGhostListenableChatChannel
+  - type: ESOrganizationChatChannel
+    organization: Parasite
+  - type: ESSpeechVerbChatChannel
+    format: es-chat-channel-parasite-hivemind-fmt-verb
+    boldFormat: es-chat-channel-parasite-hivemind-bold-fmt-verb
+  - type: ESSanitizationChatChannel

--- a/Resources/Prototypes/_ES/Chat/Channels/radio.yml
+++ b/Resources/Prototypes/_ES/Chat/Channels/radio.yml
@@ -22,7 +22,6 @@
   parent: BaseWhisper
   id: RadioWhisperCommon
   name: es-chat-channel-name-radio-common
-  order: 4
   color: LimeGreen
   chatProcessor: RadioWhisperCommonChatProcessor
   prefixes: [ ";" ]
@@ -54,7 +53,6 @@
   parent: BaseWhisper
   id: RadioWhisperCommand
   name: es-chat-channel-name-radio-command
-  order: 5
   color: "#fcdf03"
   chatProcessor: RadioWhisperCommandChatProcessor
   prefixes: [ ":c", ".c" ]
@@ -85,7 +83,6 @@
   parent: BaseWhisper
   id: RadioWhisperEngineering
   name: es-chat-channel-name-radio-engineering
-  order: 6
   color: "#ff733c"
   chatProcessor: RadioWhisperEngineeringChatProcessor
   prefixes: [ ":e", ".e" ]
@@ -116,7 +113,6 @@
   parent: BaseWhisper
   id: RadioWhisperMedical
   name: es-chat-channel-name-radio-medical
-  order: 7
   color: "#57b8f0"
   chatProcessor: RadioWhisperMedicalChatProcessor
   prefixes: [ ":m", ".m" ]
@@ -147,7 +143,6 @@
   parent: BaseWhisper
   id: RadioWhisperScience
   name: es-chat-channel-name-radio-science
-  order: 8
   color: "#cd7ccd"
   chatProcessor: RadioWhisperScienceChatProcessor
   prefixes: [ ":n", ".n" ]
@@ -178,7 +173,6 @@
   parent: BaseWhisper
   id: RadioWhisperSecurity
   name: es-chat-channel-name-radio-security
-  order: 9
   color: "#ff4242"
   chatProcessor: RadioWhisperSecurityChatProcessor
   prefixes: [ ":s", ".s" ]
@@ -209,7 +203,6 @@
   parent: BaseWhisper
   id: RadioWhisperService
   name: es-chat-channel-name-radio-service
-  order: 10
   color: "#539c00"
   chatProcessor: RadioWhisperServiceChatProcessor
   prefixes: [ ":v", ".v" ]
@@ -240,7 +233,6 @@
   parent: BaseWhisper
   id: RadioWhisperSupply
   name: es-chat-channel-name-radio-supply
-  order: 11
   color: "#b48b57"
   chatProcessor: RadioWhisperSupplyChatProcessor
   prefixes: [ ":u", ".u" ]

--- a/Resources/Prototypes/_ES/Chat/Channels/theater.yml
+++ b/Resources/Prototypes/_ES/Chat/Channels/theater.yml
@@ -7,6 +7,7 @@
   prefixes: [ "[" ]
   filterCategory: Lobby
   speechBubbleType: say
+  glorfAffected: true
   focusKey: FocusOOCWindow
   discordRelayChannel: OOC
 
@@ -30,6 +31,7 @@
   filterCategory: Stagehand
   chatBoxLocation: Stagehand
   speechBubbleType: say
+  glorfAffected: true
   focusKey: FocusDeadChatWindow
 
 - type: entity

--- a/Resources/Prototypes/_ES/Chat/Channels/theater.yml
+++ b/Resources/Prototypes/_ES/Chat/Channels/theater.yml
@@ -1,7 +1,6 @@
 - type: esChatChannel
   id: Lobby
   name: es-chat-channel-name-lobby
-  order: 20
   color: Plum
   textColor: plum
   chatProcessor: LobbyChatProcessor
@@ -24,7 +23,6 @@
 - type: esChatChannel
   id: Stagehand
   name: es-chat-channel-name-stagehand
-  order: 21
   color: "#b9b9f8"
   textColor: "#b9b9f8"
   chatProcessor: StagehandChatProcessor

--- a/Resources/Prototypes/_ES/Chat/order.yml
+++ b/Resources/Prototypes/_ES/Chat/order.yml
@@ -4,6 +4,7 @@
   - Speak
   - Whisper
   - Emote
+  - ParasiteHivemind
   - RadioWhisperCommon
   - RadioWhisperCommand
   - RadioWhisperEngineering

--- a/Resources/Prototypes/_ES/Chat/order.yml
+++ b/Resources/Prototypes/_ES/Chat/order.yml
@@ -1,0 +1,17 @@
+- type: esChatChannelOrder
+  id: Default
+  order:
+  - Speak
+  - Whisper
+  - Emote
+  - RadioWhisperCommon
+  - RadioWhisperCommand
+  - RadioWhisperEngineering
+  - RadioWhisperMedical
+  - RadioWhisperScience
+  - RadioWhisperSecurity
+  - RadioWhisperService
+  - RadioWhisperSupply
+  - Lobby
+  - Stagehand
+  - AdminChat

--- a/Resources/Prototypes/_ES/SecretIdentities/base.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/base.yml
@@ -26,6 +26,10 @@
     icon: ESParasite
     organization: Parasite
     examineString: es-secret-identity-organization-parasite-examine
+  mindComponents: # Goes on the mind so that we don't overwrite the base component on the mob
+  - type: ESChatPermissions
+    inherentChannels:
+    - ParasiteHivemind
   objectives:
     all:
     - id: ESObjectiveParasiteDie


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2483 

- Gives worms access to a hivemind channel (`#h`) they can talk on
- Changes chat channel ordering to be an explicit list 
- Fixes non-glorfable chat channels (hivemind, admin) showing typing indicators. maybe this should be a separate bool but i hate a million configurables the reuse is fine for now

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="847" height="111" alt="image" src="https://github.com/user-attachments/assets/c2008422-97fb-41ae-8094-a5ee37079f82" />
<img width="1484" height="129" alt="image" src="https://github.com/user-attachments/assets/c9ffad4c-691a-4b87-b144-3fbce32c018c" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Parasites now have a global hivemind channel they can speak to each other on.