### PR TITLE
Fix Speech Evil Crash

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -286,9 +286,11 @@ public sealed partial class ChatUIController : UIController, IOnSystemChanged<ES
         if (msg.Source == null)
             return;
 
-        var ent = EntityManager.GetEntity(msg.Source.Value);
+        if (!EntityManager.TryGetEntity(msg.Source.Value, out var ent) ||
+            !EntityManager.EntityExists(ent))
+            return;
 
-        EnqueueSpeechBubble(ent, msg, speechType);
+        EnqueueSpeechBubble(ent.Value, msg, speechType);
     }
 
     private SpeechBubble CreateSpeechBubble(EntityUid entity, SpeechBubbleData speechData)
@@ -571,7 +573,7 @@ public sealed partial class ChatUIController : UIController, IOnSystemChanged<ES
             _activeTypingSpeechBubble = null;
         }
 
-        if (_activeTypingSpeechBubble is not null)
+        if (_activeTypingSpeechBubble is not null && !_activeTypingSpeechBubble.Disposed)
         {
             _activeTypingSpeechBubble.RebuildBubbleContents(_activeTypingSpeechBubble.NameText, text, bubbleType);
         }

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChatInputBox.xaml.cs
@@ -1,11 +1,14 @@
-﻿using Content.Shared.Input;
+﻿using Content.Shared._ES.Chat;
+using Content.Shared.Input;
 using Robust.Client.UserInterface.Controls;
 
 namespace Content.Client.UserInterface.Systems.Chat.Controls;
 
 [Virtual]
-public class ChatInputBox : PanelContainer
+public partial class ChatInputBox : PanelContainer
 {
+    [Dependency] private IESSharedChatManager _chat = default!;
+
     public const string StyleClassChatPanel = "ChatPanel";
     public const string StyleClassChatLineEdit = "ChatLineEdit";
     public const string StyleClassChatFilterOptionButton = "ChatFilterOptionButton";
@@ -17,6 +20,8 @@ public class ChatInputBox : PanelContainer
 
     public ChatInputBox()
     {
+        IoCManager.InjectDependencies(this);
+
         Container = new BoxContainer
         {
             Orientation = BoxContainer.LayoutOrientation.Horizontal,
@@ -37,7 +42,8 @@ public class ChatInputBox : PanelContainer
             Name = "Input",
             PlaceHolder = GetChatboxInfoPlaceholder(),
             HorizontalExpand = true,
-            StyleClasses = { StyleClassChatLineEdit }
+            StyleClasses = { StyleClassChatLineEdit },
+            IsValid = IsInputValid,
         };
         Container.AddChild(Input);
         FilterButton = new ChannelFilterButton
@@ -47,6 +53,11 @@ public class ChatInputBox : PanelContainer
         };
         Container.AddChild(FilterButton);
         AddStyleClass(StyleClassChatPanel);
+    }
+
+    private bool IsInputValid(string text)
+    {
+        return text.Length <= _chat.MaxMessageLength;
     }
 
     private static string GetChatboxInfoPlaceholder()

--- a/Content.Server/Advertise/EntitySystems/SpeakOnUIClosedSystem.cs
+++ b/Content.Server/Advertise/EntitySystems/SpeakOnUIClosedSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class SpeakOnUIClosedSystem : SharedSpeakOnUIClosedSystem
             return false;
 
         var message = Loc.GetString(_random.Pick(messagePack.Values), ("name", Name(entity)));
-        _chat.TrySendMessage(message, ESSharedChatSystem.LocalChannel, entity);
+        _chat.TrySendMessage(message, ESSharedChatSystem.LocalChannel, entity, hideChat: entity.Comp.HideChat);
         entity.Comp.Flag = false;
         return true;
     }

--- a/Content.Shared/Advertise/Components/SpeakOnUIClosedComponent.cs
+++ b/Content.Shared/Advertise/Components/SpeakOnUIClosedComponent.cs
@@ -35,4 +35,7 @@ public sealed partial class SpeakOnUIClosedComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public bool Flag;
+
+    [DataField]
+    public bool HideChat = true;
 }

--- a/Content.Shared/CCVar/CCVars.Chat.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.cs
@@ -31,7 +31,7 @@ public sealed partial class CCVars
         CVarDef.Create("chat.rate_limit_announce_admins_delay", 15, CVar.SERVERONLY);
 
     public static readonly CVarDef<int> ChatMaxMessageLength =
-        CVarDef.Create("chat.max_message_length", 1000, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("chat.max_message_length", 192, CVar.SERVER | CVar.REPLICATED);
 
     public static readonly CVarDef<int> ChatMaxAnnouncementLength =
         CVarDef.Create("chat.max_announcement_length", 256, CVar.SERVER | CVar.REPLICATED);


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2530 
Closes #2518
Closes #2519 
Closes #2527 

was trying to fix the word getting clipped at the end of line but who fucking cares that shit did not want to work.

the speech max length stuff is like mildly naive but also who cares if it lets you send 3 characters less than you expect. people shouldn't be sending max length messages anyway.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Decreased the max chat message length to a more reasonable value.
- fix: The chat box will now cut off messages which are too long instead of simply failing to send them.

