### PR TITLE
make apcs use cable terminals

### DIFF
--- a/Resources/Maps/_ES/Shuttles/arrivals.yml
+++ b/Resources/Maps/_ES/Shuttles/arrivals.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Map
+  category: Grid
   engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 08/19/2026 16:20:09
-  entityCount: 932
-maps:
-- 40
+  time: 08/19/2026 22:01:05
+  entityCount: 931
+maps: []
 grids:
 - 1
-orphans: []
+orphans:
+- 1
 nullspace: []
 tilemap:
   8: Space
@@ -32,7 +32,7 @@ entities:
     - type: MetaData
       name: grid
     - type: Transform
-      parent: 40
+      parent: invalid
       pos: -1.421875,-0.328125
     - type: MapGrid
       chunks:
@@ -237,18 +237,6 @@ entities:
     - type: ExplosionAirtightGrid
     - type: ChunkContainer
       chunkEntities: []
-  - uid: 40
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: Broadphase
-    - type: ChunkContainer
-      chunkEntities: []
-    - type: OccluderTree
 - proto: Airlock
   entities:
   - uid: 2
@@ -492,11 +480,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 7.5,14.5
-  - uid: 42
-    components:
-    - type: Transform
-      parent: 1
-      pos: 27.5,0.5
   - uid: 44
     components:
     - type: Transform
@@ -1342,6 +1325,11 @@ entities:
     - type: Transform
       parent: 1
       pos: 27.5,12.5
+  - uid: 225
+    components:
+    - type: Transform
+      parent: 1
+      pos: 27.5,0.5
   - uid: 226
     components:
     - type: Transform
@@ -1477,23 +1465,36 @@ entities:
     - type: Transform
       parent: 1
       pos: 25.5,17.5
-- proto: CableTerminal
+- proto: CableTerminalUncuttable
   entities:
-  - uid: 43
-    components:
-    - type: Transform
-      parent: 1
-      pos: 28.5,0.5
-  - uid: 54
-    components:
-    - type: Transform
-      parent: 1
-      pos: 22.5,-6.5
-  - uid: 56
+  - uid: 40
     components:
     - type: Transform
       parent: 1
       pos: 17.5,-6.5
+  - uid: 42
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 15.5,14.5
+  - uid: 43
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 11.5,14.5
+  - uid: 54
+    components:
+    - type: Transform
+      parent: 1
+      pos: 28.5,0.5
+  - uid: 56
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 7.5,14.5
   - uid: 83
     components:
     - type: Transform
@@ -1536,44 +1537,31 @@ entities:
     components:
     - type: Transform
       parent: 1
-      rot: 3.141592653589793 rad
-      pos: 4.5,9.5
+      pos: 21.5,16.5
   - uid: 209
     components:
     - type: Transform
       parent: 1
-      rot: 1.5707963267948966 rad
-      pos: 7.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,9.5
   - uid: 217
-    components:
-    - type: Transform
-      parent: 1
-      rot: 1.5707963267948966 rad
-      pos: 11.5,14.5
-  - uid: 225
-    components:
-    - type: Transform
-      parent: 1
-      rot: 1.5707963267948966 rad
-      pos: 15.5,14.5
-  - uid: 237
     components:
     - type: Transform
       parent: 1
       rot: -1.5707963267948966 rad
       pos: 17.5,12.5
-  - uid: 249
+  - uid: 237
     components:
     - type: Transform
       parent: 1
-      pos: 21.5,16.5
-  - uid: 931
+      pos: 22.5,-6.5
+  - uid: 249
     components:
     - type: Transform
       parent: 1
       rot: 3.141592653589793 rad
       pos: 29.5,10.5
-  - uid: 932
+  - uid: 931
     components:
     - type: Transform
       parent: 1

--- a/Resources/Maps/_ES/Shuttles/arrivals.yml
+++ b/Resources/Maps/_ES/Shuttles/arrivals.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Grid
-  engineVersion: 283.0.0
+  category: Map
+  engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 07/25/2026 02:17:22
-  entityCount: 930
-maps: []
+  time: 08/19/2026 16:20:09
+  entityCount: 932
+maps:
+- 40
 grids:
 - 1
-orphans:
-- 1
+orphans: []
 nullspace: []
 tilemap:
   8: Space
@@ -32,7 +32,7 @@ entities:
     - type: MetaData
       name: grid
     - type: Transform
-      parent: invalid
+      parent: 40
       pos: -1.421875,-0.328125
     - type: MapGrid
       chunks:
@@ -235,6 +235,20 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ExplosionAirtightGrid
+    - type: ChunkContainer
+      chunkEntities: []
+  - uid: 40
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: GridTree
+    - type: Broadphase
+    - type: ChunkContainer
+      chunkEntities: []
+    - type: OccluderTree
 - proto: Airlock
   entities:
   - uid: 2
@@ -473,11 +487,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 6.5,14.5
-  - uid: 40
-    components:
-    - type: Transform
-      parent: 1
-      pos: -2.5,2.5
   - uid: 41
     components:
     - type: Transform
@@ -487,12 +496,7 @@ entities:
     components:
     - type: Transform
       parent: 1
-      pos: 4.5,10.5
-  - uid: 43
-    components:
-    - type: Transform
-      parent: 1
-      pos: 8.5,14.5
+      pos: 27.5,0.5
   - uid: 44
     components:
     - type: Transform
@@ -543,21 +547,11 @@ entities:
     - type: Transform
       parent: 1
       pos: 10.5,14.5
-  - uid: 54
-    components:
-    - type: Transform
-      parent: 1
-      pos: 12.5,14.5
   - uid: 55
     components:
     - type: Transform
       parent: 1
       pos: 11.5,14.5
-  - uid: 56
-    components:
-    - type: Transform
-      parent: 1
-      pos: -1.5,16.5
   - uid: 57
     components:
     - type: Transform
@@ -688,11 +682,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 14.5,6.5
-  - uid: 83
-    components:
-    - type: Transform
-      parent: 1
-      pos: 16.5,14.5
   - uid: 84
     components:
     - type: Transform
@@ -848,11 +837,6 @@ entities:
     - type: Transform
       parent: 1
       pos: -1.5,5.5
-  - uid: 115
-    components:
-    - type: Transform
-      parent: 1
-      pos: -0.5,-0.5
   - uid: 116
     components:
     - type: Transform
@@ -868,11 +852,6 @@ entities:
     - type: Transform
       parent: 1
       pos: -1.5,1.5
-  - uid: 119
-    components:
-    - type: Transform
-      parent: 1
-      pos: -1.5,-4.5
   - uid: 120
     components:
     - type: Transform
@@ -888,11 +867,6 @@ entities:
     - type: Transform
       parent: 1
       pos: -0.5,-2.5
-  - uid: 123
-    components:
-    - type: Transform
-      parent: 1
-      pos: 10.5,0.5
   - uid: 124
     components:
     - type: Transform
@@ -1023,11 +997,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 3.5,-1.5
-  - uid: 150
-    components:
-    - type: Transform
-      parent: 1
-      pos: 11.5,-3.5
   - uid: 151
     components:
     - type: Transform
@@ -1098,11 +1067,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 15.5,-0.5
-  - uid: 165
-    components:
-    - type: Transform
-      parent: 1
-      pos: 17.5,-7.5
   - uid: 166
     components:
     - type: Transform
@@ -1138,11 +1102,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 19.5,-2.5
-  - uid: 173
-    components:
-    - type: Transform
-      parent: 1
-      pos: 22.5,-7.5
   - uid: 174
     components:
     - type: Transform
@@ -1188,11 +1147,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 18.5,12.5
-  - uid: 183
-    components:
-    - type: Transform
-      parent: 1
-      pos: 16.5,12.5
   - uid: 184
     components:
     - type: Transform
@@ -1318,11 +1272,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 21.5,16.5
-  - uid: 209
-    components:
-    - type: Transform
-      parent: 1
-      pos: 21.5,15.5
   - uid: 210
     components:
     - type: Transform
@@ -1358,11 +1307,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 24.5,17.5
-  - uid: 217
-    components:
-    - type: Transform
-      parent: 1
-      pos: 25.5,11.5
   - uid: 218
     components:
     - type: Transform
@@ -1398,11 +1342,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 27.5,12.5
-  - uid: 225
-    components:
-    - type: Transform
-      parent: 1
-      pos: 29.5,11.5
   - uid: 226
     components:
     - type: Transform
@@ -1458,11 +1397,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 25.5,9.5
-  - uid: 237
-    components:
-    - type: Transform
-      parent: 1
-      pos: 28.5,-0.5
   - uid: 238
     components:
     - type: Transform
@@ -1518,11 +1452,6 @@ entities:
     - type: Transform
       parent: 1
       pos: 18.5,-0.5
-  - uid: 249
-    components:
-    - type: Transform
-      parent: 1
-      pos: 0.5,10.5
   - uid: 250
     components:
     - type: Transform
@@ -1548,6 +1477,107 @@ entities:
     - type: Transform
       parent: 1
       pos: 25.5,17.5
+- proto: CableTerminal
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      parent: 1
+      pos: 28.5,0.5
+  - uid: 54
+    components:
+    - type: Transform
+      parent: 1
+      pos: 22.5,-6.5
+  - uid: 56
+    components:
+    - type: Transform
+      parent: 1
+      pos: 17.5,-6.5
+  - uid: 83
+    components:
+    - type: Transform
+      parent: 1
+      pos: 11.5,-2.5
+  - uid: 115
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+  - uid: 119
+    components:
+    - type: Transform
+      parent: 1
+      pos: -1.5,-3.5
+  - uid: 123
+    components:
+    - type: Transform
+      parent: 1
+      pos: -0.5,0.5
+  - uid: 150
+    components:
+    - type: Transform
+      parent: 1
+      pos: -2.5,3.5
+  - uid: 165
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: -0.5,10.5
+  - uid: 173
+    components:
+    - type: Transform
+      parent: 1
+      rot: 3.141592653589793 rad
+      pos: -1.5,15.5
+  - uid: 183
+    components:
+    - type: Transform
+      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 4.5,9.5
+  - uid: 209
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 7.5,14.5
+  - uid: 217
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 11.5,14.5
+  - uid: 225
+    components:
+    - type: Transform
+      parent: 1
+      rot: 1.5707963267948966 rad
+      pos: 15.5,14.5
+  - uid: 237
+    components:
+    - type: Transform
+      parent: 1
+      rot: -1.5707963267948966 rad
+      pos: 17.5,12.5
+  - uid: 249
+    components:
+    - type: Transform
+      parent: 1
+      pos: 21.5,16.5
+  - uid: 931
+    components:
+    - type: Transform
+      parent: 1
+      rot: 3.141592653589793 rad
+      pos: 29.5,10.5
+  - uid: 932
+    components:
+    - type: Transform
+      parent: 1
+      pos: 25.5,12.5
 - proto: Chair
   entities:
   - uid: 254

--- a/Resources/Maps/_ES/estestship_grid.yml
+++ b/Resources/Maps/_ES/estestship_grid.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Grid
-  engineVersion: 275.0.0
+  category: Map
+  engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 03/30/2026 03:37:30
-  entityCount: 920
-maps: []
+  time: 08/19/2026 16:38:32
+  entityCount: 909
+maps:
+- 18
 grids:
 - 1
-orphans:
-- 1
+orphans: []
 nullspace: []
 tilemap:
   3: Space
@@ -32,8 +32,8 @@ entities:
     - type: MetaData
       name: test_ship
     - type: Transform
+      parent: 18
       pos: -5.321541,-10.87529
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -70,9 +70,9 @@ entities:
           version: 7
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
       fixedRotation: False
       bodyType: Dynamic
+      bodyStatus: InAir
     - type: Fixtures
       fixtures: {}
     - type: BecomesStation
@@ -91,8 +91,8 @@ entities:
         version: 2
         nodes:
         - node:
-            color: '#FFFFFFFF'
             id: Bot
+            color: '#FFFFFFFF'
           decals:
             275: -7,-22
             276: -4,-21
@@ -101,8 +101,8 @@ entities:
             279: -4,-26
             280: -7,-25
         - node:
-            color: '#52B4E996'
             id: CheckerNWSE
+            color: '#52B4E996'
           decals:
             205: 0,-12
             206: 0,-11
@@ -116,8 +116,8 @@ entities:
             214: 4,-11
             215: 4,-12
         - node:
-            color: '#FFFFFFFF'
             id: Delivery
+            color: '#FFFFFFFF'
           decals:
             251: -1,-14
             252: -1,-15
@@ -127,31 +127,31 @@ entities:
             256: -8,-15
             257: -8,-14
         - node:
-            cleanable: True
-            color: '#FFFFFFFF'
             id: DirtHeavyMonotile
+            color: '#FFFFFFFF'
+            cleanable: True
           decals:
             84: 12,-1
             86: 7,2
             115: 9,-1
         - node:
-            color: '#9FED5896'
             id: FullTileOverlayGreyscale
+            color: '#9FED5896'
           decals:
             247: 8,-6
             248: 9,-6
             249: 10,-6
             250: 11,-6
         - node:
-            color: '#D4D4D496'
             id: FullTileOverlayGreyscale
+            color: '#D4D4D496'
           decals:
             160: 1,5
             161: 2,5
             162: 3,5
         - node:
-            color: '#D4D4D496'
             id: HalfTileOverlayGreyscale
+            color: '#D4D4D496'
           decals:
             151: 0,4
             152: 1,4
@@ -163,8 +163,8 @@ entities:
             158: -1,4
             159: -2,4
         - node:
-            color: '#EFB34196'
             id: HalfTileOverlayGreyscale
+            color: '#EFB34196'
           decals:
             269: -7,-14
             270: -6,-14
@@ -173,41 +173,41 @@ entities:
             273: -3,-14
             274: -2,-14
         - node:
-            color: '#FA750096'
             id: HalfTileOverlayGreyscale
+            color: '#FA750096'
           decals:
             242: 8,-9
             243: 9,-9
             244: 10,-9
         - node:
-            color: '#FA750096'
             id: HalfTileOverlayGreyscale180
+            color: '#FA750096'
           decals:
             237: 8,-12
             238: 9,-12
             239: 10,-12
         - node:
-            color: '#EFB34196'
             id: HalfTileOverlayGreyscale270
+            color: '#EFB34196'
           decals:
             230: -2,0
             231: -2,1
             232: -2,-1
         - node:
-            color: '#FA750096'
             id: HalfTileOverlayGreyscale270
+            color: '#FA750096'
           decals:
             245: 7,-11
             246: 7,-10
         - node:
-            color: '#FA750096'
             id: HalfTileOverlayGreyscale90
+            color: '#FA750096'
           decals:
             240: 11,-11
             241: 11,-10
         - node:
-            color: '#D381C996'
             id: QuarterTileOverlayGreyscale
+            color: '#D381C996'
           decals:
             140: 8,-3
             141: 8,-2
@@ -222,8 +222,8 @@ entities:
             163: 8,-4
             164: 11,4
         - node:
-            color: '#D4D4D496'
             id: QuarterTileOverlayGreyscale
+            color: '#D4D4D496'
           decals:
             223: -6,-12
             224: -6,-11
@@ -233,8 +233,8 @@ entities:
             228: -6,-7
             229: -6,-6
         - node:
-            color: '#D381C996'
             id: QuarterTileOverlayGreyscale180
+            color: '#D381C996'
           decals:
             165: 11,4
             166: 11,3
@@ -249,15 +249,15 @@ entities:
             175: 9,-4
             176: 8,-4
         - node:
-            color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale180
+            color: '#D4D4D428'
           decals:
             180: 6,1
             181: 6,0
             182: 6,-1
         - node:
-            color: '#D4D4D428'
             id: QuarterTileOverlayGreyscale270
+            color: '#D4D4D428'
           decals:
             216: -6,-6
             217: -6,-7
@@ -267,50 +267,50 @@ entities:
             221: -6,-11
             222: -6,-12
         - node:
-            color: '#D381C996'
             id: QuarterTileOverlayGreyscale90
+            color: '#D381C996'
           decals:
             177: 6,1
             178: 6,0
             179: 6,-1
         - node:
-            color: '#FA750096'
             id: ThreeQuarterTileOverlayGreyscale
+            color: '#FA750096'
           decals:
             235: 7,-9
         - node:
-            color: '#FA750096'
             id: ThreeQuarterTileOverlayGreyscale180
+            color: '#FA750096'
           decals:
             234: 11,-12
         - node:
-            color: '#FA750096'
             id: ThreeQuarterTileOverlayGreyscale270
+            color: '#FA750096'
           decals:
             236: 7,-12
         - node:
-            color: '#FA750096'
             id: ThreeQuarterTileOverlayGreyscale90
+            color: '#FA750096'
           decals:
             233: 11,-9
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallSW
+            color: '#FFFFFFFF'
           decals:
             201: -8,-4
         - node:
-            color: '#FFFFFFFF'
             id: WarnEndE
+            color: '#FFFFFFFF'
           decals:
             268: -5,-17
         - node:
-            color: '#FFFFFFFF'
             id: WarnEndW
+            color: '#FFFFFFFF'
           decals:
             267: -6,-17
         - node:
-            color: '#FFFFFFFF'
             id: WarnFull
+            color: '#FFFFFFFF'
           decals:
             183: -1,-6
             184: -1,-7
@@ -333,8 +333,8 @@ entities:
             262: -3,-23
             263: -3,-24
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineN
+            color: '#FFFFFFFF'
           decals:
             197: -12,-4
             198: -11,-4
@@ -343,8 +343,8 @@ entities:
             264: -7,-19
             265: -1,-19
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineW
+            color: '#FFFFFFFF'
           decals:
             202: 1,5
             203: 2,5
@@ -352,6 +352,15 @@ entities:
     - type: GridAtmosphere
       version: 2
       data:
+        uniqueMixes:
+        - temperature: 293.15
+          volume: 2500
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          moles: {}
+          immutable: True
         tiles:
           0,0:
             0: 65535
@@ -464,150 +473,155 @@ entities:
             0: 4352
           0,-6:
             0: 4369
-        uniqueMixes:
-        - volume: 2500
-          temperature: 293.15
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          immutable: True
-          moles: {}
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ExplosionAirtightGrid
+    - type: ChunkContainer
+      chunkEntities: []
+  - uid: 18
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: GridTree
+    - type: Broadphase
+    - type: ChunkContainer
+      chunkEntities: []
+    - type: OccluderTree
 - proto: AirlockEngineering
   entities:
   - uid: 601
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,-12.5
-      parent: 1
   - uid: 602
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,-17.5
-      parent: 1
   - uid: 603
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,-19.5
-      parent: 1
   - uid: 604
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,-19.5
-      parent: 1
   - uid: 605
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,-17.5
-      parent: 1
 - proto: AirlockEngineeringGlass
   entities:
   - uid: 290
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -10.5,-4.5
-      parent: 1
 - proto: AirlockExternalShuttleLocked
   entities:
   - uid: 214
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -12.5,1.5
-      parent: 1
   - uid: 218
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -12.5,-0.5
-      parent: 1
 - proto: AirlockGlass
   entities:
   - uid: 73
     components:
     - type: Transform
-      pos: -2.5,0.5
       parent: 1
+      pos: -2.5,0.5
   - uid: 74
     components:
     - type: Transform
-      pos: 2.5,-4.5
       parent: 1
+      pos: 2.5,-4.5
   - uid: 228
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
 - proto: AirlockMaintLocked
   entities:
   - uid: 114
     components:
     - type: Transform
-      pos: -8.5,-14.5
       parent: 1
+      pos: -8.5,-14.5
   - uid: 181
     components:
     - type: Transform
-      pos: 3.5,-12.5
       parent: 1
+      pos: 3.5,-12.5
   - uid: 203
     components:
     - type: Transform
-      pos: -10.5,-7.5
       parent: 1
+      pos: -10.5,-7.5
   - uid: 273
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -10.5,5.5
-      parent: 1
   - uid: 322
     components:
     - type: Transform
-      pos: 12.5,-1.5
       parent: 1
+      pos: 12.5,-1.5
   - uid: 548
     components:
     - type: Transform
-      pos: 12.5,-9.5
       parent: 1
+      pos: 12.5,-9.5
   - uid: 669
     components:
     - type: Transform
-      pos: -7.5,-11.5
       parent: 1
+      pos: -7.5,-11.5
 - proto: AlwaysPoweredWallLight
   entities:
   - uid: 348
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,6.5
-      parent: 1
   - uid: 349
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,6.5
-      parent: 1
 - proto: APCHyperCapacity
   entities:
   - uid: 302
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-4.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: AtmosDeviceFanTiny
@@ -615,1739 +629,1714 @@ entities:
   - uid: 14
     components:
     - type: Transform
-      pos: 3.5,5.5
       parent: 1
+      pos: 3.5,5.5
   - uid: 15
     components:
     - type: Transform
-      pos: 1.5,5.5
       parent: 1
+      pos: 1.5,5.5
   - uid: 23
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 1
+      pos: 2.5,5.5
 - proto: BoozeDispenser
   entities:
   - uid: 399
     components:
     - type: Transform
-      pos: 9.5,-8.5
       parent: 1
+      pos: 9.5,-8.5
 - proto: C4
   entities:
   - uid: 532
     components:
     - type: Transform
-      pos: -4.5,-17.5
       parent: 1
+      pos: -4.5,-17.5
   - uid: 533
     components:
     - type: Transform
-      pos: -3.5,-17.5
       parent: 1
+      pos: -3.5,-17.5
 - proto: CableApcExtension
   entities:
   - uid: 11
     components:
     - type: Transform
+      parent: 1
       pos: 2.5,3.5
-      parent: 1
-  - uid: 18
-    components:
-    - type: Transform
-      pos: -7.5,-4.5
-      parent: 1
   - uid: 25
     components:
     - type: Transform
-      pos: 2.5,-0.5
       parent: 1
+      pos: 2.5,-0.5
   - uid: 26
     components:
     - type: Transform
-      pos: 2.5,-2.5
       parent: 1
+      pos: 2.5,-2.5
   - uid: 28
     components:
     - type: Transform
-      pos: 9.5,-8.5
       parent: 1
+      pos: 9.5,-8.5
   - uid: 39
     components:
     - type: Transform
-      pos: -7.5,-2.5
       parent: 1
+      pos: -7.5,-2.5
   - uid: 40
     components:
     - type: Transform
-      pos: -7.5,-3.5
       parent: 1
+      pos: -7.5,-3.5
   - uid: 42
     components:
     - type: Transform
-      pos: -0.5,-8.5
       parent: 1
+      pos: -0.5,-8.5
   - uid: 43
     components:
     - type: Transform
-      pos: 2.5,-5.5
       parent: 1
+      pos: 2.5,-5.5
   - uid: 44
     components:
     - type: Transform
-      pos: 2.5,0.5
       parent: 1
+      pos: 2.5,0.5
   - uid: 45
     components:
     - type: Transform
-      pos: 3.5,0.5
       parent: 1
+      pos: 3.5,0.5
   - uid: 46
     components:
     - type: Transform
-      pos: 4.5,0.5
       parent: 1
+      pos: 4.5,0.5
   - uid: 57
     components:
     - type: Transform
-      pos: 10.5,-1.5
       parent: 1
+      pos: 10.5,-1.5
   - uid: 58
     components:
     - type: Transform
-      pos: 1.5,0.5
       parent: 1
+      pos: 1.5,0.5
   - uid: 59
     components:
     - type: Transform
-      pos: 10.5,-2.5
       parent: 1
+      pos: 10.5,-2.5
   - uid: 60
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 1
+      pos: 2.5,5.5
   - uid: 61
     components:
     - type: Transform
-      pos: 3.5,3.5
       parent: 1
+      pos: 3.5,3.5
   - uid: 63
     components:
     - type: Transform
-      pos: 2.5,-8.5
       parent: 1
+      pos: 2.5,-8.5
   - uid: 64
     components:
     - type: Transform
-      pos: -2.5,-8.5
       parent: 1
+      pos: -2.5,-8.5
   - uid: 65
     components:
     - type: Transform
-      pos: -5.5,0.5
       parent: 1
+      pos: -5.5,0.5
   - uid: 66
     components:
     - type: Transform
-      pos: -7.5,0.5
       parent: 1
+      pos: -7.5,0.5
   - uid: 75
     components:
     - type: Transform
-      pos: -11.5,0.5
       parent: 1
+      pos: -11.5,0.5
   - uid: 76
     components:
     - type: Transform
-      pos: -9.5,0.5
       parent: 1
+      pos: -9.5,0.5
   - uid: 77
     components:
     - type: Transform
-      pos: -10.5,0.5
       parent: 1
+      pos: -10.5,0.5
   - uid: 78
     components:
     - type: Transform
-      pos: -0.5,0.5
       parent: 1
+      pos: -0.5,0.5
   - uid: 79
     components:
     - type: Transform
-      pos: -6.5,0.5
       parent: 1
+      pos: -6.5,0.5
   - uid: 80
     components:
     - type: Transform
-      pos: 10.5,0.5
       parent: 1
+      pos: 10.5,0.5
   - uid: 81
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 1
+      pos: 10.5,1.5
   - uid: 82
     components:
     - type: Transform
-      pos: 7.5,0.5
       parent: 1
+      pos: 7.5,0.5
   - uid: 95
     components:
     - type: Transform
-      pos: 10.5,-8.5
       parent: 1
+      pos: 10.5,-8.5
   - uid: 136
     components:
     - type: Transform
-      pos: 8.5,-8.5
       parent: 1
+      pos: 8.5,-8.5
   - uid: 138
     components:
     - type: Transform
-      pos: 2.5,-7.5
       parent: 1
+      pos: 2.5,-7.5
   - uid: 140
     components:
     - type: Transform
-      pos: 10.5,3.5
       parent: 1
+      pos: 10.5,3.5
   - uid: 143
     components:
     - type: Transform
-      pos: 3.5,-8.5
       parent: 1
+      pos: 3.5,-8.5
   - uid: 145
     components:
     - type: Transform
-      pos: 5.5,-8.5
       parent: 1
+      pos: 5.5,-8.5
   - uid: 146
     components:
     - type: Transform
-      pos: -3.5,0.5
       parent: 1
+      pos: -3.5,0.5
   - uid: 148
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 1
+      pos: 8.5,0.5
   - uid: 149
     components:
     - type: Transform
-      pos: 10.5,2.5
       parent: 1
+      pos: 10.5,2.5
   - uid: 150
     components:
     - type: Transform
-      pos: -4.5,0.5
       parent: 1
+      pos: -4.5,0.5
   - uid: 151
     components:
     - type: Transform
-      pos: -2.5,0.5
       parent: 1
+      pos: -2.5,0.5
   - uid: 152
     components:
     - type: Transform
-      pos: 6.5,-8.5
       parent: 1
+      pos: 6.5,-8.5
   - uid: 153
     components:
     - type: Transform
-      pos: 2.5,-6.5
       parent: 1
+      pos: 2.5,-6.5
   - uid: 154
     components:
     - type: Transform
-      pos: 2.5,1.5
       parent: 1
+      pos: 2.5,1.5
   - uid: 155
     components:
     - type: Transform
-      pos: 4.5,-8.5
       parent: 1
+      pos: 4.5,-8.5
   - uid: 159
     components:
     - type: Transform
-      pos: 1.5,-8.5
       parent: 1
+      pos: 1.5,-8.5
   - uid: 160
     components:
     - type: Transform
-      pos: -1.5,-8.5
       parent: 1
+      pos: -1.5,-8.5
   - uid: 161
     components:
     - type: Transform
-      pos: 7.5,-8.5
       parent: 1
+      pos: 7.5,-8.5
   - uid: 162
     components:
     - type: Transform
-      pos: 2.5,-3.5
       parent: 1
+      pos: 2.5,-3.5
   - uid: 163
     components:
     - type: Transform
-      pos: 2.5,2.5
       parent: 1
+      pos: 2.5,2.5
   - uid: 166
     components:
     - type: Transform
-      pos: -1.5,0.5
       parent: 1
+      pos: -1.5,0.5
   - uid: 167
     components:
     - type: Transform
-      pos: 5.5,0.5
       parent: 1
+      pos: 5.5,0.5
   - uid: 168
     components:
     - type: Transform
-      pos: 0.5,-8.5
       parent: 1
+      pos: 0.5,-8.5
   - uid: 169
     components:
     - type: Transform
-      pos: 6.5,0.5
       parent: 1
+      pos: 6.5,0.5
   - uid: 172
     components:
     - type: Transform
-      pos: 0.5,0.5
       parent: 1
+      pos: 0.5,0.5
   - uid: 173
     components:
     - type: Transform
-      pos: -8.5,0.5
       parent: 1
+      pos: -8.5,0.5
   - uid: 176
     components:
     - type: Transform
-      pos: 9.5,0.5
       parent: 1
+      pos: 9.5,0.5
   - uid: 177
     components:
     - type: Transform
-      pos: 2.5,4.5
       parent: 1
+      pos: 2.5,4.5
   - uid: 222
     components:
     - type: Transform
-      pos: -7.5,1.5
       parent: 1
+      pos: -7.5,1.5
   - uid: 223
     components:
     - type: Transform
-      pos: -7.5,4.5
       parent: 1
+      pos: -7.5,4.5
   - uid: 224
     components:
     - type: Transform
-      pos: -7.5,2.5
       parent: 1
+      pos: -7.5,2.5
   - uid: 225
     components:
     - type: Transform
-      pos: -7.5,3.5
       parent: 1
+      pos: -7.5,3.5
   - uid: 226
     components:
     - type: Transform
-      pos: -7.5,-0.5
       parent: 1
+      pos: -7.5,-0.5
   - uid: 227
     components:
     - type: Transform
-      pos: -7.5,-1.5
       parent: 1
+      pos: -7.5,-1.5
   - uid: 230
     components:
     - type: Transform
-      pos: 10.5,-0.5
       parent: 1
+      pos: 10.5,-0.5
   - uid: 232
     components:
     - type: Transform
-      pos: 2.5,-4.5
       parent: 1
+      pos: 2.5,-4.5
   - uid: 233
     components:
     - type: Transform
-      pos: 2.5,-1.5
       parent: 1
+      pos: 2.5,-1.5
   - uid: 364
     components:
     - type: Transform
-      pos: 4.5,3.5
       parent: 1
+      pos: 4.5,3.5
   - uid: 366
     components:
     - type: Transform
-      pos: 5.5,3.5
       parent: 1
+      pos: 5.5,3.5
   - uid: 479
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 1
+      pos: -3.5,-8.5
   - uid: 480
     components:
     - type: Transform
-      pos: -3.5,-9.5
       parent: 1
+      pos: -3.5,-9.5
   - uid: 481
     components:
     - type: Transform
-      pos: -3.5,-10.5
       parent: 1
+      pos: -3.5,-10.5
   - uid: 482
     components:
     - type: Transform
-      pos: -3.5,-11.5
       parent: 1
+      pos: -3.5,-11.5
   - uid: 483
     components:
     - type: Transform
-      pos: -3.5,-12.5
       parent: 1
+      pos: -3.5,-12.5
   - uid: 484
     components:
     - type: Transform
-      pos: -3.5,-13.5
       parent: 1
+      pos: -3.5,-13.5
   - uid: 485
     components:
     - type: Transform
-      pos: -3.5,-14.5
       parent: 1
+      pos: -3.5,-14.5
   - uid: 486
     components:
     - type: Transform
-      pos: -3.5,-15.5
       parent: 1
+      pos: -3.5,-15.5
   - uid: 487
     components:
     - type: Transform
-      pos: -3.5,-16.5
       parent: 1
+      pos: -3.5,-16.5
   - uid: 488
     components:
     - type: Transform
-      pos: -3.5,-17.5
       parent: 1
+      pos: -3.5,-17.5
   - uid: 489
     components:
     - type: Transform
-      pos: -4.5,-14.5
       parent: 1
+      pos: -4.5,-14.5
   - uid: 490
     components:
     - type: Transform
-      pos: -5.5,-14.5
       parent: 1
+      pos: -5.5,-14.5
   - uid: 491
     components:
     - type: Transform
-      pos: -6.5,-14.5
       parent: 1
+      pos: -6.5,-14.5
   - uid: 492
     components:
     - type: Transform
-      pos: -6.5,-15.5
       parent: 1
+      pos: -6.5,-15.5
   - uid: 493
     components:
     - type: Transform
-      pos: -6.5,-16.5
       parent: 1
+      pos: -6.5,-16.5
   - uid: 494
     components:
     - type: Transform
-      pos: -6.5,-17.5
       parent: 1
+      pos: -6.5,-17.5
   - uid: 495
     components:
     - type: Transform
-      pos: -6.5,-18.5
       parent: 1
+      pos: -6.5,-18.5
   - uid: 496
     components:
     - type: Transform
-      pos: -6.5,-19.5
       parent: 1
+      pos: -6.5,-19.5
   - uid: 497
     components:
     - type: Transform
-      pos: -6.5,-20.5
       parent: 1
+      pos: -6.5,-20.5
   - uid: 498
     components:
     - type: Transform
-      pos: -6.5,-21.5
       parent: 1
+      pos: -6.5,-21.5
   - uid: 499
     components:
     - type: Transform
-      pos: -6.5,-22.5
       parent: 1
+      pos: -6.5,-22.5
   - uid: 500
     components:
     - type: Transform
-      pos: -6.5,-23.5
       parent: 1
+      pos: -6.5,-23.5
   - uid: 501
     components:
     - type: Transform
-      pos: -6.5,-24.5
       parent: 1
+      pos: -6.5,-24.5
   - uid: 502
     components:
     - type: Transform
-      pos: -6.5,-25.5
       parent: 1
+      pos: -6.5,-25.5
   - uid: 503
     components:
     - type: Transform
-      pos: -5.5,-25.5
       parent: 1
+      pos: -5.5,-25.5
   - uid: 504
     components:
     - type: Transform
-      pos: -4.5,-25.5
       parent: 1
+      pos: -4.5,-25.5
   - uid: 505
     components:
     - type: Transform
-      pos: -3.5,-25.5
       parent: 1
+      pos: -3.5,-25.5
   - uid: 506
     components:
     - type: Transform
-      pos: -2.5,-25.5
       parent: 1
+      pos: -2.5,-25.5
   - uid: 507
     components:
     - type: Transform
-      pos: -1.5,-25.5
       parent: 1
+      pos: -1.5,-25.5
   - uid: 508
     components:
     - type: Transform
-      pos: -0.5,-25.5
       parent: 1
+      pos: -0.5,-25.5
   - uid: 509
     components:
     - type: Transform
-      pos: -0.5,-24.5
       parent: 1
+      pos: -0.5,-24.5
   - uid: 510
     components:
     - type: Transform
-      pos: -0.5,-23.5
       parent: 1
+      pos: -0.5,-23.5
   - uid: 511
     components:
     - type: Transform
-      pos: -0.5,-22.5
       parent: 1
+      pos: -0.5,-22.5
   - uid: 512
     components:
     - type: Transform
-      pos: -0.5,-21.5
       parent: 1
+      pos: -0.5,-21.5
   - uid: 513
     components:
     - type: Transform
-      pos: -0.5,-20.5
       parent: 1
+      pos: -0.5,-20.5
   - uid: 514
     components:
     - type: Transform
-      pos: -0.5,-19.5
       parent: 1
+      pos: -0.5,-19.5
   - uid: 515
     components:
     - type: Transform
-      pos: -0.5,-18.5
       parent: 1
+      pos: -0.5,-18.5
   - uid: 516
     components:
     - type: Transform
-      pos: -0.5,-17.5
       parent: 1
+      pos: -0.5,-17.5
   - uid: 517
     components:
     - type: Transform
-      pos: -0.5,-16.5
       parent: 1
+      pos: -0.5,-16.5
   - uid: 518
     components:
     - type: Transform
-      pos: -0.5,-15.5
       parent: 1
+      pos: -0.5,-15.5
   - uid: 519
     components:
     - type: Transform
-      pos: -0.5,-14.5
       parent: 1
+      pos: -0.5,-14.5
   - uid: 520
     components:
     - type: Transform
-      pos: -1.5,-14.5
       parent: 1
+      pos: -1.5,-14.5
   - uid: 521
     components:
     - type: Transform
-      pos: -2.5,-14.5
       parent: 1
+      pos: -2.5,-14.5
   - uid: 522
     components:
     - type: Transform
-      pos: -5.5,-20.5
       parent: 1
+      pos: -5.5,-20.5
   - uid: 523
     components:
     - type: Transform
-      pos: -4.5,-20.5
       parent: 1
+      pos: -4.5,-20.5
   - uid: 524
     components:
     - type: Transform
-      pos: -3.5,-20.5
       parent: 1
+      pos: -3.5,-20.5
   - uid: 525
     components:
     - type: Transform
-      pos: -2.5,-20.5
       parent: 1
+      pos: -2.5,-20.5
   - uid: 526
     components:
     - type: Transform
-      pos: -1.5,-20.5
       parent: 1
+      pos: -1.5,-20.5
   - uid: 681
     components:
     - type: Transform
-      pos: 11.5,-1.5
       parent: 1
+      pos: 11.5,-1.5
   - uid: 682
     components:
     - type: Transform
-      pos: 12.5,-1.5
       parent: 1
+      pos: 12.5,-1.5
   - uid: 683
     components:
     - type: Transform
-      pos: 13.5,-1.5
       parent: 1
+      pos: 13.5,-1.5
   - uid: 684
     components:
     - type: Transform
-      pos: 13.5,-2.5
       parent: 1
+      pos: 13.5,-2.5
   - uid: 685
     components:
     - type: Transform
-      pos: 13.5,-3.5
       parent: 1
+      pos: 13.5,-3.5
   - uid: 686
     components:
     - type: Transform
-      pos: 13.5,-4.5
       parent: 1
+      pos: 13.5,-4.5
   - uid: 687
     components:
     - type: Transform
-      pos: 13.5,-5.5
       parent: 1
+      pos: 13.5,-5.5
   - uid: 688
     components:
     - type: Transform
-      pos: 13.5,-6.5
       parent: 1
+      pos: 13.5,-6.5
   - uid: 689
     components:
     - type: Transform
-      pos: 13.5,-7.5
       parent: 1
+      pos: 13.5,-7.5
   - uid: 690
     components:
     - type: Transform
-      pos: 13.5,-8.5
       parent: 1
+      pos: 13.5,-8.5
   - uid: 691
     components:
     - type: Transform
-      pos: 13.5,-9.5
       parent: 1
+      pos: 13.5,-9.5
   - uid: 692
     components:
     - type: Transform
-      pos: 12.5,-9.5
       parent: 1
+      pos: 12.5,-9.5
   - uid: 693
     components:
     - type: Transform
-      pos: 11.5,-9.5
       parent: 1
+      pos: 11.5,-9.5
   - uid: 694
     components:
     - type: Transform
-      pos: 10.5,-9.5
       parent: 1
+      pos: 10.5,-9.5
   - uid: 695
     components:
     - type: Transform
-      pos: 3.5,-9.5
       parent: 1
+      pos: 3.5,-9.5
   - uid: 696
     components:
     - type: Transform
-      pos: 3.5,-10.5
       parent: 1
+      pos: 3.5,-10.5
   - uid: 697
     components:
     - type: Transform
-      pos: 3.5,-11.5
       parent: 1
+      pos: 3.5,-11.5
   - uid: 698
     components:
     - type: Transform
-      pos: 3.5,-12.5
       parent: 1
+      pos: 3.5,-12.5
   - uid: 699
     components:
     - type: Transform
-      pos: 3.5,-13.5
       parent: 1
+      pos: 3.5,-13.5
   - uid: 700
     components:
     - type: Transform
-      pos: 3.5,-14.5
       parent: 1
+      pos: 3.5,-14.5
   - uid: 701
     components:
     - type: Transform
-      pos: 3.5,-15.5
       parent: 1
+      pos: 3.5,-15.5
   - uid: 702
     components:
     - type: Transform
-      pos: 3.5,-16.5
       parent: 1
+      pos: 3.5,-16.5
   - uid: 703
     components:
     - type: Transform
-      pos: 3.5,-17.5
       parent: 1
+      pos: 3.5,-17.5
   - uid: 704
     components:
     - type: Transform
-      pos: 3.5,-18.5
       parent: 1
+      pos: 3.5,-18.5
   - uid: 705
     components:
     - type: Transform
-      pos: -4.5,-11.5
       parent: 1
+      pos: -4.5,-11.5
   - uid: 706
     components:
     - type: Transform
-      pos: -5.5,-11.5
       parent: 1
+      pos: -5.5,-11.5
   - uid: 707
     components:
     - type: Transform
-      pos: -6.5,-11.5
       parent: 1
+      pos: -6.5,-11.5
   - uid: 708
     components:
     - type: Transform
-      pos: -7.5,-11.5
       parent: 1
+      pos: -7.5,-11.5
   - uid: 709
     components:
     - type: Transform
-      pos: -8.5,-11.5
       parent: 1
+      pos: -8.5,-11.5
   - uid: 710
     components:
     - type: Transform
-      pos: -9.5,-11.5
       parent: 1
+      pos: -9.5,-11.5
   - uid: 711
     components:
     - type: Transform
-      pos: -10.5,-11.5
       parent: 1
+      pos: -10.5,-11.5
   - uid: 712
     components:
     - type: Transform
-      pos: -10.5,-12.5
       parent: 1
+      pos: -10.5,-12.5
   - uid: 713
     components:
     - type: Transform
-      pos: -10.5,-13.5
       parent: 1
+      pos: -10.5,-13.5
   - uid: 714
     components:
     - type: Transform
-      pos: -10.5,-14.5
       parent: 1
+      pos: -10.5,-14.5
   - uid: 715
     components:
     - type: Transform
-      pos: -10.5,-15.5
       parent: 1
+      pos: -10.5,-15.5
   - uid: 716
     components:
     - type: Transform
-      pos: -10.5,-16.5
       parent: 1
+      pos: -10.5,-16.5
   - uid: 717
     components:
     - type: Transform
-      pos: -10.5,-17.5
       parent: 1
+      pos: -10.5,-17.5
   - uid: 718
     components:
     - type: Transform
-      pos: -10.5,-18.5
       parent: 1
+      pos: -10.5,-18.5
   - uid: 719
     components:
     - type: Transform
-      pos: -10.5,-10.5
       parent: 1
+      pos: -10.5,-10.5
   - uid: 720
     components:
     - type: Transform
-      pos: -10.5,-9.5
       parent: 1
+      pos: -10.5,-9.5
   - uid: 721
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 1
+      pos: -8.5,4.5
   - uid: 722
     components:
     - type: Transform
-      pos: -9.5,4.5
       parent: 1
+      pos: -9.5,4.5
   - uid: 723
     components:
     - type: Transform
-      pos: -10.5,4.5
       parent: 1
+      pos: -10.5,4.5
   - uid: 724
     components:
     - type: Transform
-      pos: -10.5,5.5
       parent: 1
+      pos: -10.5,5.5
   - uid: 725
     components:
     - type: Transform
-      pos: -10.5,6.5
       parent: 1
+      pos: -10.5,6.5
   - uid: 726
     components:
     - type: Transform
-      pos: -9.5,6.5
       parent: 1
+      pos: -9.5,6.5
   - uid: 727
     components:
     - type: Transform
-      pos: -8.5,6.5
       parent: 1
+      pos: -8.5,6.5
   - uid: 728
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 1
+      pos: -7.5,6.5
   - uid: 729
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 1
+      pos: -6.5,6.5
   - uid: 730
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 1
+      pos: -5.5,6.5
   - uid: 731
     components:
     - type: Transform
-      pos: -4.5,6.5
       parent: 1
+      pos: -4.5,6.5
   - uid: 748
     components:
     - type: Transform
-      pos: 1.5,3.5
       parent: 1
+      pos: 1.5,3.5
   - uid: 872
     components:
     - type: Transform
-      pos: 0.5,3.5
       parent: 1
+      pos: 0.5,3.5
   - uid: 873
     components:
     - type: Transform
-      pos: -0.5,3.5
       parent: 1
+      pos: -0.5,3.5
   - uid: 880
     components:
     - type: Transform
-      pos: 3.5,-2.5
       parent: 1
+      pos: 3.5,-2.5
   - uid: 881
     components:
     - type: Transform
-      pos: 4.5,-2.5
       parent: 1
+      pos: 4.5,-2.5
   - uid: 882
     components:
     - type: Transform
-      pos: 5.5,-2.5
       parent: 1
+      pos: 5.5,-2.5
   - uid: 883
     components:
     - type: Transform
-      pos: 1.5,-2.5
       parent: 1
+      pos: 1.5,-2.5
   - uid: 884
     components:
     - type: Transform
-      pos: 0.5,-2.5
       parent: 1
+      pos: 0.5,-2.5
   - uid: 886
     components:
     - type: Transform
-      pos: -4.5,-8.5
       parent: 1
+      pos: -4.5,-8.5
   - uid: 887
     components:
     - type: Transform
-      pos: -5.5,-8.5
       parent: 1
+      pos: -5.5,-8.5
   - uid: 888
     components:
     - type: Transform
-      pos: -6.5,-8.5
       parent: 1
+      pos: -6.5,-8.5
   - uid: 889
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 1
+      pos: -3.5,-7.5
   - uid: 890
     components:
     - type: Transform
-      pos: -3.5,-6.5
       parent: 1
+      pos: -3.5,-6.5
   - uid: 891
     components:
     - type: Transform
-      pos: -3.5,-5.5
       parent: 1
+      pos: -3.5,-5.5
   - uid: 892
     components:
     - type: Transform
-      pos: -4.5,-5.5
       parent: 1
+      pos: -4.5,-5.5
   - uid: 893
     components:
     - type: Transform
-      pos: 5.5,-6.5
       parent: 1
+      pos: 5.5,-6.5
   - uid: 894
     components:
     - type: Transform
-      pos: 5.5,-7.5
       parent: 1
+      pos: 5.5,-7.5
   - uid: 895
     components:
     - type: Transform
-      pos: 9.5,-7.5
       parent: 1
+      pos: 9.5,-7.5
   - uid: 896
     components:
     - type: Transform
-      pos: -0.5,-6.5
       parent: 1
+      pos: -0.5,-6.5
   - uid: 897
     components:
     - type: Transform
-      pos: -0.5,-7.5
       parent: 1
+      pos: -0.5,-7.5
   - uid: 898
     components:
     - type: Transform
-      pos: -0.5,-9.5
       parent: 1
+      pos: -0.5,-9.5
   - uid: 899
     components:
     - type: Transform
-      pos: -0.5,-10.5
       parent: 1
+      pos: -0.5,-10.5
   - uid: 900
     components:
     - type: Transform
-      pos: 9.5,-6.5
       parent: 1
+      pos: 9.5,-6.5
   - uid: 911
     components:
     - type: Transform
-      pos: 9.5,3.5
       parent: 1
+      pos: 9.5,3.5
   - uid: 913
     components:
     - type: Transform
-      pos: 9.5,-2.5
       parent: 1
+      pos: 9.5,-2.5
   - uid: 914
     components:
     - type: Transform
-      pos: 8.5,-9.5
       parent: 1
+      pos: 8.5,-9.5
   - uid: 915
     components:
     - type: Transform
-      pos: 8.5,-10.5
       parent: 1
+      pos: 8.5,-10.5
   - uid: 916
     components:
     - type: Transform
-      pos: 8.5,-11.5
       parent: 1
+      pos: 8.5,-11.5
 - proto: CableHV
   entities:
   - uid: 123
     components:
     - type: Transform
-      pos: -11.5,-6.5
       parent: 1
+      pos: -11.5,-6.5
   - uid: 124
     components:
     - type: Transform
-      pos: -11.5,-5.5
       parent: 1
+      pos: -11.5,-5.5
+  - uid: 129
+    components:
+    - type: Transform
+      parent: 1
+      pos: -6.5,-11.5
+  - uid: 130
+    components:
+    - type: Transform
+      parent: 1
+      pos: -5.5,-11.5
   - uid: 205
     components:
     - type: Transform
-      pos: -10.5,-6.5
       parent: 1
+      pos: -10.5,-6.5
   - uid: 284
     components:
     - type: Transform
-      pos: -8.5,-6.5
       parent: 1
+      pos: -10.5,-7.5
   - uid: 286
     components:
     - type: Transform
-      pos: -9.5,-6.5
       parent: 1
+      pos: -10.5,-8.5
+  - uid: 394
+    components:
+    - type: Transform
+      parent: 1
+      pos: -10.5,-9.5
   - uid: 433
     components:
     - type: Transform
-      pos: -0.5,-16.5
       parent: 1
+      pos: -0.5,-16.5
   - uid: 434
     components:
     - type: Transform
-      pos: -0.5,-15.5
       parent: 1
+      pos: -0.5,-15.5
   - uid: 435
     components:
     - type: Transform
-      pos: -0.5,-17.5
       parent: 1
+      pos: -0.5,-17.5
   - uid: 436
     components:
     - type: Transform
-      pos: -0.5,-18.5
       parent: 1
+      pos: -0.5,-18.5
   - uid: 437
     components:
     - type: Transform
-      pos: -0.5,-19.5
       parent: 1
+      pos: -0.5,-19.5
   - uid: 438
     components:
     - type: Transform
-      pos: -0.5,-20.5
       parent: 1
+      pos: -0.5,-20.5
   - uid: 439
     components:
     - type: Transform
-      pos: -0.5,-21.5
       parent: 1
+      pos: -0.5,-21.5
   - uid: 440
     components:
     - type: Transform
-      pos: -0.5,-22.5
       parent: 1
+      pos: -0.5,-22.5
   - uid: 441
     components:
     - type: Transform
-      pos: -0.5,-23.5
       parent: 1
+      pos: -0.5,-23.5
   - uid: 442
     components:
     - type: Transform
-      pos: -0.5,-24.5
       parent: 1
+      pos: -0.5,-24.5
   - uid: 443
     components:
     - type: Transform
-      pos: -0.5,-25.5
       parent: 1
+      pos: -0.5,-25.5
   - uid: 444
     components:
     - type: Transform
-      pos: -1.5,-25.5
       parent: 1
+      pos: -1.5,-25.5
   - uid: 445
     components:
     - type: Transform
-      pos: -2.5,-25.5
       parent: 1
+      pos: -2.5,-25.5
   - uid: 446
     components:
     - type: Transform
-      pos: -3.5,-25.5
       parent: 1
+      pos: -3.5,-25.5
   - uid: 447
     components:
     - type: Transform
-      pos: -4.5,-25.5
       parent: 1
+      pos: -4.5,-25.5
   - uid: 448
     components:
     - type: Transform
-      pos: -5.5,-25.5
       parent: 1
+      pos: -5.5,-25.5
   - uid: 449
     components:
     - type: Transform
-      pos: -6.5,-25.5
       parent: 1
+      pos: -6.5,-25.5
   - uid: 450
     components:
     - type: Transform
-      pos: -6.5,-24.5
       parent: 1
+      pos: -6.5,-24.5
   - uid: 451
     components:
     - type: Transform
-      pos: -6.5,-23.5
       parent: 1
+      pos: -6.5,-23.5
   - uid: 452
     components:
     - type: Transform
-      pos: -6.5,-22.5
       parent: 1
+      pos: -6.5,-22.5
   - uid: 453
     components:
     - type: Transform
-      pos: -6.5,-21.5
       parent: 1
+      pos: -6.5,-21.5
   - uid: 454
     components:
     - type: Transform
-      pos: -6.5,-20.5
       parent: 1
+      pos: -6.5,-20.5
   - uid: 455
     components:
     - type: Transform
-      pos: -5.5,-20.5
       parent: 1
+      pos: -5.5,-20.5
   - uid: 456
     components:
     - type: Transform
-      pos: -4.5,-20.5
       parent: 1
+      pos: -4.5,-20.5
   - uid: 457
     components:
     - type: Transform
-      pos: -3.5,-20.5
       parent: 1
+      pos: -3.5,-20.5
   - uid: 458
     components:
     - type: Transform
-      pos: -2.5,-20.5
       parent: 1
+      pos: -2.5,-20.5
   - uid: 459
     components:
     - type: Transform
-      pos: -1.5,-20.5
       parent: 1
+      pos: -1.5,-20.5
   - uid: 460
     components:
     - type: Transform
-      pos: 0.5,-16.5
       parent: 1
+      pos: 0.5,-16.5
   - uid: 461
     components:
     - type: Transform
-      pos: 0.5,-15.5
       parent: 1
+      pos: 0.5,-15.5
   - uid: 462
     components:
     - type: Transform
-      pos: 0.5,-14.5
       parent: 1
+      pos: 0.5,-14.5
   - uid: 463
     components:
     - type: Transform
-      pos: 0.5,-13.5
       parent: 1
+      pos: 0.5,-13.5
   - uid: 464
     components:
     - type: Transform
-      pos: -0.5,-13.5
       parent: 1
+      pos: -0.5,-13.5
   - uid: 465
     components:
     - type: Transform
-      pos: -1.5,-13.5
       parent: 1
+      pos: -1.5,-13.5
   - uid: 466
     components:
     - type: Transform
-      pos: -2.5,-13.5
       parent: 1
+      pos: -2.5,-13.5
   - uid: 467
     components:
     - type: Transform
-      pos: -3.5,-13.5
       parent: 1
+      pos: -3.5,-13.5
   - uid: 468
     components:
     - type: Transform
-      pos: -3.5,-12.5
       parent: 1
+      pos: -3.5,-12.5
   - uid: 469
     components:
     - type: Transform
-      pos: -3.5,-10.5
       parent: 1
+      pos: -10.5,-10.5
   - uid: 470
     components:
     - type: Transform
-      pos: -3.5,-9.5
       parent: 1
+      pos: -10.5,-11.5
   - uid: 471
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 1
+      pos: -8.5,-11.5
   - uid: 472
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 1
+      pos: -9.5,-11.5
   - uid: 473
     components:
     - type: Transform
-      pos: -3.5,-6.5
       parent: 1
+      pos: -7.5,-11.5
   - uid: 474
     components:
     - type: Transform
-      pos: -3.5,-11.5
       parent: 1
+      pos: -3.5,-11.5
   - uid: 475
     components:
     - type: Transform
-      pos: -4.5,-6.5
       parent: 1
-  - uid: 476
-    components:
-    - type: Transform
-      pos: -5.5,-6.5
-      parent: 1
-  - uid: 477
-    components:
-    - type: Transform
-      pos: -6.5,-6.5
-      parent: 1
-  - uid: 478
-    components:
-    - type: Transform
-      pos: -7.5,-6.5
-      parent: 1
-  - uid: 534
-    components:
-    - type: Transform
-      pos: -2.5,-19.5
-      parent: 1
-  - uid: 607
-    components:
-    - type: Transform
-      pos: -2.5,-18.5
-      parent: 1
-  - uid: 608
-    components:
-    - type: Transform
-      pos: -2.5,-17.5
-      parent: 1
-  - uid: 609
-    components:
-    - type: Transform
-      pos: -1.5,-17.5
-      parent: 1
+      pos: -4.5,-11.5
 - proto: CableMV
   entities:
   - uid: 16
     components:
     - type: Transform
-      pos: -8.5,-3.5
       parent: 1
+      pos: -8.5,-3.5
   - uid: 17
     components:
     - type: Transform
-      pos: -10.5,-3.5
       parent: 1
+      pos: -10.5,-3.5
   - uid: 20
     components:
     - type: Transform
-      pos: -11.5,-5.5
       parent: 1
+      pos: -11.5,-5.5
   - uid: 21
     components:
     - type: Transform
-      pos: -9.5,-3.5
       parent: 1
+      pos: -9.5,-3.5
   - uid: 22
     components:
     - type: Transform
+      parent: 1
       pos: -7.5,-3.5
-      parent: 1
-  - uid: 122
-    components:
-    - type: Transform
-      pos: -7.5,-4.5
-      parent: 1
   - uid: 126
     components:
     - type: Transform
-      pos: -10.5,-5.5
       parent: 1
+      pos: -10.5,-5.5
   - uid: 127
     components:
     - type: Transform
-      pos: -10.5,-4.5
       parent: 1
+      pos: -10.5,-4.5
 - proto: CableTerminal
   entities:
+  - uid: 122
+    components:
+    - type: Transform
+      parent: 1
+      pos: -7.5,-3.5
   - uid: 301
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -10.5,-6.5
-      parent: 1
   - uid: 431
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,-15.5
-      parent: 1
   - uid: 432
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,-16.5
-      parent: 1
 - proto: CaptainIDCard
   entities:
   - uid: 67
     components:
     - type: Transform
-      pos: 4.5,-3.5
       parent: 1
+      pos: 4.5,-3.5
 - proto: Catwalk
   entities:
   - uid: 352
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,6.5
-      parent: 1
   - uid: 353
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,7.5
-      parent: 1
   - uid: 354
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,6.5
-      parent: 1
   - uid: 355
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
-      parent: 1
   - uid: 356
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,6.5
-      parent: 1
   - uid: 357
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
-      parent: 1
   - uid: 358
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,6.5
-      parent: 1
   - uid: 359
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,7.5
-      parent: 1
   - uid: 360
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,6.5
-      parent: 1
   - uid: 361
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,7.5
-      parent: 1
 - proto: ChairOfficeDark
   entities:
   - uid: 606
     components:
     - type: Transform
-      pos: -3.5,-16.5
       parent: 1
+      pos: -3.5,-16.5
 - proto: ChairOfficeLight
   entities:
   - uid: 103
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 10.5,-3.5
-      parent: 1
 - proto: ChemDispenserEmpty
   entities:
   - uid: 398
     components:
     - type: Transform
-      pos: 10.5,-8.5
       parent: 1
+      pos: 10.5,-8.5
 - proto: ChemMaster
   entities:
   - uid: 396
     components:
     - type: Transform
-      pos: 11.5,-8.5
       parent: 1
+      pos: 11.5,-8.5
 - proto: ClosetEmergencyFilledRandom
   entities:
   - uid: 133
     components:
     - type: Transform
-      pos: -1.5,4.5
       parent: 1
+      pos: -1.5,4.5
 - proto: ClosetFireFilled
   entities:
   - uid: 134
     components:
     - type: Transform
-      pos: -0.5,4.5
       parent: 1
+      pos: -0.5,4.5
 - proto: ClosetMaintenance
   entities:
   - uid: 732
     components:
     - type: Transform
-      pos: -10.5,7.5
       parent: 1
+      pos: -10.5,7.5
   - uid: 733
     components:
     - type: Transform
-      pos: -9.5,7.5
       parent: 1
+      pos: -9.5,7.5
   - uid: 734
     components:
     - type: Transform
-      pos: -3.5,7.5
       parent: 1
+      pos: -3.5,7.5
   - uid: 735
     components:
     - type: Transform
-      pos: -11.5,7.5
       parent: 1
+      pos: -11.5,7.5
   - uid: 736
     components:
     - type: Transform
-      pos: -4.5,7.5
       parent: 1
+      pos: -4.5,7.5
   - uid: 737
     components:
     - type: Transform
-      pos: -8.5,-8.5
       parent: 1
+      pos: -8.5,-8.5
   - uid: 738
     components:
     - type: Transform
-      pos: -8.5,-9.5
       parent: 1
+      pos: -8.5,-9.5
   - uid: 739
     components:
     - type: Transform
-      pos: -8.5,-10.5
       parent: 1
+      pos: -8.5,-10.5
   - uid: 740
     components:
     - type: Transform
-      pos: -9.5,-15.5
       parent: 1
+      pos: -9.5,-15.5
   - uid: 741
     components:
     - type: Transform
-      pos: -9.5,-16.5
       parent: 1
+      pos: -9.5,-16.5
   - uid: 742
     components:
     - type: Transform
-      pos: -9.5,-17.5
       parent: 1
+      pos: -9.5,-17.5
   - uid: 743
     components:
     - type: Transform
-      pos: -9.5,-13.5
       parent: 1
+      pos: -9.5,-13.5
   - uid: 744
     components:
     - type: Transform
-      pos: -9.5,-12.5
       parent: 1
+      pos: -9.5,-12.5
   - uid: 745
     components:
     - type: Transform
-      pos: 4.5,-18.5
       parent: 1
+      pos: 4.5,-18.5
   - uid: 746
     components:
     - type: Transform
-      pos: 4.5,-17.5
       parent: 1
+      pos: 4.5,-17.5
   - uid: 747
     components:
     - type: Transform
-      pos: 4.5,-16.5
       parent: 1
+      pos: 4.5,-16.5
   - uid: 749
     components:
     - type: Transform
-      pos: 4.5,-14.5
       parent: 1
+      pos: 4.5,-14.5
   - uid: 750
     components:
     - type: Transform
-      pos: 15.5,-10.5
       parent: 1
+      pos: 15.5,-10.5
   - uid: 751
     components:
     - type: Transform
-      pos: 15.5,-11.5
       parent: 1
+      pos: 15.5,-11.5
   - uid: 752
     components:
     - type: Transform
-      pos: 15.5,-1.5
       parent: 1
+      pos: 15.5,-1.5
   - uid: 753
     components:
     - type: Transform
-      pos: 15.5,-0.5
       parent: 1
+      pos: 15.5,-0.5
   - uid: 917
     components:
     - type: Transform
-      pos: 4.5,-15.5
       parent: 1
+      pos: 4.5,-15.5
 - proto: ClothingBeltUtility
   entities:
   - uid: 164
     components:
     - type: Transform
-      pos: 6.5,-3.5
       parent: 1
+      pos: 6.5,-3.5
 - proto: ClothingHandsGlovesColorYellow
   entities:
   - uid: 368
     components:
     - type: Transform
-      pos: 6.491309,-3.1327314
       parent: 1
+      pos: 6.491309,-3.1327314
 - proto: ClothingHandsGlovesForensic
   entities:
   - uid: 68
     components:
     - type: Transform
-      pos: 8.463863,-1.778347
       parent: 1
+      pos: 8.463863,-1.778347
 - proto: ClothingShoesBootsMag
   entities:
   - uid: 378
     components:
     - type: Transform
-      pos: 5.582713,4.7356176
       parent: 1
+      pos: 5.582713,4.7356176
 - proto: ComputerMassMedia
   entities:
   - uid: 876
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: 11.5,-3.5
-      parent: 1
 - proto: ComputerPowerMonitoring
   entities:
   - uid: 531
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-17.5
-      parent: 1
 - proto: CrateAirGrenade
   entities:
   - uid: 100
     components:
     - type: Transform
-      pos: 8.5,-3.5
       parent: 1
+      pos: 8.5,-3.5
 - proto: CrateSurgery
   entities:
   - uid: 642
     components:
     - type: Transform
-      pos: 4.5,-10.5
       parent: 1
+      pos: 4.5,-10.5
 - proto: DebugGenerator
   entities:
   - uid: 24
     components:
     - type: Transform
-      pos: -9.5,-6.5
       parent: 1
+      pos: -9.5,-6.5
   - uid: 125
     components:
     - type: Transform
-      pos: -8.5,-6.5
       parent: 1
+      pos: -8.5,-6.5
 - proto: DefaultStationBeaconBotany
   entities:
   - uid: 407
     components:
     - type: Transform
-      pos: 9.5,-6.5
       parent: 1
+      pos: 9.5,-6.5
 - proto: DefaultStationBeaconChemistry
   entities:
   - uid: 406
     components:
     - type: Transform
-      pos: 9.5,-10.5
       parent: 1
+      pos: 9.5,-10.5
 - proto: DefaultStationBeaconDisposals
   entities:
   - uid: 404
     components:
     - type: Transform
-      pos: -4.5,-8.5
       parent: 1
+      pos: -4.5,-8.5
 - proto: DefaultStationBeaconEngineering
   entities:
   - uid: 403
     components:
     - type: Transform
-      pos: -10.5,-5.5
       parent: 1
+      pos: -10.5,-5.5
 - proto: DefaultStationBeaconMedical
   entities:
   - uid: 405
     components:
     - type: Transform
-      pos: 2.5,-10.5
       parent: 1
+      pos: 2.5,-10.5
 - proto: DefaultStationBeaconScience
   entities:
   - uid: 408
     components:
     - type: Transform
-      pos: 10.5,0.5
       parent: 1
+      pos: 10.5,0.5
 - proto: DefaultStationBeaconToolRoom
   entities:
   - uid: 409
     components:
     - type: Transform
-      pos: 2.5,0.5
       parent: 1
+      pos: 2.5,0.5
 - proto: DogBed
   entities:
   - uid: 236
     components:
     - type: Transform
-      pos: -0.5,2.5
       parent: 1
+      pos: -0.5,2.5
 - proto: ESAntimatterCapsule
   entities:
   - uid: 535
     components:
     - type: Transform
-      pos: -3.5,-23.5
       parent: 1
+      pos: -3.5,-23.5
 - proto: ESAutolathe
   entities:
   - uid: 108
     components:
     - type: Transform
-      pos: 11.5,4.5
       parent: 1
+      pos: 11.5,4.5
 - proto: ESCrateServiceJanitorialSupplies
   entities:
   - uid: 919
     components:
     - type: Transform
-      pos: 8.5,-11.5
       parent: 1
+      pos: 8.5,-11.5
 - proto: ESEmag
   entities:
   - uid: 2
     components:
     - type: Transform
-      pos: 4.668252,-3.3334112
       parent: 1
+      pos: 4.668252,-3.3334112
 - proto: ESFireAxeCabinetFilled
   entities:
   - uid: 209
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -2.5,2.5
-      parent: 1
     - type: Fixtures
       fixtures: {}
 - proto: ESMagazine9mm
@@ -2355,1323 +2344,1321 @@ entities:
   - uid: 3
     components:
     - type: Transform
-      pos: 0.6912546,-3.3862343
       parent: 1
+      pos: 0.6912546,-3.3862343
   - uid: 31
     components:
     - type: Transform
-      pos: 0.7537546,-3.2924843
       parent: 1
+      pos: 0.7537546,-3.2924843
   - uid: 294
     components:
     - type: Transform
-      pos: 0.5975046,-3.5581093
       parent: 1
+      pos: 0.5975046,-3.5581093
 - proto: ESMarkerSpawnRegionMaintenance
   entities:
   - uid: 761
     components:
     - type: Transform
-      pos: 15.5,-8.5
       parent: 1
+      pos: 15.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 762
     components:
     - type: Transform
-      pos: 15.5,-9.5
       parent: 1
+      pos: 15.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 763
     components:
     - type: Transform
-      pos: 15.5,-10.5
       parent: 1
+      pos: 15.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 764
     components:
     - type: Transform
-      pos: 15.5,-11.5
       parent: 1
+      pos: 15.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 765
     components:
     - type: Transform
-      pos: 13.5,-0.5
       parent: 1
+      pos: 13.5,-0.5
     - type: PlacementReplacement
       key: ""
   - uid: 766
     components:
     - type: Transform
-      pos: 13.5,-1.5
       parent: 1
+      pos: 13.5,-1.5
     - type: PlacementReplacement
       key: ""
   - uid: 767
     components:
     - type: Transform
-      pos: 13.5,-2.5
       parent: 1
+      pos: 13.5,-2.5
     - type: PlacementReplacement
       key: ""
   - uid: 768
     components:
     - type: Transform
-      pos: 13.5,-3.5
       parent: 1
+      pos: 13.5,-3.5
     - type: PlacementReplacement
       key: ""
   - uid: 769
     components:
     - type: Transform
-      pos: 13.5,-4.5
       parent: 1
+      pos: 13.5,-4.5
     - type: PlacementReplacement
       key: ""
   - uid: 770
     components:
     - type: Transform
-      pos: 13.5,-5.5
       parent: 1
+      pos: 13.5,-5.5
     - type: PlacementReplacement
       key: ""
   - uid: 771
     components:
     - type: Transform
-      pos: 13.5,-6.5
       parent: 1
+      pos: 13.5,-6.5
     - type: PlacementReplacement
       key: ""
   - uid: 772
     components:
     - type: Transform
-      pos: 13.5,-7.5
       parent: 1
+      pos: 13.5,-7.5
     - type: PlacementReplacement
       key: ""
   - uid: 773
     components:
     - type: Transform
-      pos: 13.5,-8.5
       parent: 1
+      pos: 13.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 774
     components:
     - type: Transform
-      pos: 13.5,-9.5
       parent: 1
+      pos: 13.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 775
     components:
     - type: Transform
-      pos: 14.5,-9.5
       parent: 1
+      pos: 14.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 776
     components:
     - type: Transform
-      pos: 14.5,-10.5
       parent: 1
+      pos: 14.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 777
     components:
     - type: Transform
-      pos: 14.5,-11.5
       parent: 1
+      pos: 14.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 778
     components:
     - type: Transform
-      pos: 15.5,-0.5
       parent: 1
+      pos: 15.5,-0.5
     - type: PlacementReplacement
       key: ""
   - uid: 779
     components:
     - type: Transform
-      pos: 15.5,-1.5
       parent: 1
+      pos: 15.5,-1.5
     - type: PlacementReplacement
       key: ""
   - uid: 780
     components:
     - type: Transform
-      pos: 15.5,-2.5
       parent: 1
+      pos: 15.5,-2.5
     - type: PlacementReplacement
       key: ""
   - uid: 781
     components:
     - type: Transform
-      pos: 15.5,-3.5
       parent: 1
+      pos: 15.5,-3.5
     - type: PlacementReplacement
       key: ""
   - uid: 782
     components:
     - type: Transform
-      pos: 15.5,-4.5
       parent: 1
+      pos: 15.5,-4.5
     - type: PlacementReplacement
       key: ""
   - uid: 783
     components:
     - type: Transform
-      pos: 15.5,-5.5
       parent: 1
+      pos: 15.5,-5.5
     - type: PlacementReplacement
       key: ""
   - uid: 784
     components:
     - type: Transform
-      pos: 15.5,-6.5
       parent: 1
+      pos: 15.5,-6.5
     - type: PlacementReplacement
       key: ""
   - uid: 785
     components:
     - type: Transform
-      pos: 15.5,-7.5
       parent: 1
+      pos: 15.5,-7.5
     - type: PlacementReplacement
       key: ""
   - uid: 786
     components:
     - type: Transform
-      pos: 13.5,-10.5
       parent: 1
+      pos: 13.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 787
     components:
     - type: Transform
-      pos: 13.5,-11.5
       parent: 1
+      pos: 13.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 788
     components:
     - type: Transform
-      pos: 14.5,-0.5
       parent: 1
+      pos: 14.5,-0.5
     - type: PlacementReplacement
       key: ""
   - uid: 789
     components:
     - type: Transform
-      pos: 14.5,-1.5
       parent: 1
+      pos: 14.5,-1.5
     - type: PlacementReplacement
       key: ""
   - uid: 790
     components:
     - type: Transform
-      pos: 14.5,-2.5
       parent: 1
+      pos: 14.5,-2.5
     - type: PlacementReplacement
       key: ""
   - uid: 791
     components:
     - type: Transform
-      pos: 14.5,-3.5
       parent: 1
+      pos: 14.5,-3.5
     - type: PlacementReplacement
       key: ""
   - uid: 792
     components:
     - type: Transform
-      pos: 14.5,-4.5
       parent: 1
+      pos: 14.5,-4.5
     - type: PlacementReplacement
       key: ""
   - uid: 793
     components:
     - type: Transform
-      pos: 14.5,-5.5
       parent: 1
+      pos: 14.5,-5.5
     - type: PlacementReplacement
       key: ""
   - uid: 794
     components:
     - type: Transform
-      pos: 14.5,-6.5
       parent: 1
+      pos: 14.5,-6.5
     - type: PlacementReplacement
       key: ""
   - uid: 795
     components:
     - type: Transform
-      pos: 14.5,-7.5
       parent: 1
+      pos: 14.5,-7.5
     - type: PlacementReplacement
       key: ""
   - uid: 796
     components:
     - type: Transform
-      pos: 14.5,-8.5
       parent: 1
+      pos: 14.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 797
     components:
     - type: Transform
-      pos: 2.5,-13.5
       parent: 1
+      pos: 2.5,-13.5
     - type: PlacementReplacement
       key: ""
   - uid: 798
     components:
     - type: Transform
-      pos: 2.5,-14.5
       parent: 1
+      pos: 2.5,-14.5
     - type: PlacementReplacement
       key: ""
   - uid: 799
     components:
     - type: Transform
-      pos: 2.5,-15.5
       parent: 1
+      pos: 2.5,-15.5
     - type: PlacementReplacement
       key: ""
   - uid: 800
     components:
     - type: Transform
-      pos: 2.5,-16.5
       parent: 1
+      pos: 2.5,-16.5
     - type: PlacementReplacement
       key: ""
   - uid: 801
     components:
     - type: Transform
-      pos: 2.5,-17.5
       parent: 1
+      pos: 2.5,-17.5
     - type: PlacementReplacement
       key: ""
   - uid: 802
     components:
     - type: Transform
-      pos: 2.5,-18.5
       parent: 1
+      pos: 2.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 803
     components:
     - type: Transform
-      pos: 3.5,-13.5
       parent: 1
+      pos: 3.5,-13.5
     - type: PlacementReplacement
       key: ""
   - uid: 804
     components:
     - type: Transform
-      pos: 3.5,-14.5
       parent: 1
+      pos: 3.5,-14.5
     - type: PlacementReplacement
       key: ""
   - uid: 805
     components:
     - type: Transform
-      pos: 3.5,-15.5
       parent: 1
+      pos: 3.5,-15.5
     - type: PlacementReplacement
       key: ""
   - uid: 806
     components:
     - type: Transform
-      pos: 3.5,-16.5
       parent: 1
+      pos: 3.5,-16.5
     - type: PlacementReplacement
       key: ""
   - uid: 807
     components:
     - type: Transform
-      pos: 3.5,-17.5
       parent: 1
+      pos: 3.5,-17.5
     - type: PlacementReplacement
       key: ""
   - uid: 808
     components:
     - type: Transform
-      pos: 3.5,-18.5
       parent: 1
+      pos: 3.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 809
     components:
     - type: Transform
-      pos: 4.5,-13.5
       parent: 1
+      pos: 4.5,-13.5
     - type: PlacementReplacement
       key: ""
   - uid: 810
     components:
     - type: Transform
-      pos: 4.5,-14.5
       parent: 1
+      pos: 4.5,-14.5
     - type: PlacementReplacement
       key: ""
   - uid: 811
     components:
     - type: Transform
-      pos: 4.5,-15.5
       parent: 1
+      pos: 4.5,-15.5
     - type: PlacementReplacement
       key: ""
   - uid: 812
     components:
     - type: Transform
-      pos: 4.5,-16.5
       parent: 1
+      pos: 4.5,-16.5
     - type: PlacementReplacement
       key: ""
   - uid: 813
     components:
     - type: Transform
-      pos: 4.5,-17.5
       parent: 1
+      pos: 4.5,-17.5
     - type: PlacementReplacement
       key: ""
   - uid: 814
     components:
     - type: Transform
-      pos: 4.5,-18.5
       parent: 1
+      pos: 4.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 815
     components:
     - type: Transform
-      pos: 1.5,-18.5
       parent: 1
+      pos: 1.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 816
     components:
     - type: Transform
-      pos: -8.5,-18.5
       parent: 1
+      pos: -8.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 817
     components:
     - type: Transform
-      pos: -11.5,-8.5
       parent: 1
+      pos: -11.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 818
     components:
     - type: Transform
-      pos: -10.5,-8.5
       parent: 1
+      pos: -10.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 819
     components:
     - type: Transform
-      pos: -11.5,-18.5
       parent: 1
+      pos: -11.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 820
     components:
     - type: Transform
-      pos: -11.5,-17.5
       parent: 1
+      pos: -11.5,-17.5
     - type: PlacementReplacement
       key: ""
   - uid: 821
     components:
     - type: Transform
-      pos: -11.5,-16.5
       parent: 1
+      pos: -11.5,-16.5
     - type: PlacementReplacement
       key: ""
   - uid: 822
     components:
     - type: Transform
-      pos: -11.5,-15.5
       parent: 1
+      pos: -11.5,-15.5
     - type: PlacementReplacement
       key: ""
   - uid: 823
     components:
     - type: Transform
-      pos: -11.5,-14.5
       parent: 1
+      pos: -11.5,-14.5
     - type: PlacementReplacement
       key: ""
   - uid: 824
     components:
     - type: Transform
-      pos: -11.5,-13.5
       parent: 1
+      pos: -11.5,-13.5
     - type: PlacementReplacement
       key: ""
   - uid: 825
     components:
     - type: Transform
-      pos: -11.5,-12.5
       parent: 1
+      pos: -11.5,-12.5
     - type: PlacementReplacement
       key: ""
   - uid: 826
     components:
     - type: Transform
-      pos: -11.5,-11.5
       parent: 1
+      pos: -11.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 827
     components:
     - type: Transform
-      pos: -11.5,-10.5
       parent: 1
+      pos: -11.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 828
     components:
     - type: Transform
-      pos: -11.5,-9.5
       parent: 1
+      pos: -11.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 829
     components:
     - type: Transform
-      pos: -9.5,-8.5
       parent: 1
+      pos: -9.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 830
     components:
     - type: Transform
-      pos: -10.5,-18.5
       parent: 1
+      pos: -10.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 831
     components:
     - type: Transform
-      pos: -10.5,-17.5
       parent: 1
+      pos: -10.5,-17.5
     - type: PlacementReplacement
       key: ""
   - uid: 832
     components:
     - type: Transform
-      pos: -10.5,-16.5
       parent: 1
+      pos: -10.5,-16.5
     - type: PlacementReplacement
       key: ""
   - uid: 833
     components:
     - type: Transform
-      pos: -10.5,-15.5
       parent: 1
+      pos: -10.5,-15.5
     - type: PlacementReplacement
       key: ""
   - uid: 834
     components:
     - type: Transform
-      pos: -10.5,-14.5
       parent: 1
+      pos: -10.5,-14.5
     - type: PlacementReplacement
       key: ""
   - uid: 835
     components:
     - type: Transform
-      pos: -10.5,-13.5
       parent: 1
+      pos: -10.5,-13.5
     - type: PlacementReplacement
       key: ""
   - uid: 836
     components:
     - type: Transform
-      pos: -10.5,-12.5
       parent: 1
+      pos: -10.5,-12.5
     - type: PlacementReplacement
       key: ""
   - uid: 837
     components:
     - type: Transform
-      pos: -10.5,-11.5
       parent: 1
+      pos: -10.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 838
     components:
     - type: Transform
-      pos: -10.5,-10.5
       parent: 1
+      pos: -10.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 839
     components:
     - type: Transform
-      pos: -10.5,-9.5
       parent: 1
+      pos: -10.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 840
     components:
     - type: Transform
-      pos: -9.5,-18.5
       parent: 1
+      pos: -9.5,-18.5
     - type: PlacementReplacement
       key: ""
   - uid: 841
     components:
     - type: Transform
-      pos: -9.5,-17.5
       parent: 1
+      pos: -9.5,-17.5
     - type: PlacementReplacement
       key: ""
   - uid: 842
     components:
     - type: Transform
-      pos: -9.5,-16.5
       parent: 1
+      pos: -9.5,-16.5
     - type: PlacementReplacement
       key: ""
   - uid: 843
     components:
     - type: Transform
-      pos: -9.5,-15.5
       parent: 1
+      pos: -9.5,-15.5
     - type: PlacementReplacement
       key: ""
   - uid: 844
     components:
     - type: Transform
-      pos: -9.5,-14.5
       parent: 1
+      pos: -9.5,-14.5
     - type: PlacementReplacement
       key: ""
   - uid: 845
     components:
     - type: Transform
-      pos: -9.5,-13.5
       parent: 1
+      pos: -9.5,-13.5
     - type: PlacementReplacement
       key: ""
   - uid: 846
     components:
     - type: Transform
-      pos: -9.5,-12.5
       parent: 1
+      pos: -9.5,-12.5
     - type: PlacementReplacement
       key: ""
   - uid: 847
     components:
     - type: Transform
-      pos: -9.5,-11.5
       parent: 1
+      pos: -9.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 848
     components:
     - type: Transform
-      pos: -9.5,-10.5
       parent: 1
+      pos: -9.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 849
     components:
     - type: Transform
-      pos: -9.5,-9.5
       parent: 1
+      pos: -9.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 850
     components:
     - type: Transform
-      pos: -8.5,7.5
       parent: 1
+      pos: -8.5,7.5
   - uid: 851
     components:
     - type: Transform
-      pos: -8.5,-10.5
       parent: 1
+      pos: -8.5,-10.5
     - type: PlacementReplacement
       key: ""
   - uid: 852
     components:
     - type: Transform
-      pos: -8.5,-9.5
       parent: 1
+      pos: -8.5,-9.5
     - type: PlacementReplacement
       key: ""
   - uid: 853
     components:
     - type: Transform
-      pos: -8.5,-8.5
       parent: 1
+      pos: -8.5,-8.5
     - type: PlacementReplacement
       key: ""
   - uid: 854
     components:
     - type: Transform
-      pos: -8.5,-11.5
       parent: 1
+      pos: -8.5,-11.5
     - type: PlacementReplacement
       key: ""
   - uid: 855
     components:
     - type: Transform
-      pos: -8.5,6.5
       parent: 1
+      pos: -8.5,6.5
   - uid: 856
     components:
     - type: Transform
-      pos: -9.5,7.5
       parent: 1
+      pos: -9.5,7.5
   - uid: 857
     components:
     - type: Transform
-      pos: -9.5,6.5
       parent: 1
+      pos: -9.5,6.5
   - uid: 858
     components:
     - type: Transform
-      pos: -10.5,7.5
       parent: 1
+      pos: -10.5,7.5
   - uid: 859
     components:
     - type: Transform
-      pos: -10.5,6.5
       parent: 1
+      pos: -10.5,6.5
   - uid: 860
     components:
     - type: Transform
-      pos: -11.5,7.5
       parent: 1
+      pos: -11.5,7.5
   - uid: 861
     components:
     - type: Transform
-      pos: -11.5,6.5
       parent: 1
+      pos: -11.5,6.5
   - uid: 862
     components:
     - type: Transform
-      pos: -3.5,7.5
       parent: 1
+      pos: -3.5,7.5
   - uid: 863
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 1
+      pos: -3.5,6.5
   - uid: 864
     components:
     - type: Transform
-      pos: -4.5,7.5
       parent: 1
+      pos: -4.5,7.5
   - uid: 865
     components:
     - type: Transform
-      pos: -4.5,6.5
       parent: 1
+      pos: -4.5,6.5
   - uid: 866
     components:
     - type: Transform
-      pos: -5.5,7.5
       parent: 1
+      pos: -5.5,7.5
   - uid: 867
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 1
+      pos: -5.5,6.5
   - uid: 868
     components:
     - type: Transform
-      pos: -6.5,7.5
       parent: 1
+      pos: -6.5,7.5
   - uid: 869
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 1
+      pos: -6.5,6.5
   - uid: 870
     components:
     - type: Transform
-      pos: -7.5,7.5
       parent: 1
+      pos: -7.5,7.5
   - uid: 871
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 1
+      pos: -7.5,6.5
 - proto: ESNegentropyAccumulator
   entities:
   - uid: 208
     components:
     - type: Transform
-      pos: -0.5,-21.5
       parent: 1
+      pos: -0.5,-21.5
   - uid: 387
     components:
     - type: Transform
-      pos: -6.5,-21.5
       parent: 1
+      pos: -6.5,-21.5
   - uid: 388
     components:
     - type: Transform
-      pos: -6.5,-24.5
       parent: 1
+      pos: -6.5,-24.5
   - uid: 389
     components:
     - type: Transform
-      pos: -3.5,-25.5
       parent: 1
+      pos: -3.5,-25.5
   - uid: 390
     components:
     - type: Transform
-      pos: -0.5,-24.5
       parent: 1
+      pos: -0.5,-24.5
   - uid: 391
     components:
     - type: Transform
-      pos: -3.5,-20.5
       parent: 1
+      pos: -3.5,-20.5
 - proto: ESPoweredLightDepartment
   entities:
   - uid: 7
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,-11.5
-      parent: 1
   - uid: 112
     components:
     - type: Transform
-      pos: -7.5,4.5
       parent: 1
+      pos: -7.5,4.5
   - uid: 119
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -3.5,1.5
-      parent: 1
   - uid: 120
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -1.5,1.5
-      parent: 1
   - uid: 121
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,3.5
-      parent: 1
   - uid: 200
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -11.5,0.5
-      parent: 1
   - uid: 206
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,-2.5
-      parent: 1
   - uid: 258
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-11.5
-      parent: 1
   - uid: 282
     components:
     - type: Transform
-      pos: 5.5,4.5
       parent: 1
+      pos: 5.5,4.5
   - uid: 283
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -9.5,-6.5
-      parent: 1
   - uid: 289
     components:
     - type: Transform
-      pos: -0.5,4.5
       parent: 1
+      pos: -0.5,4.5
   - uid: 303
     components:
     - type: Transform
-      pos: 7.5,-5.5
       parent: 1
+      pos: 7.5,-5.5
   - uid: 304
     components:
     - type: Transform
-      pos: -2.5,-5.5
       parent: 1
+      pos: -2.5,-5.5
   - uid: 327
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 11.5,-8.5
-      parent: 1
   - uid: 328
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -6.5,-8.5
-      parent: 1
   - uid: 329
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
-      parent: 1
   - uid: 330
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,-3.5
-      parent: 1
   - uid: 331
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
-      parent: 1
   - uid: 332
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-3.5
-      parent: 1
   - uid: 592
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-15.5
-      parent: 1
   - uid: 593
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,-15.5
-      parent: 1
   - uid: 594
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,-17.5
-      parent: 1
   - uid: 595
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -2.5,-17.5
-      parent: 1
   - uid: 596
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-22.5
-      parent: 1
   - uid: 597
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,-26.5
-      parent: 1
   - uid: 598
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 0.5,-22.5
-      parent: 1
   - uid: 599
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -6.5,-18.5
-      parent: 1
   - uid: 600
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -0.5,-18.5
-      parent: 1
 - proto: ESShotgunShellsBoxBeanbag
   entities:
   - uid: 371
     components:
     - type: Transform
+      parent: 1
       pos: -1.7068815,-0.5606327
-      parent: 1
-- proto: ESShotgunShellsBoxBuckshot
-  entities:
-  - uid: 373
-    components:
-    - type: Transform
-      pos: -1.3943815,-0.2637577
-      parent: 1
 - proto: ESShotgunShellsBoxBuckshot
   entities:
   - uid: 372
     components:
     - type: Transform
-      pos: -1.4568815,-0.8106327
       parent: 1
+      pos: -1.4568815,-0.8106327
+  - uid: 373
+    components:
+    - type: Transform
+      parent: 1
+      pos: -1.3943815,-0.2637577
 - proto: ESSpawnPointAssistant
   entities:
   - uid: 234
     components:
     - type: Transform
-      pos: 1.5,2.5
       parent: 1
+      pos: 1.5,2.5
 - proto: ESSpawnPointAtmos
   entities:
   - uid: 377
     components:
     - type: Transform
-      pos: -2.5,-14.5
       parent: 1
+      pos: -2.5,-14.5
 - proto: ESSpawnPointBartender
   entities:
   - uid: 885
     components:
     - type: Transform
-      pos: 7.5,-9.5
       parent: 1
+      pos: 7.5,-9.5
 - proto: ESSpawnPointCaptain
   entities:
   - uid: 170
     components:
     - type: Transform
+      parent: 1
       pos: 2.5,2.5
-      parent: 1
-- proto: ESSpawnPointQuartermaster
-  entities:
-  - uid: 375
-    components:
-    - type: Transform
-      pos: 10.5,2.5
-      parent: 1
 - proto: ESSpawnPointChef
   entities:
   - uid: 641
     components:
     - type: Transform
-      pos: 7.5,-7.5
       parent: 1
+      pos: 7.5,-7.5
 - proto: ESSpawnPointClown
   entities:
   - uid: 132
     components:
     - type: Transform
-      pos: 7.5,-8.5
       parent: 1
+      pos: 7.5,-8.5
 - proto: ESSpawnPointCoroner
   entities:
   - uid: 165
     components:
     - type: Transform
-      pos: 1.5,-9.5
       parent: 1
+      pos: 1.5,-9.5
 - proto: ESSpawnPointDetective
   entities:
   - uid: 639
     components:
     - type: Transform
+      parent: 1
       pos: -0.5,-1.5
-      parent: 1
-- proto: ESSpawnPointStationAdmin
-  entities:
-  - uid: 877
-    components:
-    - type: Transform
-      pos: 3.5,2.5
-      parent: 1
 - proto: ESSpawnPointJanitor
   entities:
   - uid: 878
     components:
     - type: Transform
-      pos: 7.5,-10.5
       parent: 1
+      pos: 7.5,-10.5
 - proto: ESSpawnPointMedicalDoctor
   entities:
   - uid: 645
     components:
     - type: Transform
-      pos: 3.5,-9.5
       parent: 1
+      pos: 3.5,-9.5
 - proto: ESSpawnPointParamedic
   entities:
   - uid: 400
     components:
     - type: Transform
-      pos: 2.5,-9.5
       parent: 1
+      pos: 2.5,-9.5
+- proto: ESSpawnPointQuartermaster
+  entities:
+  - uid: 375
+    components:
+    - type: Transform
+      parent: 1
+      pos: 10.5,2.5
 - proto: ESSpawnPointReporter
   entities:
   - uid: 54
     components:
     - type: Transform
-      pos: 10.5,-2.5
       parent: 1
+      pos: 10.5,-2.5
 - proto: ESSpawnPointScientist
   entities:
   - uid: 901
     components:
     - type: Transform
-      pos: 10.5,-1.5
       parent: 1
+      pos: 10.5,-1.5
 - proto: ESSpawnPointSecurityOfficer
   entities:
   - uid: 640
     components:
     - type: Transform
-      pos: 0.5,-1.5
       parent: 1
+      pos: 0.5,-1.5
+- proto: ESSpawnPointStationAdmin
+  entities:
+  - uid: 877
+    components:
+    - type: Transform
+      parent: 1
+      pos: 3.5,2.5
 - proto: ESSpawnPointStationEngineer
   entities:
   - uid: 376
     components:
     - type: Transform
-      pos: -4.5,-14.5
       parent: 1
+      pos: -4.5,-14.5
 - proto: ESSpawnPointTheatergoer
   entities:
   - uid: 879
     components:
     - type: Transform
-      pos: 2.5,3.5
       parent: 1
+      pos: 2.5,3.5
 - proto: ESSpeedLoader357
   entities:
   - uid: 175
     components:
     - type: Transform
-      pos: 0.035004616,-3.6206093
       parent: 1
+      pos: 0.035004616,-3.6206093
   - uid: 369
     components:
     - type: Transform
-      pos: 0.19125462,-3.3237343
       parent: 1
+      pos: 0.19125462,-3.3237343
   - uid: 370
     components:
     - type: Transform
-      pos: 0.14437962,-3.4643593
       parent: 1
+      pos: 0.14437962,-3.4643593
 - proto: ESSuitStorageFilledEVA
   entities:
   - uid: 374
     components:
     - type: Transform
-      pos: 4.5,4.5
       parent: 1
+      pos: 4.5,4.5
 - proto: ESVendingMachineChemicals
   entities:
   - uid: 397
     components:
     - type: Transform
-      pos: 11.5,-11.5
       parent: 1
+      pos: 11.5,-11.5
 - proto: ESVendingMachineMedical
   entities:
   - uid: 363
     components:
     - type: Transform
-      pos: 4.5,-11.5
       parent: 1
+      pos: 4.5,-11.5
 - proto: ESVendingMachineNutri
   entities:
   - uid: 395
     components:
     - type: Transform
-      pos: 10.5,-7.5
       parent: 1
+      pos: 10.5,-7.5
 - proto: ESVendingMachineSeedsUnlocked
   entities:
   - uid: 393
     components:
     - type: Transform
-      pos: 11.5,-7.5
       parent: 1
+      pos: 11.5,-7.5
 - proto: ESWeaponCaptainEnergyGun
   entities:
   - uid: 93
     components:
     - type: Transform
-      pos: -1.5,-2.5
       parent: 1
+      pos: -1.5,-2.5
 - proto: ESWeaponDoubleBarrelShotgun
   entities:
   - uid: 92
     components:
     - type: Transform
-      pos: -1.5118704,-1.1362343
       parent: 1
+      pos: -1.5118704,-1.1362343
 - proto: ESWeaponEnergyRifle
   entities:
   - uid: 85
     components:
     - type: Transform
-      pos: -1.4806204,-1.9643593
       parent: 1
+      pos: -1.4806204,-1.9643593
 - proto: ESWeaponKnife
   entities:
   - uid: 317
     components:
     - type: Transform
-      pos: -0.7931204,-3.4643593
       parent: 1
+      pos: -0.7931204,-3.4643593
 - proto: ESWeaponPistol9mm
   entities:
   - uid: 316
     components:
     - type: Transform
-      pos: -1.3868704,-3.1674843
       parent: 1
+      pos: -1.3868704,-3.1674843
 - proto: ESWeaponRevolver357
   entities:
   - uid: 315
     components:
     - type: Transform
-      pos: -1.5,-3.5
       parent: 1
+      pos: -1.5,-3.5
 - proto: ESWeaponShotgun
   entities:
   - uid: 84
     components:
     - type: Transform
-      pos: -1.5,-1.5
       parent: 1
+      pos: -1.5,-1.5
 - proto: ExGrenade
   entities:
   - uid: 96
     components:
     - type: Transform
-      pos: 8.479488,-2.434597
       parent: 1
+      pos: 8.479488,-2.434597
   - uid: 97
     components:
     - type: Transform
-      pos: 8.651363,-2.293972
       parent: 1
+      pos: 8.651363,-2.293972
   - uid: 106
     components:
     - type: Transform
-      pos: 8.307613,-2.622097
       parent: 1
+      pos: 8.307613,-2.622097
 - proto: ExosuitFabricator
   entities:
   - uid: 131
     components:
     - type: Transform
-      pos: 11.5,1.5
       parent: 1
+      pos: 11.5,1.5
 - proto: FirelockGlass
   entities:
   - uid: 334
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-5.5
-      parent: 1
   - uid: 335
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-6.5
-      parent: 1
   - uid: 336
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
-      parent: 1
   - uid: 337
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-8.5
-      parent: 1
   - uid: 338
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-10.5
-      parent: 1
   - uid: 339
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-11.5
-      parent: 1
   - uid: 340
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-9.5
-      parent: 1
   - uid: 341
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-5.5
-      parent: 1
   - uid: 342
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
-      parent: 1
   - uid: 343
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
-      parent: 1
   - uid: 344
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
-      parent: 1
   - uid: 345
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-9.5
-      parent: 1
   - uid: 346
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-10.5
-      parent: 1
   - uid: 347
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5
-      parent: 1
 - proto: FloorDrain
   entities:
   - uid: 401
     components:
     - type: Transform
-      pos: 10.5,-10.5
       parent: 1
+      pos: 10.5,-10.5
     - type: Fixtures
       fixtures: {}
 - proto: ForensicScanner
@@ -3679,88 +3666,88 @@ entities:
   - uid: 105
     components:
     - type: Transform
-      pos: 8.5,-1.5
       parent: 1
+      pos: 8.5,-1.5
 - proto: GasOutletInjector
   entities:
   - uid: 410
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,-19.5
-      parent: 1
 - proto: GasPipeBend
   entities:
   - uid: 411
     components:
     - type: Transform
-      pos: -3.5,-16.5
       parent: 1
+      pos: -3.5,-16.5
   - uid: 415
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -6.5,-16.5
-      parent: 1
   - uid: 420
     components:
     - type: Transform
-      pos: -6.5,-13.5
       parent: 1
+      pos: -6.5,-13.5
 - proto: GasPipeStraight
   entities:
   - uid: 412
     components:
     - type: Transform
-      pos: -3.5,-17.5
       parent: 1
+      pos: -3.5,-17.5
   - uid: 413
     components:
     - type: Transform
-      pos: -3.5,-18.5
       parent: 1
+      pos: -3.5,-18.5
 - proto: GasPipeTJunction
   entities:
   - uid: 423
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,-14.5
-      parent: 1
   - uid: 424
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,-15.5
-      parent: 1
 - proto: GasPort
   entities:
   - uid: 417
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-15.5
-      parent: 1
   - uid: 418
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-14.5
-      parent: 1
   - uid: 419
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-13.5
-      parent: 1
 - proto: GasPressurePump
   entities:
   - uid: 416
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -4.5,-16.5
-      parent: 1
     - type: GasPressurePump
       targetPressure: 5.1
 - proto: GasValve
@@ -3768,716 +3755,716 @@ entities:
   - uid: 414
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -5.5,-16.5
-      parent: 1
 - proto: GravityGeneratorMini
   entities:
   - uid: 402
     components:
     - type: Transform
-      pos: -8.5,-5.5
       parent: 1
+      pos: -8.5,-5.5
 - proto: Grille
   entities:
   - uid: 13
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,5.5
-      parent: 1
   - uid: 29
     components:
     - type: Transform
-      pos: 7.5,4.5
       parent: 1
+      pos: 7.5,4.5
   - uid: 30
     components:
     - type: Transform
-      pos: 7.5,2.5
       parent: 1
+      pos: 7.5,2.5
   - uid: 34
     components:
     - type: Transform
-      pos: 7.5,3.5
       parent: 1
+      pos: 7.5,3.5
   - uid: 35
     components:
     - type: Transform
-      pos: 7.5,1.5
       parent: 1
+      pos: 7.5,1.5
   - uid: 36
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
   - uid: 37
     components:
     - type: Transform
-      pos: 7.5,-3.5
       parent: 1
+      pos: 7.5,-3.5
   - uid: 38
     components:
     - type: Transform
-      pos: 7.5,-2.5
       parent: 1
+      pos: 7.5,-2.5
   - uid: 137
     components:
     - type: Transform
-      pos: 7.5,-0.5
       parent: 1
+      pos: 7.5,-0.5
   - uid: 185
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -9.5,-4.5
-      parent: 1
   - uid: 220
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -8.5,-4.5
-      parent: 1
   - uid: 285
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -11.5,-4.5
-      parent: 1
   - uid: 287
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
-      parent: 1
   - uid: 291
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
-      parent: 1
   - uid: 306
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,5.5
-      parent: 1
   - uid: 536
     components:
     - type: Transform
-      pos: -4.5,-18.5
       parent: 1
+      pos: -4.5,-18.5
   - uid: 537
     components:
     - type: Transform
-      pos: -3.5,-18.5
       parent: 1
+      pos: -3.5,-18.5
   - uid: 538
     components:
     - type: Transform
-      pos: -2.5,-18.5
       parent: 1
+      pos: -2.5,-18.5
   - uid: 615
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,8.5
-      parent: 1
   - uid: 616
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -8.5,8.5
-      parent: 1
   - uid: 680
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -7.5,8.5
-      parent: 1
 - proto: hydroponicsTray
   entities:
   - uid: 380
     components:
     - type: Transform
-      pos: 8.5,-5.5
       parent: 1
+      pos: 8.5,-5.5
   - uid: 381
     components:
     - type: Transform
-      pos: 9.5,-5.5
       parent: 1
+      pos: 9.5,-5.5
   - uid: 382
     components:
     - type: Transform
-      pos: 10.5,-5.5
       parent: 1
+      pos: 10.5,-5.5
   - uid: 383
     components:
     - type: Transform
-      pos: 11.5,-5.5
       parent: 1
+      pos: 11.5,-5.5
 - proto: IngotGold
   entities:
   - uid: 62
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 1
+      pos: 8.5,1.5
 - proto: IngotSilver
   entities:
   - uid: 86
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 1
+      pos: 8.5,1.5
 - proto: JanitorialTrolley
   entities:
   - uid: 920
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 7.5,-11.5
-      parent: 1
 - proto: JetpackBlueFilled
   entities:
   - uid: 379
     components:
     - type: Transform
-      pos: 5.363963,4.5012426
       parent: 1
+      pos: 5.363963,4.5012426
 - proto: LockerMedicalFilled
   entities:
   - uid: 83
     components:
     - type: Transform
-      pos: 4.5,-9.5
       parent: 1
+      pos: 4.5,-9.5
 - proto: LockerSecurityFilled
   entities:
   - uid: 135
     components:
     - type: Transform
-      pos: 0.5,4.5
       parent: 1
+      pos: 0.5,4.5
 - proto: MachineMaterialSilo
   entities:
   - uid: 55
     components:
     - type: Transform
-      pos: 11.5,0.5
       parent: 1
+      pos: 11.5,0.5
 - proto: Multitool
   entities:
   - uid: 157
     components:
     - type: Transform
-      pos: 6.460059,-2.8671064
       parent: 1
+      pos: 6.460059,-2.8671064
 - proto: OperatingTable
   entities:
   - uid: 362
     components:
     - type: Transform
-      pos: 2.5,-10.5
       parent: 1
+      pos: 2.5,-10.5
 - proto: PlasmaCanister
   entities:
   - uid: 421
     components:
     - type: Transform
-      pos: -7.5,-14.5
       parent: 1
+      pos: -7.5,-14.5
   - uid: 422
     components:
     - type: Transform
-      pos: -7.5,-13.5
       parent: 1
+      pos: -7.5,-13.5
   - uid: 425
     components:
     - type: Transform
-      pos: -0.5,-13.5
       parent: 1
+      pos: -0.5,-13.5
   - uid: 426
     components:
     - type: Transform
-      pos: -0.5,-14.5
       parent: 1
+      pos: -0.5,-14.5
   - uid: 427
     components:
     - type: Transform
-      pos: 0.5,-14.5
       parent: 1
+      pos: 0.5,-14.5
   - uid: 428
     components:
     - type: Transform
-      pos: 0.5,-13.5
       parent: 1
+      pos: 0.5,-13.5
 - proto: PortableGeneratorJrPacman
   entities:
   - uid: 874
     components:
     - type: Transform
-      pos: 4.5,-13.5
       parent: 1
+      pos: 4.5,-13.5
 - proto: PoweredDimSmallLight
   entities:
   - uid: 670
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -11.5,-10.5
-      parent: 1
   - uid: 671
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -10.5,-18.5
-      parent: 1
   - uid: 672
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 4.5,-16.5
-      parent: 1
   - uid: 673
     components:
     - type: Transform
-      pos: -10.5,7.5
       parent: 1
+      pos: -10.5,7.5
   - uid: 674
     components:
     - type: Transform
-      pos: -4.5,7.5
       parent: 1
+      pos: -4.5,7.5
   - uid: 675
     components:
     - type: Transform
-      pos: 14.5,-0.5
       parent: 1
+      pos: 14.5,-0.5
   - uid: 676
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,-9.5
-      parent: 1
   - uid: 677
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,-4.5
-      parent: 1
 - proto: Rack
   entities:
   - uid: 72
     components:
     - type: Transform
-      pos: 5.5,4.5
       parent: 1
+      pos: 5.5,4.5
   - uid: 99
     components:
     - type: Transform
-      pos: 8.5,-2.5
       parent: 1
+      pos: 8.5,-2.5
   - uid: 101
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 1
+      pos: 8.5,2.5
   - uid: 104
     components:
     - type: Transform
-      pos: 8.5,-1.5
       parent: 1
+      pos: 8.5,-1.5
   - uid: 107
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 1
+      pos: 8.5,1.5
   - uid: 193
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
+      pos: 8.5,4.5
   - uid: 211
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 1
+      pos: 8.5,3.5
   - uid: 527
     components:
     - type: Transform
+      parent: 1
       rot: 1.5707963267948966 rad
       pos: -7.5,-16.5
-      parent: 1
   - uid: 754
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,-2.5
-      parent: 1
   - uid: 755
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,-3.5
-      parent: 1
   - uid: 756
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,-9.5
-      parent: 1
   - uid: 757
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 15.5,-8.5
-      parent: 1
   - uid: 758
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: 2.5,-13.5
-      parent: 1
   - uid: 759
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -8.5,-18.5
-      parent: 1
   - uid: 760
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -5.5,7.5
-      parent: 1
   - uid: 905
     components:
     - type: Transform
-      pos: 6.5,2.5
       parent: 1
+      pos: 6.5,2.5
 - proto: RCD
   entities:
   - uid: 41
     components:
     - type: Transform
-      pos: 5.369523,-3.537487
       parent: 1
+      pos: 5.369523,-3.537487
 - proto: RCDAmmo
   entities:
   - uid: 910
     components:
     - type: Transform
-      pos: 5.447648,-3.287487
       parent: 1
+      pos: 5.447648,-3.287487
   - uid: 912
     components:
     - type: Transform
-      pos: 5.650773,-3.287487
       parent: 1
+      pos: 5.650773,-3.287487
 - proto: Recycler
   entities:
   - uid: 365
     components:
     - type: Transform
-      pos: -6.5,-6.5
       parent: 1
+      pos: -6.5,-6.5
 - proto: ReinforcedWindow
   entities:
   - uid: 539
     components:
     - type: Transform
-      pos: -4.5,-18.5
       parent: 1
+      pos: -4.5,-18.5
   - uid: 540
     components:
     - type: Transform
-      pos: -3.5,-18.5
       parent: 1
+      pos: -3.5,-18.5
   - uid: 541
     components:
     - type: Transform
-      pos: -2.5,-18.5
       parent: 1
+      pos: -2.5,-18.5
   - uid: 617
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -7.5,8.5
-      parent: 1
   - uid: 678
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -6.5,8.5
-      parent: 1
   - uid: 679
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -8.5,8.5
-      parent: 1
 - proto: SeedExtractor
   entities:
   - uid: 392
     components:
     - type: Transform
-      pos: 7.5,-5.5
       parent: 1
+      pos: 7.5,-5.5
 - proto: SheetGlass
   entities:
   - uid: 51
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 1
+      pos: 8.5,3.5
   - uid: 52
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 1
+      pos: 8.5,3.5
   - uid: 53
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 1
+      pos: 8.5,3.5
 - proto: SheetPlasma
   entities:
   - uid: 174
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 1
+      pos: 8.5,1.5
 - proto: SheetPlastic
   entities:
   - uid: 48
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 1
+      pos: 8.5,2.5
   - uid: 49
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 1
+      pos: 8.5,2.5
   - uid: 50
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 1
+      pos: 8.5,2.5
 - proto: SheetSteel
   entities:
   - uid: 47
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
+      pos: 8.5,4.5
   - uid: 139
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
+      pos: 8.5,4.5
   - uid: 171
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 1
+      pos: 8.5,4.5
 - proto: SheetUranium
   entities:
   - uid: 147
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 1
+      pos: 8.5,1.5
 - proto: SMESBasic
   entities:
   - uid: 128
     components:
     - type: Transform
-      pos: -11.5,-6.5
       parent: 1
+      pos: -11.5,-6.5
   - uid: 429
     components:
     - type: Transform
-      pos: 0.5,-16.5
       parent: 1
+      pos: 0.5,-16.5
   - uid: 430
     components:
     - type: Transform
-      pos: 0.5,-15.5
       parent: 1
+      pos: 0.5,-15.5
 - proto: SpawnMobCorgiMouse
   entities:
   - uid: 239
     components:
     - type: Transform
-      pos: -0.5,2.5
       parent: 1
+      pos: -0.5,2.5
 - proto: SpawnMobHuman
   entities:
   - uid: 102
     components:
     - type: Transform
-      pos: 1.5,-10.5
       parent: 1
+      pos: 1.5,-10.5
   - uid: 875
     components:
     - type: Transform
-      pos: -6.5,-2.5
       parent: 1
+      pos: -6.5,-2.5
   - uid: 902
     components:
     - type: Transform
-      pos: -4.5,3.5
       parent: 1
+      pos: -4.5,3.5
   - uid: 903
     components:
     - type: Transform
-      pos: -6.5,3.5
       parent: 1
+      pos: -6.5,3.5
   - uid: 904
     components:
     - type: Transform
-      pos: -4.5,-2.5
       parent: 1
+      pos: -4.5,-2.5
 - proto: SpawnPointLatejoin
   entities:
   - uid: 237
     components:
     - type: Transform
-      pos: 2.5,0.5
       parent: 1
+      pos: 2.5,0.5
 - proto: Stunbaton
   entities:
   - uid: 295
     components:
     - type: Transform
-      pos: -0.8556204,-3.4643593
       parent: 1
+      pos: -0.8556204,-3.4643593
 - proto: SubstationBasic
   entities:
   - uid: 253
     components:
     - type: Transform
-      pos: -11.5,-5.5
       parent: 1
+      pos: -11.5,-5.5
 - proto: Table
   entities:
   - uid: 32
     components:
     - type: Transform
-      pos: 5.5,-3.5
       parent: 1
+      pos: 5.5,-3.5
   - uid: 87
     components:
     - type: Transform
-      pos: -0.5,-3.5
       parent: 1
+      pos: -0.5,-3.5
   - uid: 88
     components:
     - type: Transform
-      pos: 4.5,-3.5
       parent: 1
+      pos: 4.5,-3.5
   - uid: 89
     components:
     - type: Transform
-      pos: -1.5,-3.5
       parent: 1
+      pos: -1.5,-3.5
   - uid: 90
     components:
     - type: Transform
-      pos: -1.5,-2.5
       parent: 1
+      pos: -1.5,-2.5
   - uid: 91
     components:
     - type: Transform
-      pos: -1.5,-1.5
       parent: 1
+      pos: -1.5,-1.5
   - uid: 98
     components:
     - type: Transform
-      pos: 0.5,-3.5
       parent: 1
+      pos: 0.5,-3.5
   - uid: 210
     components:
     - type: Transform
-      pos: -1.5,-0.5
       parent: 1
+      pos: -1.5,-0.5
   - uid: 279
     components:
     - type: Transform
-      pos: 6.5,-1.5
       parent: 1
+      pos: 6.5,-1.5
   - uid: 280
     components:
     - type: Transform
-      pos: 6.5,-3.5
       parent: 1
+      pos: 6.5,-3.5
   - uid: 297
     components:
     - type: Transform
-      pos: 6.5,-2.5
       parent: 1
+      pos: 6.5,-2.5
   - uid: 529
     components:
     - type: Transform
-      pos: -4.5,-17.5
       parent: 1
+      pos: -4.5,-17.5
   - uid: 530
     components:
     - type: Transform
-      pos: -3.5,-17.5
       parent: 1
+      pos: -3.5,-17.5
 - proto: TargetHuman
   entities:
   - uid: 33
     components:
     - type: Transform
-      pos: 1.5,-3.5
       parent: 1
+      pos: 1.5,-3.5
     - type: DamagePopup
       damagePopupType: Total
   - uid: 158
     components:
     - type: Transform
-      pos: 3.5,-3.5
       parent: 1
+      pos: 3.5,-3.5
 - proto: ToolboxArtisticFilled
   entities:
   - uid: 141
     components:
     - type: Transform
-      pos: 6.491888,-2.387021
       parent: 1
+      pos: 6.491888,-2.387021
 - proto: ToolboxElectricalFilled
   entities:
   - uid: 94
     components:
     - type: Transform
-      pos: 6.470132,-1.4121637
       parent: 1
+      pos: 6.470132,-1.4121637
 - proto: ToolboxEmergencyFilled
   entities:
   - uid: 144
     components:
     - type: Transform
-      pos: 6.4594803,-2.0535936
       parent: 1
+      pos: 6.4594803,-2.0535936
 - proto: ToolboxMechanicalFilled
   entities:
   - uid: 56
     components:
     - type: Transform
-      pos: 6.4548507,-1.7341499
       parent: 1
+      pos: 6.4548507,-1.7341499
 - proto: TwoWayLever
   entities:
   - uid: 367
     components:
     - type: Transform
-      pos: -6.5,-8.5
       parent: 1
+      pos: -6.5,-8.5
     - type: DeviceLinkSource
       linkedPorts:
         365:
@@ -4492,1245 +4479,1245 @@ entities:
   - uid: 386
     components:
     - type: Transform
-      pos: -3.5,-9.5
       parent: 1
+      pos: -3.5,-9.5
 - proto: VendingMachineTankDispenserEVA
   entities:
   - uid: 278
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 1
+      pos: 6.5,4.5
 - proto: WallReinforced
   entities:
   - uid: 542
     components:
     - type: Transform
-      pos: -7.5,-19.5
       parent: 1
+      pos: -7.5,-19.5
   - uid: 543
     components:
     - type: Transform
-      pos: -7.5,-18.5
       parent: 1
+      pos: -7.5,-18.5
   - uid: 544
     components:
     - type: Transform
-      pos: -7.5,-17.5
       parent: 1
+      pos: -7.5,-17.5
   - uid: 545
     components:
     - type: Transform
-      pos: -8.5,-17.5
       parent: 1
+      pos: -8.5,-17.5
   - uid: 546
     components:
     - type: Transform
-      pos: -8.5,-16.5
       parent: 1
+      pos: -8.5,-16.5
   - uid: 547
     components:
     - type: Transform
-      pos: -8.5,-15.5
       parent: 1
+      pos: -8.5,-15.5
   - uid: 549
     components:
     - type: Transform
-      pos: -8.5,-13.5
       parent: 1
+      pos: -8.5,-13.5
   - uid: 550
     components:
     - type: Transform
-      pos: -8.5,-12.5
       parent: 1
+      pos: -8.5,-12.5
   - uid: 551
     components:
     - type: Transform
-      pos: -5.5,-17.5
       parent: 1
+      pos: -5.5,-17.5
   - uid: 552
     components:
     - type: Transform
-      pos: -5.5,-18.5
       parent: 1
+      pos: -5.5,-18.5
   - uid: 553
     components:
     - type: Transform
-      pos: -5.5,-19.5
       parent: 1
+      pos: -5.5,-19.5
   - uid: 554
     components:
     - type: Transform
-      pos: -1.5,-19.5
       parent: 1
+      pos: -1.5,-19.5
   - uid: 555
     components:
     - type: Transform
-      pos: -1.5,-18.5
       parent: 1
+      pos: -1.5,-18.5
   - uid: 556
     components:
     - type: Transform
-      pos: -1.5,-17.5
       parent: 1
+      pos: -1.5,-17.5
   - uid: 557
     components:
     - type: Transform
-      pos: 0.5,-19.5
       parent: 1
+      pos: 0.5,-19.5
   - uid: 558
     components:
     - type: Transform
-      pos: 0.5,-18.5
       parent: 1
+      pos: 0.5,-18.5
   - uid: 559
     components:
     - type: Transform
-      pos: 0.5,-17.5
       parent: 1
+      pos: 0.5,-17.5
   - uid: 560
     components:
     - type: Transform
-      pos: 1.5,-17.5
       parent: 1
+      pos: 1.5,-17.5
   - uid: 561
     components:
     - type: Transform
-      pos: 1.5,-16.5
       parent: 1
+      pos: 1.5,-16.5
   - uid: 562
     components:
     - type: Transform
-      pos: 1.5,-15.5
       parent: 1
+      pos: 1.5,-15.5
   - uid: 563
     components:
     - type: Transform
-      pos: 1.5,-14.5
       parent: 1
+      pos: 1.5,-14.5
   - uid: 564
     components:
     - type: Transform
-      pos: 1.5,-13.5
       parent: 1
+      pos: 1.5,-13.5
   - uid: 565
     components:
     - type: Transform
-      pos: 1.5,-19.5
       parent: 1
+      pos: 1.5,-19.5
   - uid: 566
     components:
     - type: Transform
-      pos: 1.5,-20.5
       parent: 1
+      pos: 1.5,-20.5
   - uid: 567
     components:
     - type: Transform
-      pos: 1.5,-21.5
       parent: 1
+      pos: 1.5,-21.5
   - uid: 568
     components:
     - type: Transform
-      pos: 1.5,-22.5
       parent: 1
+      pos: 1.5,-22.5
   - uid: 569
     components:
     - type: Transform
-      pos: 1.5,-23.5
       parent: 1
+      pos: 1.5,-23.5
   - uid: 570
     components:
     - type: Transform
-      pos: 1.5,-24.5
       parent: 1
+      pos: 1.5,-24.5
   - uid: 571
     components:
     - type: Transform
-      pos: 1.5,-25.5
       parent: 1
+      pos: 1.5,-25.5
   - uid: 572
     components:
     - type: Transform
-      pos: 1.5,-26.5
       parent: 1
+      pos: 1.5,-26.5
   - uid: 573
     components:
     - type: Transform
-      pos: 0.5,-26.5
       parent: 1
+      pos: 0.5,-26.5
   - uid: 574
     components:
     - type: Transform
-      pos: -0.5,-26.5
       parent: 1
+      pos: -0.5,-26.5
   - uid: 575
     components:
     - type: Transform
-      pos: -1.5,-26.5
       parent: 1
+      pos: -1.5,-26.5
   - uid: 576
     components:
     - type: Transform
-      pos: -1.5,-27.5
       parent: 1
+      pos: -1.5,-27.5
   - uid: 577
     components:
     - type: Transform
-      pos: -2.5,-27.5
       parent: 1
+      pos: -2.5,-27.5
   - uid: 578
     components:
     - type: Transform
-      pos: -3.5,-27.5
       parent: 1
+      pos: -3.5,-27.5
   - uid: 579
     components:
     - type: Transform
-      pos: -4.5,-27.5
       parent: 1
+      pos: -4.5,-27.5
   - uid: 580
     components:
     - type: Transform
-      pos: -5.5,-27.5
       parent: 1
+      pos: -5.5,-27.5
   - uid: 581
     components:
     - type: Transform
-      pos: -5.5,-26.5
       parent: 1
+      pos: -5.5,-26.5
   - uid: 582
     components:
     - type: Transform
-      pos: -6.5,-26.5
       parent: 1
+      pos: -6.5,-26.5
   - uid: 583
     components:
     - type: Transform
-      pos: -7.5,-26.5
       parent: 1
+      pos: -7.5,-26.5
   - uid: 584
     components:
     - type: Transform
-      pos: -8.5,-26.5
       parent: 1
+      pos: -8.5,-26.5
   - uid: 585
     components:
     - type: Transform
-      pos: -8.5,-25.5
       parent: 1
+      pos: -8.5,-25.5
   - uid: 586
     components:
     - type: Transform
-      pos: -8.5,-24.5
       parent: 1
+      pos: -8.5,-24.5
   - uid: 587
     components:
     - type: Transform
-      pos: -8.5,-23.5
       parent: 1
+      pos: -8.5,-23.5
   - uid: 588
     components:
     - type: Transform
-      pos: -8.5,-22.5
       parent: 1
+      pos: -8.5,-22.5
   - uid: 589
     components:
     - type: Transform
-      pos: -8.5,-21.5
       parent: 1
+      pos: -8.5,-21.5
   - uid: 590
     components:
     - type: Transform
-      pos: -8.5,-20.5
       parent: 1
+      pos: -8.5,-20.5
   - uid: 591
     components:
     - type: Transform
-      pos: -8.5,-19.5
       parent: 1
+      pos: -8.5,-19.5
 - proto: WallSolid
   entities:
   - uid: 4
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
-      parent: 1
   - uid: 5
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
-      parent: 1
   - uid: 6
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,0.5
-      parent: 1
   - uid: 8
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,4.5
-      parent: 1
   - uid: 9
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 11.5,5.5
-      parent: 1
   - uid: 12
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,5.5
-      parent: 1
   - uid: 19
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-3.5
-      parent: 1
   - uid: 109
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-6.5
-      parent: 1
   - uid: 110
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-5.5
-      parent: 1
   - uid: 111
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-3.5
-      parent: 1
   - uid: 113
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-7.5
-      parent: 1
   - uid: 115
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
-      parent: 1
   - uid: 116
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,-12.5
-      parent: 1
   - uid: 117
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-4.5
-      parent: 1
   - uid: 118
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -11.5,-7.5
-      parent: 1
   - uid: 178
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,0.5
-      parent: 1
   - uid: 179
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,4.5
-      parent: 1
   - uid: 180
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,2.5
-      parent: 1
   - uid: 182
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-7.5
-      parent: 1
   - uid: 183
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,5.5
-      parent: 1
   - uid: 184
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,2.5
-      parent: 1
   - uid: 186
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,-4.5
-      parent: 1
   - uid: 187
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -5.5,-12.5
-      parent: 1
   - uid: 188
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
-      parent: 1
   - uid: 189
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,-12.5
-      parent: 1
   - uid: 190
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-12.5
-      parent: 1
   - uid: 191
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,-12.5
-      parent: 1
   - uid: 192
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,-12.5
-      parent: 1
   - uid: 194
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-1.5
-      parent: 1
   - uid: 195
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 11.5,-4.5
-      parent: 1
   - uid: 197
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-3.5
-      parent: 1
   - uid: 198
     components:
     - type: Transform
-      pos: -8.5,5.5
       parent: 1
+      pos: -8.5,5.5
   - uid: 199
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-2.5
-      parent: 1
   - uid: 201
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
-      parent: 1
   - uid: 202
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-6.5
-      parent: 1
   - uid: 204
     components:
     - type: Transform
-      pos: -2.5,6.5
       parent: 1
+      pos: -2.5,6.5
   - uid: 207
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,1.5
-      parent: 1
   - uid: 212
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,-12.5
-      parent: 1
   - uid: 213
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,4.5
-      parent: 1
   - uid: 215
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,3.5
-      parent: 1
   - uid: 216
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -9.5,-7.5
-      parent: 1
   - uid: 217
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -8.5,-7.5
-      parent: 1
   - uid: 219
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -4.5,5.5
-      parent: 1
   - uid: 221
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,-4.5
-      parent: 1
   - uid: 229
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,-12.5
-      parent: 1
   - uid: 235
     components:
     - type: Transform
-      pos: 2.5,-19.5
       parent: 1
+      pos: 2.5,-19.5
   - uid: 238
     components:
     - type: Transform
-      pos: 4.5,-19.5
       parent: 1
+      pos: 4.5,-19.5
   - uid: 240
     components:
     - type: Transform
-      pos: 5.5,-19.5
       parent: 1
+      pos: 5.5,-19.5
   - uid: 241
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-12.5
-      parent: 1
   - uid: 242
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-8.5
-      parent: 1
   - uid: 243
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-9.5
-      parent: 1
   - uid: 244
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -3.5,-4.5
-      parent: 1
   - uid: 245
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,-2.5
-      parent: 1
   - uid: 246
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-4.5
-      parent: 1
   - uid: 247
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -11.5,5.5
-      parent: 1
   - uid: 248
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -12.5,5.5
-      parent: 1
   - uid: 249
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-4.5
-      parent: 1
   - uid: 251
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,-4.5
-      parent: 1
   - uid: 252
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-4.5
-      parent: 1
   - uid: 254
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-1.5
-      parent: 1
   - uid: 256
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -6.5,5.5
-      parent: 1
   - uid: 257
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-12.5
-      parent: 1
   - uid: 259
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,5.5
-      parent: 1
   - uid: 260
     components:
     - type: Transform
-      pos: 3.5,-19.5
       parent: 1
+      pos: 3.5,-19.5
   - uid: 261
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,-4.5
-      parent: 1
   - uid: 262
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
-      parent: 1
   - uid: 263
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,-4.5
-      parent: 1
   - uid: 264
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-0.5
-      parent: 1
   - uid: 265
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -0.5,5.5
-      parent: 1
   - uid: 266
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -5.5,5.5
-      parent: 1
   - uid: 267
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -1.5,5.5
-      parent: 1
   - uid: 268
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -6.5,-4.5
-      parent: 1
   - uid: 269
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,5.5
-      parent: 1
   - uid: 270
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
-      parent: 1
   - uid: 271
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 5.5,5.5
-      parent: 1
   - uid: 272
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,2.5
-      parent: 1
   - uid: 274
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 0.5,-4.5
-      parent: 1
   - uid: 276
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -4.5,-12.5
-      parent: 1
   - uid: 277
     components:
     - type: Transform
-      pos: 5.5,-15.5
       parent: 1
+      pos: 5.5,-15.5
   - uid: 281
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-10.5
-      parent: 1
   - uid: 288
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
-      parent: 1
   - uid: 292
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,3.5
-      parent: 1
   - uid: 293
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,5.5
-      parent: 1
   - uid: 296
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -5.5,-4.5
-      parent: 1
   - uid: 298
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -6.5,-12.5
-      parent: 1
   - uid: 299
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,-4.5
-      parent: 1
   - uid: 300
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 7.5,-4.5
-      parent: 1
   - uid: 305
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 4.5,5.5
-      parent: 1
   - uid: 307
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,-2.5
-      parent: 1
   - uid: 308
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
-      parent: 1
   - uid: 309
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -9.5,5.5
-      parent: 1
   - uid: 310
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 8.5,5.5
-      parent: 1
   - uid: 311
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 6.5,5.5
-      parent: 1
   - uid: 312
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-0.5
-      parent: 1
   - uid: 313
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: -7.5,-5.5
-      parent: 1
   - uid: 314
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 2.5,-12.5
-      parent: 1
   - uid: 318
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 11.5,-12.5
-      parent: 1
   - uid: 319
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-12.5
-      parent: 1
   - uid: 320
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-11.5
-      parent: 1
   - uid: 321
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-10.5
-      parent: 1
   - uid: 323
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-8.5
-      parent: 1
   - uid: 324
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-7.5
-      parent: 1
   - uid: 325
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-6.5
-      parent: 1
   - uid: 326
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 12.5,-5.5
-      parent: 1
   - uid: 610
     components:
     - type: Transform
-      pos: -2.5,7.5
       parent: 1
+      pos: -2.5,7.5
   - uid: 611
     components:
     - type: Transform
-      pos: -2.5,8.5
       parent: 1
+      pos: -2.5,8.5
   - uid: 612
     components:
     - type: Transform
-      pos: -3.5,8.5
       parent: 1
+      pos: -3.5,8.5
   - uid: 613
     components:
     - type: Transform
-      pos: -4.5,8.5
       parent: 1
+      pos: -4.5,8.5
   - uid: 614
     components:
     - type: Transform
-      pos: -5.5,8.5
       parent: 1
+      pos: -5.5,8.5
   - uid: 618
     components:
     - type: Transform
-      pos: -9.5,8.5
       parent: 1
+      pos: -9.5,8.5
   - uid: 619
     components:
     - type: Transform
-      pos: -10.5,8.5
       parent: 1
+      pos: -10.5,8.5
   - uid: 620
     components:
     - type: Transform
-      pos: -11.5,8.5
       parent: 1
+      pos: -11.5,8.5
   - uid: 621
     components:
     - type: Transform
-      pos: -12.5,8.5
       parent: 1
+      pos: -12.5,8.5
   - uid: 622
     components:
     - type: Transform
-      pos: -12.5,7.5
       parent: 1
+      pos: -12.5,7.5
   - uid: 623
     components:
     - type: Transform
-      pos: -12.5,6.5
       parent: 1
+      pos: -12.5,6.5
   - uid: 624
     components:
     - type: Transform
-      pos: -12.5,-8.5
       parent: 1
+      pos: -12.5,-8.5
   - uid: 625
     components:
     - type: Transform
-      pos: -12.5,-9.5
       parent: 1
+      pos: -12.5,-9.5
   - uid: 626
     components:
     - type: Transform
-      pos: -12.5,-10.5
       parent: 1
+      pos: -12.5,-10.5
   - uid: 627
     components:
     - type: Transform
-      pos: -12.5,-11.5
       parent: 1
+      pos: -12.5,-11.5
   - uid: 628
     components:
     - type: Transform
-      pos: -12.5,-12.5
       parent: 1
+      pos: -12.5,-12.5
   - uid: 629
     components:
     - type: Transform
-      pos: -12.5,-13.5
       parent: 1
+      pos: -12.5,-13.5
   - uid: 630
     components:
     - type: Transform
-      pos: -12.5,-14.5
       parent: 1
+      pos: -12.5,-14.5
   - uid: 631
     components:
     - type: Transform
-      pos: -12.5,-15.5
       parent: 1
+      pos: -12.5,-15.5
   - uid: 632
     components:
     - type: Transform
-      pos: -12.5,-16.5
       parent: 1
+      pos: -12.5,-16.5
   - uid: 633
     components:
     - type: Transform
-      pos: -12.5,-17.5
       parent: 1
+      pos: -12.5,-17.5
   - uid: 634
     components:
     - type: Transform
-      pos: -12.5,-18.5
       parent: 1
+      pos: -12.5,-18.5
   - uid: 635
     components:
     - type: Transform
-      pos: -12.5,-19.5
       parent: 1
+      pos: -12.5,-19.5
   - uid: 636
     components:
     - type: Transform
-      pos: -11.5,-19.5
       parent: 1
+      pos: -11.5,-19.5
   - uid: 637
     components:
     - type: Transform
-      pos: -10.5,-19.5
       parent: 1
+      pos: -10.5,-19.5
   - uid: 638
     components:
     - type: Transform
-      pos: -9.5,-19.5
       parent: 1
+      pos: -9.5,-19.5
   - uid: 643
     components:
     - type: Transform
-      pos: 5.5,-18.5
       parent: 1
+      pos: 5.5,-18.5
   - uid: 644
     components:
     - type: Transform
-      pos: 5.5,-16.5
       parent: 1
+      pos: 5.5,-16.5
   - uid: 646
     components:
     - type: Transform
-      pos: 5.5,-14.5
       parent: 1
+      pos: 5.5,-14.5
   - uid: 647
     components:
     - type: Transform
-      pos: 5.5,-13.5
       parent: 1
+      pos: 5.5,-13.5
   - uid: 648
     components:
     - type: Transform
-      pos: 5.5,-17.5
       parent: 1
+      pos: 5.5,-17.5
   - uid: 649
     components:
     - type: Transform
-      pos: 13.5,-12.5
       parent: 1
+      pos: 13.5,-12.5
   - uid: 650
     components:
     - type: Transform
-      pos: 14.5,-12.5
       parent: 1
+      pos: 14.5,-12.5
   - uid: 651
     components:
     - type: Transform
-      pos: 15.5,-12.5
       parent: 1
+      pos: 15.5,-12.5
   - uid: 652
     components:
     - type: Transform
-      pos: 16.5,-12.5
       parent: 1
+      pos: 16.5,-12.5
   - uid: 653
     components:
     - type: Transform
-      pos: 16.5,-11.5
       parent: 1
+      pos: 16.5,-11.5
   - uid: 654
     components:
     - type: Transform
-      pos: 16.5,-10.5
       parent: 1
+      pos: 16.5,-10.5
   - uid: 655
     components:
     - type: Transform
-      pos: 16.5,-9.5
       parent: 1
+      pos: 16.5,-9.5
   - uid: 656
     components:
     - type: Transform
-      pos: 16.5,-8.5
       parent: 1
+      pos: 16.5,-8.5
   - uid: 657
     components:
     - type: Transform
-      pos: 16.5,-7.5
       parent: 1
+      pos: 16.5,-7.5
   - uid: 658
     components:
     - type: Transform
-      pos: 16.5,-6.5
       parent: 1
+      pos: 16.5,-6.5
   - uid: 659
     components:
     - type: Transform
-      pos: 16.5,-5.5
       parent: 1
+      pos: 16.5,-5.5
   - uid: 660
     components:
     - type: Transform
-      pos: 16.5,-4.5
       parent: 1
+      pos: 16.5,-4.5
   - uid: 661
     components:
     - type: Transform
-      pos: 16.5,-3.5
       parent: 1
+      pos: 16.5,-3.5
   - uid: 662
     components:
     - type: Transform
-      pos: 16.5,-2.5
       parent: 1
+      pos: 16.5,-2.5
   - uid: 663
     components:
     - type: Transform
-      pos: 16.5,-1.5
       parent: 1
+      pos: 16.5,-1.5
   - uid: 664
     components:
     - type: Transform
-      pos: 16.5,-0.5
       parent: 1
+      pos: 16.5,-0.5
   - uid: 665
     components:
     - type: Transform
-      pos: 16.5,0.5
       parent: 1
+      pos: 16.5,0.5
   - uid: 666
     components:
     - type: Transform
-      pos: 15.5,0.5
       parent: 1
+      pos: 15.5,0.5
   - uid: 667
     components:
     - type: Transform
-      pos: 14.5,0.5
       parent: 1
+      pos: 14.5,0.5
   - uid: 668
     components:
     - type: Transform
-      pos: 13.5,0.5
       parent: 1
+      pos: 13.5,0.5
   - uid: 918
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,-12.5
-      parent: 1
 - proto: WaterTankFull
   entities:
   - uid: 385
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 1
+      pos: -3.5,-8.5
 - proto: WeldingFuelTankFull
   entities:
   - uid: 384
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 1
+      pos: -3.5,-7.5
 - proto: Window
   entities:
   - uid: 10
     components:
     - type: Transform
-      pos: 7.5,-0.5
       parent: 1
+      pos: 7.5,-0.5
   - uid: 27
     components:
     - type: Transform
-      pos: 7.5,2.5
       parent: 1
+      pos: 7.5,2.5
   - uid: 69
     components:
     - type: Transform
-      pos: 7.5,-2.5
       parent: 1
+      pos: 7.5,-2.5
   - uid: 70
     components:
     - type: Transform
-      pos: 7.5,-3.5
       parent: 1
+      pos: 7.5,-3.5
   - uid: 71
     components:
     - type: Transform
-      pos: 7.5,4.5
       parent: 1
+      pos: 7.5,4.5
   - uid: 142
     components:
     - type: Transform
-      pos: 7.5,1.5
       parent: 1
+      pos: 7.5,1.5
   - uid: 156
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 1
+      pos: 7.5,-1.5
   - uid: 196
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -9.5,-4.5
-      parent: 1
   - uid: 231
     components:
     - type: Transform
-      pos: 7.5,3.5
       parent: 1
+      pos: 7.5,3.5
   - uid: 250
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -8.5,-4.5
-      parent: 1
   - uid: 255
     components:
     - type: Transform
+      parent: 1
       rot: -1.5707963267948966 rad
       pos: -11.5,-4.5
-      parent: 1
   - uid: 275
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 1.5,-4.5
-      parent: 1
   - uid: 333
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 3.5,-4.5
-      parent: 1
   - uid: 350
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 9.5,5.5
-      parent: 1
   - uid: 351
     components:
     - type: Transform
+      parent: 1
       rot: 3.141592653589793 rad
       pos: 10.5,5.5
-      parent: 1
 - proto: Wrench
   entities:
   - uid: 528
     components:
     - type: Transform
-      pos: -7.5,-16.5
       parent: 1
+      pos: -7.5,-16.5
 ...

--- a/Resources/Maps/_ES/estestship_grid.yml
+++ b/Resources/Maps/_ES/estestship_grid.yml
@@ -1,16 +1,16 @@
 meta:
   format: 7
-  category: Map
+  category: Grid
   engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 08/19/2026 16:38:32
-  entityCount: 909
-maps:
-- 18
+  time: 08/19/2026 21:49:52
+  entityCount: 910
+maps: []
 grids:
 - 1
-orphans: []
+orphans:
+- 1
 nullspace: []
 tilemap:
   3: Space
@@ -32,7 +32,7 @@ entities:
     - type: MetaData
       name: test_ship
     - type: Transform
-      parent: 18
+      parent: invalid
       pos: -5.321541,-10.87529
     - type: MapGrid
       chunks:
@@ -479,18 +479,6 @@ entities:
     - type: ExplosionAirtightGrid
     - type: ChunkContainer
       chunkEntities: []
-  - uid: 18
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: Broadphase
-    - type: ChunkContainer
-      chunkEntities: []
-    - type: OccluderTree
 - proto: AirlockEngineering
   entities:
   - uid: 601
@@ -1634,6 +1622,16 @@ entities:
       pos: 8.5,-11.5
 - proto: CableHV
   entities:
+  - uid: 18
+    components:
+    - type: Transform
+      parent: 1
+      pos: -3.5,-11.5
+  - uid: 122
+    components:
+    - type: Transform
+      parent: 1
+      pos: -4.5,-11.5
   - uid: 123
     components:
     - type: Transform
@@ -1648,12 +1646,12 @@ entities:
     components:
     - type: Transform
       parent: 1
-      pos: -6.5,-11.5
+      pos: -5.5,-11.5
   - uid: 130
     components:
     - type: Transform
       parent: 1
-      pos: -5.5,-11.5
+      pos: -6.5,-11.5
   - uid: 205
     components:
     - type: Transform
@@ -1663,17 +1661,17 @@ entities:
     components:
     - type: Transform
       parent: 1
-      pos: -10.5,-7.5
+      pos: -8.5,-6.5
   - uid: 286
     components:
     - type: Transform
       parent: 1
-      pos: -10.5,-8.5
+      pos: -9.5,-6.5
   - uid: 394
     components:
     - type: Transform
       parent: 1
-      pos: -10.5,-9.5
+      pos: -7.5,-11.5
   - uid: 433
     components:
     - type: Transform
@@ -1858,17 +1856,17 @@ entities:
     components:
     - type: Transform
       parent: 1
-      pos: -10.5,-10.5
+      pos: -10.5,-11.5
   - uid: 470
     components:
     - type: Transform
       parent: 1
-      pos: -10.5,-11.5
+      pos: -8.5,-11.5
   - uid: 471
     components:
     - type: Transform
       parent: 1
-      pos: -8.5,-11.5
+      pos: -10.5,-8.5
   - uid: 472
     components:
     - type: Transform
@@ -1878,17 +1876,17 @@ entities:
     components:
     - type: Transform
       parent: 1
-      pos: -7.5,-11.5
+      pos: -10.5,-10.5
   - uid: 474
     components:
     - type: Transform
       parent: 1
-      pos: -3.5,-11.5
-  - uid: 475
+      pos: -10.5,-9.5
+  - uid: 476
     components:
     - type: Transform
       parent: 1
-      pos: -4.5,-11.5
+      pos: -10.5,-7.5
 - proto: CableMV
   entities:
   - uid: 16
@@ -1928,11 +1926,6 @@ entities:
       pos: -10.5,-4.5
 - proto: CableTerminal
   entities:
-  - uid: 122
-    components:
-    - type: Transform
-      parent: 1
-      pos: -7.5,-3.5
   - uid: 301
     components:
     - type: Transform
@@ -1951,6 +1944,11 @@ entities:
       parent: 1
       rot: 1.5707963267948966 rad
       pos: -0.5,-16.5
+  - uid: 475
+    components:
+    - type: Transform
+      parent: 1
+      pos: -7.5,-3.5
 - proto: CaptainIDCard
   entities:
   - uid: 67

--- a/Resources/Maps/_ES/syndiebase.yml
+++ b/Resources/Maps/_ES/syndiebase.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 267.3.0
+  engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 11/05/2025 04:52:07
-  entityCount: 863
+  time: 08/19/2026 16:22:12
+  entityCount: 851
 maps:
 - 3
 grids:
@@ -60,11 +60,11 @@ entities:
           version: 7
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
-      angularDamping: 0.05
       linearDamping: 0.05
       fixedRotation: False
       bodyType: Dynamic
+      bodyStatus: InAir
+      angularDamping: 0.05
     - type: Fixtures
       fixtures: {}
     - type: BecomesStation
@@ -74,25 +74,25 @@ entities:
       dampingModifier: 0.25
     - type: GridPathfinding
     - type: Gravity
+      inherent: True
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
-      inherent: True
       enabled: True
     - type: DecalGrid
       chunkCollection:
         version: 2
         nodes:
         - node:
-            color: '#FFFFFFFF'
             id: Arrows
+            color: '#FFFFFFFF'
           decals:
             49: -16,-10
             50: -14,-10
             51: -10,-10
             52: -8,-10
         - node:
-            color: '#7D15007D'
             id: CheckerNWSE
+            color: '#7D15007D'
           decals:
             31: -12,-3
             32: -12,-4
@@ -103,9 +103,9 @@ entities:
             37: -13,-4
             38: -13,-3
         - node:
-            cleanable: True
-            color: '#FFFFFFFF'
             id: Dirt
+            color: '#FFFFFFFF'
+            cleanable: True
           decals:
             104: 9,2
             105: 9,6
@@ -137,9 +137,9 @@ entities:
             131: -4,4
             132: -1,3
         - node:
-            cleanable: True
-            color: '#FFFFFFFF'
             id: DirtHeavy
+            color: '#FFFFFFFF'
+            cleanable: True
           decals:
             53: -13,3
             54: -12,4
@@ -181,9 +181,9 @@ entities:
             234: -7,-9
             235: -10,-9
         - node:
-            cleanable: True
-            color: '#FFFFFFFF'
             id: DirtLight
+            color: '#FFFFFFFF'
+            cleanable: True
           decals:
             66: -15,8
             67: -14,9
@@ -268,9 +268,9 @@ entities:
             249: -17,-9
             250: -16,-8
         - node:
-            cleanable: True
-            color: '#FFFFFFFF'
             id: DirtMedium
+            color: '#FFFFFFFF'
+            cleanable: True
           decals:
             59: -13,9
             60: -15,9
@@ -311,8 +311,8 @@ entities:
             240: -12,-9
             251: -17,-8
         - node:
-            color: '#7D15007D'
             id: HalfTileOverlayGreyscale90
+            color: '#7D15007D'
           decals:
             39: 7,2
             40: 7,1
@@ -321,8 +321,8 @@ entities:
             47: 7,-4
             48: 7,-5
         - node:
-            color: '#7D15007D'
             id: QuarterTileOverlayGreyscale180
+            color: '#7D15007D'
           decals:
             13: -8,-6
             14: -8,-5
@@ -333,8 +333,8 @@ entities:
             19: -8,0
             20: -8,1
         - node:
-            color: '#7D15007D'
             id: QuarterTileOverlayGreyscale270
+            color: '#7D15007D'
           decals:
             21: -10,-6
             22: -10,-5
@@ -345,18 +345,18 @@ entities:
             27: -10,0
             28: -10,1
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallNE
+            color: '#FFFFFFFF'
           decals:
             9: -15,9
         - node:
-            color: '#FFFFFFFF'
             id: WarnCornerSmallNW
+            color: '#FFFFFFFF'
           decals:
             8: -13,9
         - node:
-            color: '#FFFFFFFF'
             id: WarnLineW
+            color: '#FFFFFFFF'
           decals:
             7: -14,9
     - type: SpreaderGrid
@@ -364,6 +364,15 @@ entities:
     - type: GridAtmosphere
       version: 2
       data:
+        uniqueMixes:
+        - temperature: 293.15
+          volume: 2500
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          moles: {}
+          immutable: True
         tiles:
           -4,-3:
             0: 65360
@@ -474,18 +483,12 @@ entities:
             1: 8738
           -5,2:
             1: 38
-        uniqueMixes:
-        - volume: 2500
-          temperature: 293.15
-          moles:
-            Oxygen: 21.824879
-            Nitrogen: 82.10312
-        - volume: 2500
-          immutable: True
-          moles: {}
         chunkSize: 4
     - type: GasTileOverlay
     - type: RadiationGridResistance
+    - type: ChunkContainer
+      chunkEntities: []
+    - type: ExplosionAirtightGrid
   - uid: 3
     components:
     - type: MetaData
@@ -496,6 +499,8 @@ entities:
     - type: GridTree
     - type: Broadphase
     - type: OccluderTree
+    - type: ChunkContainer
+      chunkEntities: []
 - proto: ActionToggleLight
   entities:
   - uid: 135
@@ -512,174 +517,174 @@ entities:
   - uid: 80
     components:
     - type: Transform
-      pos: 4.5,-3.5
       parent: 2
+      pos: 4.5,-3.5
   - uid: 81
     components:
     - type: Transform
-      pos: 8.5,-3.5
       parent: 2
+      pos: 8.5,-3.5
   - uid: 82
     components:
     - type: Transform
-      pos: 8.5,-1.5
       parent: 2
+      pos: 8.5,-1.5
   - uid: 83
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 2
+      pos: 8.5,1.5
   - uid: 367
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 6.5,8.5
-      parent: 2
   - uid: 391
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -13.5,5.5
-      parent: 2
 - proto: AirlockGlass
   entities:
   - uid: 283
     components:
     - type: Transform
-      pos: -6.5,0.5
       parent: 2
+      pos: -6.5,0.5
   - uid: 284
     components:
     - type: Transform
-      pos: -6.5,-1.5
       parent: 2
+      pos: -6.5,-1.5
   - uid: 386
     components:
     - type: Transform
-      pos: -9.5,-6.5
       parent: 2
+      pos: -9.5,-6.5
   - uid: 387
     components:
     - type: Transform
-      pos: -7.5,-6.5
       parent: 2
+      pos: -7.5,-6.5
   - uid: 388
     components:
     - type: Transform
-      pos: -10.5,0.5
       parent: 2
+      pos: -10.5,0.5
 - proto: AirlockHatchMaintenance
   entities:
   - uid: 153
     components:
     - type: Transform
-      pos: 8.5,5.5
       parent: 2
+      pos: 8.5,5.5
   - uid: 168
     components:
     - type: Transform
-      pos: 3.5,3.5
       parent: 2
+      pos: 3.5,3.5
   - uid: 169
     components:
     - type: Transform
-      pos: -1.5,5.5
       parent: 2
+      pos: -1.5,5.5
   - uid: 326
     components:
     - type: Transform
-      pos: -10.5,6.5
       parent: 2
+      pos: -10.5,6.5
   - uid: 331
     components:
     - type: Transform
-      pos: -8.5,2.5
       parent: 2
+      pos: -8.5,2.5
   - uid: 332
     components:
     - type: Transform
-      pos: -5.5,-8.5
       parent: 2
+      pos: -5.5,-8.5
   - uid: 333
     components:
     - type: Transform
-      pos: 6.5,-5.5
       parent: 2
+      pos: 6.5,-5.5
 - proto: AirlockMaint
   entities:
   - uid: 716
     components:
     - type: Transform
-      pos: 1.5,-8.5
       parent: 2
+      pos: 1.5,-8.5
 - proto: AirlockShuttle
   entities:
   - uid: 409
     components:
     - type: Transform
-      pos: -15.5,-10.5
       parent: 2
+      pos: -15.5,-10.5
   - uid: 410
     components:
     - type: Transform
-      pos: -13.5,-10.5
       parent: 2
+      pos: -13.5,-10.5
   - uid: 411
     components:
     - type: Transform
-      pos: -9.5,-10.5
       parent: 2
+      pos: -9.5,-10.5
   - uid: 412
     components:
     - type: Transform
-      pos: -7.5,-10.5
       parent: 2
+      pos: -7.5,-10.5
 - proto: AirlockSyndicate
   entities:
   - uid: 392
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -10.5,-4.5
-      parent: 2
 - proto: APCBasic
   entities:
   - uid: 469
     components:
     - type: Transform
-      pos: 1.5,2.5
       parent: 2
+      pos: 1.5,2.5
     - type: Fixtures
       fixtures: {}
   - uid: 470
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -13.5,-1.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
   - uid: 471
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -16.5,-6.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
   - uid: 472
     components:
     - type: Transform
-      pos: -10.5,-6.5
       parent: 2
+      pos: -10.5,-6.5
     - type: Fixtures
       fixtures: {}
   - uid: 498
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 8.5,4.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: Ashtray
@@ -687,2796 +692,2814 @@ entities:
   - uid: 133
     components:
     - type: Transform
-      pos: 9.5,2.5
       parent: 2
+      pos: 9.5,2.5
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 823
     components:
     - type: Transform
-      pos: -9.5,-10.5
       parent: 2
+      pos: -9.5,-10.5
   - uid: 824
     components:
     - type: Transform
-      pos: -7.5,-10.5
       parent: 2
+      pos: -7.5,-10.5
   - uid: 825
     components:
     - type: Transform
-      pos: -13.5,-10.5
       parent: 2
+      pos: -13.5,-10.5
   - uid: 826
     components:
     - type: Transform
-      pos: -15.5,-10.5
       parent: 2
+      pos: -15.5,-10.5
 - proto: BannerNanotrasen
   entities:
   - uid: 714
     components:
     - type: Transform
-      pos: 3.5,-9.5
       parent: 2
+      pos: 3.5,-9.5
   - uid: 715
     components:
     - type: Transform
-      pos: -0.5,-9.5
       parent: 2
+      pos: -0.5,-9.5
 - proto: BannerSyndicate
   entities:
   - uid: 245
     components:
     - type: Transform
-      pos: 3.5,-1.5
       parent: 2
+      pos: 3.5,-1.5
   - uid: 285
     components:
     - type: Transform
-      pos: -6.5,-7.5
       parent: 2
+      pos: -6.5,-7.5
 - proto: Barricade
   entities:
   - uid: 807
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 2
+      pos: -6.5,6.5
 - proto: BarricadeBlock
   entities:
   - uid: 806
     components:
     - type: Transform
-      pos: 6.5,8.5
       parent: 2
+      pos: 6.5,8.5
   - uid: 814
     components:
     - type: Transform
-      pos: 1.5,-8.5
       parent: 2
+      pos: 1.5,-8.5
 - proto: Bed
   entities:
   - uid: 115
     components:
     - type: Transform
-      pos: 11.5,2.5
       parent: 2
+      pos: 11.5,2.5
   - uid: 116
     components:
     - type: Transform
-      pos: 11.5,-0.5
       parent: 2
+      pos: 11.5,-0.5
   - uid: 124
     components:
     - type: Transform
-      pos: 11.5,-4.5
       parent: 2
+      pos: 11.5,-4.5
 - proto: BedsheetBlack
   entities:
   - uid: 118
     components:
     - type: Transform
-      pos: 11.5,2.5
       parent: 2
+      pos: 11.5,2.5
   - uid: 119
     components:
     - type: Transform
-      pos: 11.5,-0.5
       parent: 2
+      pos: 11.5,-0.5
   - uid: 125
     components:
     - type: Transform
-      pos: 11.5,-4.5
       parent: 2
+      pos: 11.5,-4.5
 - proto: BibleNanoTrasen
   entities:
   - uid: 713
     components:
     - type: Transform
-      pos: 1.5,-11.5
       parent: 2
+      pos: 1.5,-11.5
 - proto: BodyBagFolded
   entities:
   - uid: 444
     components:
     - type: Transform
-      pos: -14.5,6.5
       parent: 2
+      pos: -14.5,6.5
 - proto: BoxBodyBag
   entities:
   - uid: 445
     components:
     - type: Transform
-      pos: -15.5,6.5
       parent: 2
+      pos: -15.5,6.5
 - proto: CableApcExtension
   entities:
   - uid: 149
     components:
     - type: Transform
-      pos: 2.5,3.5
       parent: 2
+      pos: 2.5,3.5
   - uid: 197
     components:
     - type: Transform
-      pos: 3.5,3.5
       parent: 2
+      pos: 3.5,3.5
   - uid: 198
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 2
+      pos: 2.5,5.5
   - uid: 199
     components:
     - type: Transform
-      pos: -4.5,3.5
       parent: 2
+      pos: -4.5,3.5
   - uid: 200
     components:
     - type: Transform
-      pos: -1.5,3.5
       parent: 2
+      pos: -1.5,3.5
   - uid: 201
     components:
     - type: Transform
-      pos: 4.5,3.5
       parent: 2
+      pos: 4.5,3.5
   - uid: 202
     components:
     - type: Transform
-      pos: 5.5,3.5
       parent: 2
+      pos: 5.5,3.5
   - uid: 203
     components:
     - type: Transform
-      pos: -2.5,6.5
       parent: 2
+      pos: -2.5,6.5
   - uid: 204
     components:
     - type: Transform
-      pos: -13.5,0.5
       parent: 2
+      pos: -13.5,0.5
   - uid: 205
     components:
     - type: Transform
+      parent: 2
       pos: -0.5,6.5
-      parent: 2
-  - uid: 206
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 2
   - uid: 207
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 2
+      pos: -1.5,6.5
   - uid: 208
     components:
     - type: Transform
-      pos: 0.5,6.5
       parent: 2
+      pos: 0.5,6.5
   - uid: 209
     components:
     - type: Transform
-      pos: 1.5,-7.5
       parent: 2
+      pos: 1.5,-7.5
   - uid: 210
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 2
+      pos: -3.5,-7.5
   - uid: 211
     components:
     - type: Transform
-      pos: -4.5,-8.5
       parent: 2
+      pos: -4.5,-8.5
   - uid: 212
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 2
+      pos: -3.5,-8.5
   - uid: 213
     components:
     - type: Transform
-      pos: -5.5,-8.5
       parent: 2
+      pos: -5.5,-8.5
   - uid: 214
     components:
     - type: Transform
-      pos: -7.5,-8.5
       parent: 2
+      pos: -7.5,-8.5
   - uid: 215
     components:
     - type: Transform
-      pos: -6.5,-8.5
       parent: 2
+      pos: -6.5,-8.5
   - uid: 216
     components:
     - type: Transform
+      parent: 2
       pos: -12.5,-4.5
-      parent: 2
-  - uid: 217
-    components:
-    - type: Transform
-      pos: -10.5,-6.5
-      parent: 2
   - uid: 218
     components:
     - type: Transform
-      pos: -10.5,-8.5
       parent: 2
+      pos: -10.5,-8.5
   - uid: 219
     components:
     - type: Transform
-      pos: -13.5,-4.5
       parent: 2
+      pos: -13.5,-4.5
   - uid: 220
     components:
     - type: Transform
-      pos: -15.5,-4.5
       parent: 2
+      pos: -15.5,-4.5
   - uid: 221
     components:
     - type: Transform
-      pos: -16.5,-4.5
       parent: 2
+      pos: -16.5,-4.5
   - uid: 222
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 2
+      pos: -8.5,4.5
   - uid: 223
     components:
     - type: Transform
-      pos: -16.5,-5.5
       parent: 2
+      pos: -16.5,-5.5
   - uid: 224
     components:
     - type: Transform
-      pos: -14.5,-4.5
       parent: 2
+      pos: -14.5,-4.5
   - uid: 225
     components:
     - type: Transform
-      pos: -10.5,-7.5
       parent: 2
+      pos: -10.5,-7.5
   - uid: 226
     components:
     - type: Transform
-      pos: -12.5,-8.5
       parent: 2
+      pos: -12.5,-8.5
   - uid: 227
     components:
     - type: Transform
-      pos: -11.5,-8.5
       parent: 2
+      pos: -11.5,-8.5
   - uid: 228
     components:
     - type: Transform
-      pos: -13.5,-8.5
       parent: 2
+      pos: -13.5,-8.5
   - uid: 338
     components:
     - type: Transform
-      pos: 2.5,-7.5
       parent: 2
+      pos: 2.5,-7.5
   - uid: 339
     components:
     - type: Transform
-      pos: -13.5,5.5
       parent: 2
+      pos: -13.5,5.5
   - uid: 340
     components:
     - type: Transform
-      pos: -11.5,6.5
       parent: 2
+      pos: -11.5,6.5
   - uid: 341
     components:
     - type: Transform
-      pos: -8.5,-7.5
       parent: 2
+      pos: -8.5,-7.5
   - uid: 342
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 2
+      pos: -5.5,6.5
   - uid: 343
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 2
+      pos: -7.5,6.5
   - uid: 344
     components:
     - type: Transform
-      pos: -8.5,5.5
       parent: 2
+      pos: -8.5,5.5
   - uid: 345
     components:
     - type: Transform
-      pos: -13.5,3.5
       parent: 2
+      pos: -13.5,3.5
   - uid: 346
     components:
     - type: Transform
-      pos: -13.5,2.5
       parent: 2
+      pos: -13.5,2.5
   - uid: 347
     components:
     - type: Transform
+      parent: 2
       pos: -13.5,8.5
-      parent: 2
-  - uid: 348
-    components:
-    - type: Transform
-      pos: -16.5,-6.5
-      parent: 2
   - uid: 349
     components:
     - type: Transform
-      pos: -8.5,6.5
       parent: 2
+      pos: -8.5,6.5
   - uid: 350
     components:
     - type: Transform
-      pos: -13.5,-0.5
       parent: 2
+      pos: -13.5,-0.5
   - uid: 351
     components:
     - type: Transform
-      pos: -13.5,4.5
       parent: 2
+      pos: -13.5,4.5
   - uid: 352
     components:
     - type: Transform
-      pos: -13.5,7.5
       parent: 2
+      pos: -13.5,7.5
   - uid: 353
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 2
+      pos: -6.5,6.5
   - uid: 354
     components:
     - type: Transform
-      pos: -12.5,6.5
       parent: 2
+      pos: -12.5,6.5
   - uid: 355
     components:
     - type: Transform
-      pos: -10.5,6.5
       parent: 2
+      pos: -10.5,6.5
   - uid: 356
     components:
     - type: Transform
-      pos: -13.5,6.5
       parent: 2
+      pos: -13.5,6.5
   - uid: 357
     components:
     - type: Transform
-      pos: -13.5,9.5
       parent: 2
+      pos: -13.5,9.5
   - uid: 358
     components:
     - type: Transform
-      pos: -13.5,1.5
       parent: 2
+      pos: -13.5,1.5
   - uid: 359
     components:
     - type: Transform
-      pos: -9.5,6.5
       parent: 2
+      pos: -9.5,6.5
   - uid: 362
     components:
     - type: Transform
-      pos: 2.5,4.5
       parent: 2
+      pos: 2.5,4.5
   - uid: 363
     components:
     - type: Transform
-      pos: 1.5,-3.5
       parent: 2
+      pos: 1.5,-3.5
   - uid: 377
     components:
     - type: Transform
-      pos: 6.5,-2.5
       parent: 2
+      pos: 6.5,-2.5
   - uid: 455
     components:
     - type: Transform
-      pos: -8.5,-1.5
       parent: 2
+      pos: -8.5,-1.5
   - uid: 456
     components:
     - type: Transform
-      pos: -4.5,-0.5
       parent: 2
+      pos: -4.5,-0.5
   - uid: 458
     components:
     - type: Transform
-      pos: -8.5,-2.5
       parent: 2
+      pos: -8.5,-2.5
   - uid: 459
     components:
     - type: Transform
-      pos: -8.5,-5.5
       parent: 2
+      pos: -8.5,-5.5
   - uid: 460
     components:
     - type: Transform
-      pos: -8.5,-4.5
       parent: 2
+      pos: -8.5,-4.5
   - uid: 461
     components:
     - type: Transform
-      pos: -8.5,-3.5
       parent: 2
+      pos: -8.5,-3.5
   - uid: 462
     components:
     - type: Transform
-      pos: 6.5,-7.5
       parent: 2
+      pos: 6.5,-7.5
   - uid: 463
     components:
     - type: Transform
-      pos: -0.5,-7.5
       parent: 2
+      pos: -0.5,-7.5
   - uid: 464
     components:
     - type: Transform
-      pos: 0.5,-7.5
       parent: 2
+      pos: 0.5,-7.5
   - uid: 465
     components:
     - type: Transform
-      pos: 3.5,-7.5
       parent: 2
+      pos: 3.5,-7.5
   - uid: 466
     components:
     - type: Transform
-      pos: 4.5,-7.5
       parent: 2
+      pos: 4.5,-7.5
   - uid: 467
     components:
     - type: Transform
-      pos: 5.5,-7.5
       parent: 2
+      pos: 5.5,-7.5
   - uid: 468
     components:
     - type: Transform
-      pos: -8.5,-6.5
       parent: 2
+      pos: -8.5,-6.5
   - uid: 473
     components:
     - type: Transform
-      pos: 6.5,1.5
       parent: 2
+      pos: 6.5,1.5
   - uid: 474
     components:
     - type: Transform
-      pos: 6.5,3.5
       parent: 2
+      pos: 6.5,3.5
   - uid: 475
     components:
     - type: Transform
-      pos: 6.5,2.5
       parent: 2
+      pos: 6.5,2.5
   - uid: 476
     components:
     - type: Transform
-      pos: 6.5,-0.5
       parent: 2
+      pos: 6.5,-0.5
   - uid: 477
     components:
     - type: Transform
+      parent: 2
       pos: 1.5,0.5
-      parent: 2
-  - uid: 478
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 2
   - uid: 479
     components:
     - type: Transform
-      pos: 6.5,9.5
       parent: 2
+      pos: 6.5,9.5
   - uid: 480
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 2
+      pos: 6.5,5.5
   - uid: 481
     components:
     - type: Transform
-      pos: 6.5,7.5
       parent: 2
+      pos: 6.5,7.5
   - uid: 482
     components:
     - type: Transform
-      pos: 7.5,4.5
       parent: 2
+      pos: 7.5,4.5
   - uid: 486
     components:
     - type: Transform
-      pos: -3.5,-1.5
       parent: 2
+      pos: -3.5,-1.5
   - uid: 487
     components:
     - type: Transform
-      pos: -2.5,-1.5
       parent: 2
+      pos: -2.5,-1.5
   - uid: 488
     components:
     - type: Transform
-      pos: -1.5,-1.5
       parent: 2
+      pos: -1.5,-1.5
   - uid: 489
     components:
     - type: Transform
-      pos: -3.5,-0.5
       parent: 2
+      pos: -3.5,-0.5
   - uid: 490
     components:
     - type: Transform
-      pos: -3.5,-2.5
       parent: 2
+      pos: -3.5,-2.5
   - uid: 491
     components:
     - type: Transform
-      pos: -3.5,-3.5
       parent: 2
+      pos: -3.5,-3.5
   - uid: 492
     components:
     - type: Transform
-      pos: 0.5,-1.5
       parent: 2
+      pos: 0.5,-1.5
   - uid: 493
     components:
     - type: Transform
-      pos: -0.5,-1.5
       parent: 2
+      pos: -0.5,-1.5
   - uid: 494
     components:
     - type: Transform
-      pos: 1.5,-1.5
       parent: 2
+      pos: 1.5,-1.5
   - uid: 495
     components:
     - type: Transform
-      pos: 1.5,-2.5
       parent: 2
+      pos: 1.5,-2.5
   - uid: 496
     components:
     - type: Transform
+      parent: 2
       pos: 2.5,-3.5
-      parent: 2
-  - uid: 519
-    components:
-    - type: Transform
-      pos: 8.5,4.5
-      parent: 2
   - uid: 597
     components:
     - type: Transform
-      pos: 6.5,-1.5
       parent: 2
+      pos: 6.5,-1.5
   - uid: 598
     components:
     - type: Transform
-      pos: 1.5,-0.5
       parent: 2
+      pos: 1.5,-0.5
   - uid: 599
     components:
     - type: Transform
-      pos: 6.5,-3.5
       parent: 2
+      pos: 6.5,-3.5
   - uid: 600
     components:
     - type: Transform
-      pos: 1.5,1.5
       parent: 2
+      pos: 1.5,1.5
   - uid: 601
     components:
     - type: Transform
-      pos: 6.5,10.5
       parent: 2
+      pos: 6.5,10.5
   - uid: 602
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 2
+      pos: 6.5,6.5
   - uid: 603
     components:
     - type: Transform
-      pos: 6.5,8.5
       parent: 2
+      pos: 6.5,8.5
   - uid: 604
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 2
+      pos: 6.5,4.5
   - uid: 627
     components:
     - type: Transform
-      pos: 1.5,6.5
       parent: 2
+      pos: 1.5,6.5
   - uid: 628
     components:
     - type: Transform
-      pos: 2.5,6.5
       parent: 2
+      pos: 2.5,6.5
   - uid: 629
     components:
     - type: Transform
-      pos: -9.5,-8.5
       parent: 2
+      pos: -9.5,-8.5
   - uid: 630
     components:
     - type: Transform
-      pos: -2.5,-7.5
       parent: 2
+      pos: -2.5,-7.5
   - uid: 631
     components:
     - type: Transform
-      pos: -8.5,-0.5
       parent: 2
+      pos: -8.5,-0.5
   - uid: 632
     components:
     - type: Transform
-      pos: -14.5,-8.5
       parent: 2
+      pos: -14.5,-8.5
   - uid: 633
     components:
     - type: Transform
-      pos: -8.5,-8.5
       parent: 2
+      pos: -8.5,-8.5
   - uid: 634
     components:
     - type: Transform
-      pos: -1.5,-7.5
       parent: 2
+      pos: -1.5,-7.5
   - uid: 635
     components:
     - type: Transform
-      pos: -8.5,0.5
       parent: 2
+      pos: -8.5,0.5
   - uid: 636
     components:
     - type: Transform
-      pos: -15.5,-8.5
       parent: 2
+      pos: -15.5,-8.5
   - uid: 638
     components:
     - type: Transform
-      pos: 6.5,0.5
       parent: 2
+      pos: 6.5,0.5
   - uid: 651
     components:
     - type: Transform
-      pos: -3.5,1.5
       parent: 2
+      pos: -3.5,1.5
   - uid: 652
     components:
     - type: Transform
-      pos: -3.5,3.5
       parent: 2
+      pos: -3.5,3.5
   - uid: 653
     components:
     - type: Transform
-      pos: -3.5,0.5
       parent: 2
+      pos: -3.5,0.5
   - uid: 654
     components:
     - type: Transform
-      pos: -3.5,2.5
       parent: 2
+      pos: -3.5,2.5
   - uid: 655
     components:
     - type: Transform
-      pos: -2.5,3.5
       parent: 2
+      pos: -2.5,3.5
   - uid: 708
     components:
     - type: Transform
-      pos: 1.5,-8.5
       parent: 2
+      pos: 1.5,-8.5
   - uid: 709
     components:
     - type: Transform
-      pos: 1.5,-9.5
       parent: 2
+      pos: 1.5,-9.5
   - uid: 710
     components:
     - type: Transform
-      pos: 1.5,-10.5
       parent: 2
+      pos: 1.5,-10.5
   - uid: 827
     components:
     - type: Transform
-      pos: 7.5,1.5
       parent: 2
+      pos: 7.5,1.5
   - uid: 828
     components:
     - type: Transform
-      pos: 8.5,1.5
       parent: 2
+      pos: 8.5,1.5
   - uid: 829
     components:
     - type: Transform
-      pos: 10.5,1.5
       parent: 2
+      pos: 10.5,1.5
   - uid: 830
     components:
     - type: Transform
-      pos: 9.5,1.5
       parent: 2
+      pos: 9.5,1.5
   - uid: 831
     components:
     - type: Transform
-      pos: 10.5,-1.5
       parent: 2
+      pos: 10.5,-1.5
   - uid: 832
     components:
     - type: Transform
-      pos: 9.5,-1.5
       parent: 2
+      pos: 9.5,-1.5
   - uid: 833
     components:
     - type: Transform
-      pos: 8.5,-1.5
       parent: 2
+      pos: 8.5,-1.5
   - uid: 834
     components:
     - type: Transform
-      pos: 7.5,-1.5
       parent: 2
+      pos: 7.5,-1.5
   - uid: 835
     components:
     - type: Transform
-      pos: 7.5,-3.5
       parent: 2
+      pos: 7.5,-3.5
   - uid: 836
     components:
     - type: Transform
-      pos: 8.5,-3.5
       parent: 2
+      pos: 8.5,-3.5
   - uid: 837
     components:
     - type: Transform
-      pos: 9.5,-3.5
       parent: 2
+      pos: 9.5,-3.5
   - uid: 838
     components:
     - type: Transform
-      pos: 10.5,-3.5
       parent: 2
+      pos: 10.5,-3.5
 - proto: CableHV
   entities:
   - uid: 360
     components:
     - type: Transform
-      pos: 7.5,11.5
       parent: 2
+      pos: 7.5,11.5
   - uid: 374
     components:
     - type: Transform
-      pos: 6.5,11.5
       parent: 2
+      pos: 6.5,11.5
   - uid: 375
     components:
     - type: Transform
-      pos: 5.5,11.5
       parent: 2
+      pos: 5.5,11.5
 - proto: CableMV
   entities:
   - uid: 376
     components:
     - type: Transform
-      pos: 5.5,11.5
       parent: 2
+      pos: 5.5,11.5
   - uid: 453
     components:
     - type: Transform
-      pos: 5.5,10.5
       parent: 2
+      pos: 5.5,10.5
   - uid: 454
     components:
     - type: Transform
-      pos: 5.5,9.5
       parent: 2
+      pos: 5.5,9.5
   - uid: 485
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 2
+      pos: -1.5,6.5
   - uid: 499
     components:
     - type: Transform
-      pos: -1.5,5.5
       parent: 2
+      pos: -1.5,5.5
   - uid: 500
     components:
     - type: Transform
-      pos: -1.5,4.5
       parent: 2
+      pos: -1.5,4.5
   - uid: 501
     components:
     - type: Transform
-      pos: -1.5,3.5
       parent: 2
+      pos: -1.5,3.5
   - uid: 502
     components:
     - type: Transform
-      pos: -1.5,2.5
       parent: 2
+      pos: -1.5,2.5
   - uid: 503
     components:
     - type: Transform
-      pos: -1.5,1.5
       parent: 2
+      pos: -1.5,1.5
   - uid: 504
     components:
     - type: Transform
-      pos: -0.5,1.5
       parent: 2
+      pos: -0.5,1.5
   - uid: 505
     components:
     - type: Transform
-      pos: 0.5,1.5
       parent: 2
+      pos: 0.5,1.5
   - uid: 506
     components:
     - type: Transform
+      parent: 2
       pos: 1.5,1.5
-      parent: 2
-  - uid: 507
-    components:
-    - type: Transform
-      pos: 1.5,2.5
-      parent: 2
   - uid: 508
     components:
     - type: Transform
-      pos: -0.5,6.5
       parent: 2
+      pos: -0.5,6.5
   - uid: 509
     components:
     - type: Transform
-      pos: 0.5,6.5
       parent: 2
+      pos: 0.5,6.5
   - uid: 510
     components:
     - type: Transform
-      pos: 1.5,6.5
       parent: 2
+      pos: 1.5,6.5
   - uid: 511
     components:
     - type: Transform
-      pos: 2.5,6.5
       parent: 2
+      pos: 2.5,6.5
   - uid: 512
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 2
+      pos: 2.5,5.5
   - uid: 513
     components:
     - type: Transform
-      pos: 2.5,4.5
       parent: 2
+      pos: 2.5,4.5
   - uid: 514
     components:
     - type: Transform
-      pos: 2.5,3.5
       parent: 2
+      pos: 2.5,3.5
   - uid: 515
     components:
     - type: Transform
-      pos: 3.5,3.5
       parent: 2
+      pos: 3.5,3.5
   - uid: 516
     components:
     - type: Transform
-      pos: 4.5,3.5
       parent: 2
+      pos: 4.5,3.5
   - uid: 517
     components:
     - type: Transform
-      pos: 5.5,3.5
       parent: 2
+      pos: 5.5,3.5
   - uid: 518
     components:
     - type: Transform
-      pos: 6.5,3.5
       parent: 2
+      pos: 6.5,3.5
   - uid: 520
     components:
     - type: Transform
+      parent: 2
       pos: 7.5,4.5
-      parent: 2
-  - uid: 521
-    components:
-    - type: Transform
-      pos: 8.5,4.5
-      parent: 2
   - uid: 522
     components:
     - type: Transform
-      pos: -2.5,6.5
       parent: 2
+      pos: -2.5,6.5
   - uid: 523
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 2
+      pos: -3.5,6.5
   - uid: 524
     components:
     - type: Transform
-      pos: -4.5,6.5
       parent: 2
+      pos: -4.5,6.5
   - uid: 525
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 2
+      pos: -5.5,6.5
   - uid: 526
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 2
+      pos: -6.5,6.5
   - uid: 527
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 2
+      pos: -7.5,6.5
   - uid: 528
     components:
     - type: Transform
-      pos: -8.5,6.5
       parent: 2
+      pos: -8.5,6.5
   - uid: 529
     components:
     - type: Transform
-      pos: -9.5,6.5
       parent: 2
+      pos: -9.5,6.5
   - uid: 530
     components:
     - type: Transform
-      pos: -10.5,6.5
       parent: 2
+      pos: -10.5,6.5
   - uid: 531
     components:
     - type: Transform
-      pos: -11.5,6.5
       parent: 2
+      pos: -11.5,6.5
   - uid: 532
     components:
     - type: Transform
-      pos: -12.5,6.5
       parent: 2
+      pos: -12.5,6.5
   - uid: 533
     components:
     - type: Transform
-      pos: -13.5,6.5
       parent: 2
+      pos: -13.5,6.5
   - uid: 534
     components:
     - type: Transform
-      pos: -13.5,5.5
       parent: 2
+      pos: -13.5,5.5
   - uid: 535
     components:
     - type: Transform
-      pos: -13.5,4.5
       parent: 2
+      pos: -13.5,4.5
   - uid: 536
     components:
     - type: Transform
-      pos: -13.5,3.5
       parent: 2
+      pos: -13.5,3.5
   - uid: 537
     components:
     - type: Transform
-      pos: -13.5,2.5
       parent: 2
+      pos: -13.5,2.5
   - uid: 538
     components:
     - type: Transform
-      pos: -13.5,1.5
       parent: 2
+      pos: -13.5,1.5
   - uid: 539
     components:
     - type: Transform
-      pos: -13.5,0.5
       parent: 2
+      pos: -13.5,0.5
   - uid: 540
     components:
     - type: Transform
+      parent: 2
       pos: -13.5,-0.5
-      parent: 2
-  - uid: 541
-    components:
-    - type: Transform
-      pos: -13.5,-1.5
-      parent: 2
   - uid: 542
     components:
     - type: Transform
-      pos: -8.5,5.5
       parent: 2
+      pos: -8.5,5.5
   - uid: 543
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 2
+      pos: -8.5,4.5
   - uid: 544
     components:
     - type: Transform
-      pos: -8.5,3.5
       parent: 2
+      pos: -8.5,3.5
   - uid: 545
     components:
     - type: Transform
-      pos: -8.5,2.5
       parent: 2
+      pos: -8.5,2.5
   - uid: 546
     components:
     - type: Transform
-      pos: -8.5,1.5
       parent: 2
+      pos: -8.5,1.5
   - uid: 547
     components:
     - type: Transform
-      pos: -8.5,0.5
       parent: 2
+      pos: -8.5,0.5
   - uid: 548
     components:
     - type: Transform
-      pos: -8.5,-0.5
       parent: 2
+      pos: -8.5,-0.5
   - uid: 549
     components:
     - type: Transform
-      pos: -8.5,-1.5
       parent: 2
+      pos: -8.5,-1.5
   - uid: 550
     components:
     - type: Transform
-      pos: -8.5,-2.5
       parent: 2
+      pos: -8.5,-2.5
   - uid: 551
     components:
     - type: Transform
-      pos: -8.5,-3.5
       parent: 2
+      pos: -8.5,-3.5
   - uid: 552
     components:
     - type: Transform
-      pos: -8.5,-4.5
       parent: 2
+      pos: -8.5,-4.5
   - uid: 553
     components:
     - type: Transform
-      pos: -8.5,-5.5
       parent: 2
+      pos: -8.5,-5.5
   - uid: 554
     components:
     - type: Transform
-      pos: -8.5,-6.5
       parent: 2
+      pos: -8.5,-6.5
   - uid: 555
     components:
     - type: Transform
-      pos: -8.5,-7.5
       parent: 2
+      pos: -8.5,-7.5
   - uid: 556
     components:
     - type: Transform
-      pos: -8.5,-8.5
       parent: 2
+      pos: -8.5,-8.5
   - uid: 557
     components:
     - type: Transform
-      pos: -9.5,-8.5
       parent: 2
+      pos: -9.5,-8.5
   - uid: 558
     components:
     - type: Transform
-      pos: -10.5,-8.5
       parent: 2
+      pos: -10.5,-8.5
   - uid: 559
     components:
     - type: Transform
+      parent: 2
       pos: -10.5,-7.5
-      parent: 2
-  - uid: 560
-    components:
-    - type: Transform
-      pos: -10.5,-6.5
-      parent: 2
   - uid: 561
     components:
     - type: Transform
-      pos: -9.5,-4.5
       parent: 2
+      pos: -9.5,-4.5
   - uid: 562
     components:
     - type: Transform
-      pos: -10.5,-4.5
       parent: 2
+      pos: -10.5,-4.5
   - uid: 563
     components:
     - type: Transform
-      pos: -11.5,-4.5
       parent: 2
+      pos: -11.5,-4.5
   - uid: 564
     components:
     - type: Transform
-      pos: -12.5,-4.5
       parent: 2
+      pos: -12.5,-4.5
   - uid: 565
     components:
     - type: Transform
-      pos: -13.5,-4.5
       parent: 2
+      pos: -13.5,-4.5
   - uid: 566
     components:
     - type: Transform
-      pos: -14.5,-4.5
       parent: 2
+      pos: -14.5,-4.5
   - uid: 567
     components:
     - type: Transform
-      pos: -15.5,-4.5
       parent: 2
+      pos: -15.5,-4.5
   - uid: 568
     components:
     - type: Transform
-      pos: -16.5,-4.5
       parent: 2
+      pos: -16.5,-4.5
   - uid: 569
     components:
     - type: Transform
+      parent: 2
       pos: -16.5,-5.5
-      parent: 2
-  - uid: 570
-    components:
-    - type: Transform
-      pos: -16.5,-6.5
-      parent: 2
   - uid: 571
     components:
     - type: Transform
-      pos: 6.5,1.5
       parent: 2
+      pos: 6.5,1.5
   - uid: 572
     components:
     - type: Transform
-      pos: 6.5,2.5
       parent: 2
+      pos: 6.5,2.5
   - uid: 573
     components:
     - type: Transform
-      pos: 6.5,0.5
       parent: 2
+      pos: 6.5,0.5
   - uid: 574
     components:
     - type: Transform
-      pos: 6.5,-0.5
       parent: 2
+      pos: 6.5,-0.5
   - uid: 575
     components:
     - type: Transform
-      pos: 6.5,-1.5
       parent: 2
+      pos: 6.5,-1.5
   - uid: 576
     components:
     - type: Transform
-      pos: 6.5,-2.5
       parent: 2
+      pos: 6.5,-2.5
   - uid: 577
     components:
     - type: Transform
-      pos: 6.5,-3.5
       parent: 2
+      pos: 6.5,-3.5
   - uid: 578
     components:
     - type: Transform
-      pos: 6.5,-4.5
       parent: 2
+      pos: 6.5,-4.5
   - uid: 579
     components:
     - type: Transform
-      pos: 6.5,-5.5
       parent: 2
+      pos: 6.5,-5.5
   - uid: 580
     components:
     - type: Transform
-      pos: 6.5,-6.5
       parent: 2
+      pos: 6.5,-6.5
   - uid: 581
     components:
     - type: Transform
-      pos: 6.5,-7.5
       parent: 2
+      pos: 6.5,-7.5
   - uid: 582
     components:
     - type: Transform
-      pos: 5.5,-7.5
       parent: 2
+      pos: 5.5,-7.5
   - uid: 583
     components:
     - type: Transform
-      pos: 4.5,-7.5
       parent: 2
+      pos: 4.5,-7.5
   - uid: 584
     components:
     - type: Transform
-      pos: 3.5,-7.5
       parent: 2
+      pos: 3.5,-7.5
   - uid: 585
     components:
     - type: Transform
-      pos: 2.5,-7.5
       parent: 2
+      pos: 2.5,-7.5
   - uid: 586
     components:
     - type: Transform
-      pos: 1.5,-7.5
       parent: 2
+      pos: 1.5,-7.5
   - uid: 587
     components:
     - type: Transform
-      pos: 0.5,-7.5
       parent: 2
+      pos: 0.5,-7.5
   - uid: 588
     components:
     - type: Transform
-      pos: -0.5,-7.5
       parent: 2
+      pos: -0.5,-7.5
   - uid: 589
     components:
     - type: Transform
-      pos: -1.5,-7.5
       parent: 2
+      pos: -1.5,-7.5
   - uid: 590
     components:
     - type: Transform
-      pos: -2.5,-7.5
       parent: 2
+      pos: -2.5,-7.5
   - uid: 591
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 2
+      pos: -3.5,-7.5
   - uid: 592
     components:
     - type: Transform
-      pos: -3.5,-8.5
       parent: 2
+      pos: -3.5,-8.5
   - uid: 593
     components:
     - type: Transform
-      pos: -4.5,-8.5
       parent: 2
+      pos: -4.5,-8.5
   - uid: 594
     components:
     - type: Transform
-      pos: -5.5,-8.5
       parent: 2
+      pos: -5.5,-8.5
   - uid: 595
     components:
     - type: Transform
-      pos: -6.5,-8.5
       parent: 2
+      pos: -6.5,-8.5
   - uid: 596
     components:
     - type: Transform
-      pos: -7.5,-8.5
       parent: 2
+      pos: -7.5,-8.5
   - uid: 639
     components:
     - type: Transform
-      pos: 6.5,4.5
       parent: 2
+      pos: 6.5,4.5
   - uid: 640
     components:
     - type: Transform
-      pos: 6.5,7.5
       parent: 2
+      pos: 6.5,7.5
   - uid: 641
     components:
     - type: Transform
-      pos: 6.5,9.5
       parent: 2
+      pos: 6.5,9.5
   - uid: 642
     components:
     - type: Transform
-      pos: 6.5,5.5
       parent: 2
+      pos: 6.5,5.5
   - uid: 643
     components:
     - type: Transform
-      pos: 6.5,6.5
       parent: 2
+      pos: 6.5,6.5
   - uid: 644
     components:
     - type: Transform
-      pos: 6.5,8.5
       parent: 2
+      pos: 6.5,8.5
+- proto: CableTerminal
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      parent: 2
+      pos: -13.5,-0.5
+  - uid: 206
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -10.5,-7.5
+  - uid: 217
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 7.5,4.5
+  - uid: 243
+    components:
+    - type: Transform
+      parent: 2
+      pos: -16.5,-5.5
+  - uid: 348
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
 - proto: CandleBlueInfinite
   entities:
   - uid: 723
     components:
     - type: Transform
-      pos: 0.5,-11.5
       parent: 2
+      pos: 0.5,-11.5
   - uid: 724
     components:
     - type: Transform
-      pos: 2.5,-11.5
       parent: 2
+      pos: 2.5,-11.5
 - proto: Carpet
   entities:
   - uid: 117
     components:
     - type: Transform
-      pos: 11.5,-4.5
       parent: 2
+      pos: 11.5,-4.5
   - uid: 120
     components:
     - type: Transform
-      pos: 10.5,-4.5
       parent: 2
+      pos: 10.5,-4.5
   - uid: 126
     components:
     - type: Transform
-      pos: 10.5,-0.5
       parent: 2
+      pos: 10.5,-0.5
   - uid: 127
     components:
     - type: Transform
-      pos: 11.5,-0.5
       parent: 2
+      pos: 11.5,-0.5
   - uid: 128
     components:
     - type: Transform
-      pos: 10.5,2.5
       parent: 2
+      pos: 10.5,2.5
   - uid: 129
     components:
     - type: Transform
-      pos: 11.5,2.5
       parent: 2
+      pos: 11.5,2.5
 - proto: CarpetBlue
   entities:
   - uid: 808
     components:
     - type: Transform
-      pos: 0.5,-10.5
       parent: 2
+      pos: 0.5,-10.5
   - uid: 809
     components:
     - type: Transform
-      pos: 0.5,-11.5
       parent: 2
+      pos: 0.5,-11.5
   - uid: 810
     components:
     - type: Transform
-      pos: 1.5,-11.5
       parent: 2
+      pos: 1.5,-11.5
   - uid: 811
     components:
     - type: Transform
-      pos: 2.5,-10.5
       parent: 2
+      pos: 2.5,-10.5
   - uid: 812
     components:
     - type: Transform
-      pos: 1.5,-10.5
       parent: 2
+      pos: 1.5,-10.5
   - uid: 813
     components:
     - type: Transform
-      pos: 2.5,-11.5
       parent: 2
+      pos: 2.5,-11.5
 - proto: Catwalk
   entities:
   - uid: 607
     components:
     - type: Transform
-      pos: 1.5,6.5
       parent: 2
+      pos: 1.5,6.5
   - uid: 608
     components:
     - type: Transform
-      pos: 0.5,6.5
       parent: 2
+      pos: 0.5,6.5
   - uid: 609
     components:
     - type: Transform
-      pos: -0.5,6.5
       parent: 2
+      pos: -0.5,6.5
   - uid: 610
     components:
     - type: Transform
-      pos: -1.5,6.5
       parent: 2
+      pos: -1.5,6.5
   - uid: 611
     components:
     - type: Transform
-      pos: -2.5,6.5
       parent: 2
+      pos: -2.5,6.5
   - uid: 612
     components:
     - type: Transform
-      pos: -3.5,6.5
       parent: 2
+      pos: -3.5,6.5
   - uid: 613
     components:
     - type: Transform
-      pos: -4.5,6.5
       parent: 2
+      pos: -4.5,6.5
   - uid: 614
     components:
     - type: Transform
-      pos: -5.5,6.5
       parent: 2
+      pos: -5.5,6.5
   - uid: 615
     components:
     - type: Transform
-      pos: -6.5,6.5
       parent: 2
+      pos: -6.5,6.5
   - uid: 616
     components:
     - type: Transform
-      pos: -7.5,6.5
       parent: 2
+      pos: -7.5,6.5
   - uid: 617
     components:
     - type: Transform
-      pos: -8.5,3.5
       parent: 2
+      pos: -8.5,3.5
   - uid: 618
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 2
+      pos: 2.5,5.5
   - uid: 619
     components:
     - type: Transform
-      pos: 2.5,4.5
       parent: 2
+      pos: 2.5,4.5
   - uid: 620
     components:
     - type: Transform
-      pos: -8.5,4.5
       parent: 2
+      pos: -8.5,4.5
   - uid: 621
     components:
     - type: Transform
-      pos: -8.5,5.5
       parent: 2
+      pos: -8.5,5.5
   - uid: 738
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -2.5,-7.5
-      parent: 2
   - uid: 739
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -1.5,-7.5
-      parent: 2
   - uid: 740
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
-      parent: 2
   - uid: 741
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
-      parent: 2
   - uid: 742
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 1.5,-7.5
-      parent: 2
   - uid: 743
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 2.5,-7.5
-      parent: 2
   - uid: 744
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 3.5,-7.5
-      parent: 2
   - uid: 745
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
-      parent: 2
   - uid: 746
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 5.5,-7.5
-      parent: 2
 - proto: Chair
   entities:
   - uid: 191
     components:
     - type: Transform
-      pos: -14.5,-7.5
       parent: 2
+      pos: -14.5,-7.5
   - uid: 192
     components:
     - type: Transform
-      pos: -15.5,-7.5
       parent: 2
+      pos: -15.5,-7.5
   - uid: 193
     components:
     - type: Transform
-      pos: -13.5,-7.5
       parent: 2
+      pos: -13.5,-7.5
   - uid: 194
     components:
     - type: Transform
-      pos: -12.5,-7.5
       parent: 2
+      pos: -12.5,-7.5
   - uid: 195
     components:
     - type: Transform
-      pos: -11.5,-7.5
       parent: 2
+      pos: -11.5,-7.5
   - uid: 196
     components:
     - type: Transform
-      pos: -10.5,-7.5
       parent: 2
+      pos: -10.5,-7.5
   - uid: 848
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 9.5,11.5
-      parent: 2
   - uid: 849
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 10.5,10.5
-      parent: 2
 - proto: ChairOfficeDark
   entities:
   - uid: 130
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 10.5,2.5
-      parent: 2
   - uid: 131
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 10.5,-0.5
-      parent: 2
   - uid: 132
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 10.5,-4.5
-      parent: 2
   - uid: 422
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -12.5,-3.5
-      parent: 2
   - uid: 423
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -12.5,-4.5
-      parent: 2
 - proto: ChairPilotSeat
   entities:
   - uid: 424
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -16.5,-3.5
-      parent: 2
   - uid: 425
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -15.5,-3.5
-      parent: 2
 - proto: ChairWood
   entities:
   - uid: 720
     components:
     - type: Transform
-      pos: 0.5,-10.5
       parent: 2
+      pos: 0.5,-10.5
   - uid: 721
     components:
     - type: Transform
-      pos: 1.5,-10.5
       parent: 2
+      pos: 1.5,-10.5
   - uid: 722
     components:
     - type: Transform
-      pos: 2.5,-10.5
       parent: 2
+      pos: 2.5,-10.5
 - proto: CigPackSyndicate
   entities:
   - uid: 842
     components:
     - type: Transform
-      pos: 10.3898945,11.682428
       parent: 2
+      pos: 10.3898945,11.682428
 - proto: ClothingHandsGlovesColorYellow
   entities:
   - uid: 656
     components:
     - type: Transform
-      pos: 7.5,10.5
       parent: 2
+      pos: 7.5,10.5
 - proto: ClothingNeckStethoscope
   entities:
   - uid: 441
     components:
     - type: Transform
-      pos: -15.5,-0.5
       parent: 2
+      pos: -15.5,-0.5
 - proto: Cobweb1
   entities:
   - uid: 63
     components:
     - type: Transform
-      pos: -5.5,4.5
       parent: 2
+      pos: -5.5,4.5
   - uid: 137
     components:
     - type: Transform
-      pos: 9.5,2.5
       parent: 2
+      pos: 9.5,2.5
   - uid: 623
     components:
     - type: Transform
-      pos: -16.5,-7.5
       parent: 2
+      pos: -16.5,-7.5
   - uid: 626
     components:
     - type: Transform
-      pos: -13.5,10.5
       parent: 2
+      pos: -13.5,10.5
 - proto: Cobweb2
   entities:
   - uid: 62
     components:
     - type: Transform
-      pos: 3.5,1.5
       parent: 2
+      pos: 3.5,1.5
   - uid: 138
     components:
     - type: Transform
-      pos: 11.5,-3.5
       parent: 2
+      pos: 11.5,-3.5
   - uid: 622
     components:
     - type: Transform
-      pos: -11.5,-2.5
       parent: 2
+      pos: -11.5,-2.5
   - uid: 624
     components:
     - type: Transform
-      pos: -11.5,4.5
       parent: 2
+      pos: -11.5,4.5
   - uid: 625
     components:
     - type: Transform
-      pos: -11.5,9.5
       parent: 2
+      pos: -11.5,9.5
 - proto: ComfyChair
   entities:
   - uid: 676
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 0.5,-4.5
-      parent: 2
   - uid: 677
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
-      parent: 2
 - proto: ComputerId
   entities:
   - uid: 416
     components:
     - type: Transform
-      pos: -15.5,-2.5
       parent: 2
+      pos: -15.5,-2.5
+- proto: CrateEngineeringSolar
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      parent: 2
+      pos: 7.5,9.5
 - proto: CrateGenericSteel
   entities:
   - uid: 163
     components:
     - type: Transform
-      pos: -4.5,4.5
       parent: 2
+      pos: -4.5,4.5
 - proto: Crematorium
   entities:
   - uid: 187
     components:
     - type: Transform
-      pos: -13.5,10.5
       parent: 2
+      pos: -13.5,10.5
 - proto: DrinkMugRed
   entities:
   - uid: 446
     components:
     - type: Transform
-      pos: -15.5,3.5
       parent: 2
+      pos: -15.5,3.5
 - proto: DrinkSyndicatebomb
   entities:
   - uid: 48
     components:
     - type: Transform
-      pos: -0.5,2.5
       parent: 2
+      pos: -0.5,2.5
   - uid: 49
     components:
     - type: Transform
-      pos: -1.5,2.5
       parent: 2
+      pos: -1.5,2.5
   - uid: 50
     components:
     - type: Transform
-      pos: -2.5,2.5
       parent: 2
+      pos: -2.5,2.5
   - uid: 51
     components:
     - type: Transform
-      pos: -3.5,2.5
       parent: 2
+      pos: -3.5,2.5
   - uid: 52
     components:
     - type: Transform
-      pos: -4.5,2.5
       parent: 2
+      pos: -4.5,2.5
   - uid: 53
     components:
     - type: Transform
-      pos: -5.5,2.5
       parent: 2
+      pos: -5.5,2.5
 - proto: ESCatwalkGrey
   entities:
   - uid: 378
     components:
     - type: Transform
-      pos: -8.5,1.5
       parent: 2
+      pos: -8.5,1.5
   - uid: 379
     components:
     - type: Transform
-      pos: -8.5,0.5
       parent: 2
+      pos: -8.5,0.5
   - uid: 380
     components:
     - type: Transform
-      pos: -8.5,-0.5
       parent: 2
+      pos: -8.5,-0.5
   - uid: 381
     components:
     - type: Transform
-      pos: -8.5,-1.5
       parent: 2
+      pos: -8.5,-1.5
   - uid: 382
     components:
     - type: Transform
-      pos: -8.5,-2.5
       parent: 2
+      pos: -8.5,-2.5
   - uid: 383
     components:
     - type: Transform
-      pos: -8.5,-3.5
       parent: 2
+      pos: -8.5,-3.5
   - uid: 384
     components:
     - type: Transform
-      pos: -8.5,-4.5
       parent: 2
+      pos: -8.5,-4.5
   - uid: 385
     components:
     - type: Transform
-      pos: -8.5,-5.5
       parent: 2
+      pos: -8.5,-5.5
   - uid: 645
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 7.5,9.5
-      parent: 2
   - uid: 646
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 6.5,10.5
-      parent: 2
   - uid: 647
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 5.5,10.5
-      parent: 2
   - uid: 648
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 7.5,10.5
-      parent: 2
   - uid: 649
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 6.5,9.5
-      parent: 2
   - uid: 650
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 5.5,9.5
-      parent: 2
 - proto: ESCrateTrashBin
   entities:
   - uid: 5
     components:
     - type: Transform
-      pos: 4.5,4.5
       parent: 2
+      pos: 4.5,4.5
   - uid: 408
     components:
     - type: Transform
-      pos: -16.5,-7.5
       parent: 2
+      pos: -16.5,-7.5
   - uid: 759
     components:
     - type: Transform
-      pos: 1.5,-6.5
       parent: 2
+      pos: 1.5,-6.5
 - proto: ESCrateTrashBinFilledRandom
   entities:
   - uid: 64
     components:
     - type: Transform
-      pos: -5.5,-4.5
       parent: 2
+      pos: -5.5,-4.5
 - proto: ESCrateTrashBinSecure
   entities:
   - uid: 448
     components:
     - type: Transform
-      pos: -17.5,-5.5
       parent: 2
+      pos: -17.5,-5.5
+- proto: ESPoweredLightDepartment
+  entities:
+  - uid: 658
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-2.5
+  - uid: 659
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+  - uid: 660
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+  - uid: 663
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -11.5,3.5
+  - uid: 664
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -16.5,-8.5
+  - uid: 665
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
 - proto: ESSpawnerRandomGrilleBroken50
   entities:
   - uid: 773
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -6.5,11.5
-      parent: 2
   - uid: 778
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -1.5,11.5
-      parent: 2
   - uid: 781
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
-      parent: 2
   - uid: 782
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,9.5
-      parent: 2
   - uid: 789
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,4.5
-      parent: 2
   - uid: 790
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,5.5
-      parent: 2
   - uid: 791
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,0.5
-      parent: 2
   - uid: 796
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -20.5,-1.5
-      parent: 2
   - uid: 797
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -20.5,-6.5
-      parent: 2
   - uid: 798
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,2.5
-      parent: 2
   - uid: 799
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,-4.5
-      parent: 2
   - uid: 800
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,-3.5
-      parent: 2
   - uid: 843
     components:
     - type: Transform
-      pos: 9.5,9.5
       parent: 2
+      pos: 9.5,9.5
 - proto: ESSpawnerRandomGrilleBroken75
   entities:
   - uid: 687
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -7.5,11.5
-      parent: 2
   - uid: 775
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -4.5,11.5
-      parent: 2
   - uid: 776
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -3.5,11.5
-      parent: 2
   - uid: 779
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -0.5,11.5
-      parent: 2
   - uid: 780
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
-      parent: 2
   - uid: 783
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,8.5
-      parent: 2
   - uid: 784
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,7.5
-      parent: 2
   - uid: 785
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,6.5
-      parent: 2
   - uid: 786
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,2.5
-      parent: 2
   - uid: 787
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,1.5
-      parent: 2
   - uid: 788
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -18.5,3.5
-      parent: 2
   - uid: 792
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -20.5,-3.5
-      parent: 2
   - uid: 793
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -20.5,-4.5
-      parent: 2
   - uid: 794
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -20.5,-2.5
-      parent: 2
   - uid: 795
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -20.5,-5.5
-      parent: 2
   - uid: 801
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,1.5
-      parent: 2
   - uid: 802
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,0.5
-      parent: 2
   - uid: 803
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,-0.5
-      parent: 2
   - uid: 804
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,-1.5
-      parent: 2
   - uid: 805
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 14.5,-2.5
-      parent: 2
 - proto: ESSpawnerRandomMaintCanister
   entities:
   - uid: 747
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -4.5,-7.5
-      parent: 2
 - proto: ESSpawnerRandomMaintCrate
   entities:
   - uid: 771
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -9.5,7.5
-      parent: 2
 - proto: ESSpawnerRandomMaintLootExposed100
   entities:
   - uid: 753
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -2.5,-9.5
-      parent: 2
   - uid: 754
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
-      parent: 2
   - uid: 772
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -1.5,7.5
-      parent: 2
 - proto: ESSpawnerRandomMaintLootExposed25
   entities:
   - uid: 851
     components:
     - type: Transform
-      pos: -3.5,-7.5
       parent: 2
+      pos: -3.5,-7.5
   - uid: 854
     components:
     - type: Transform
-      pos: 0.5,-7.5
       parent: 2
+      pos: 0.5,-7.5
   - uid: 855
     components:
     - type: Transform
-      pos: 9.5,5.5
       parent: 2
+      pos: 9.5,5.5
   - uid: 856
     components:
     - type: Transform
-      pos: 9.5,11.5
       parent: 2
+      pos: 9.5,11.5
   - uid: 857
     components:
     - type: Transform
-      pos: 10.5,10.5
       parent: 2
+      pos: 10.5,10.5
   - uid: 860
     components:
     - type: Transform
-      pos: -9.5,4.5
       parent: 2
+      pos: -9.5,4.5
   - uid: 861
     components:
     - type: Transform
-      pos: -4.5,6.5
       parent: 2
+      pos: -4.5,6.5
 - proto: ESSpawnerRandomMaintLootExposed50
   entities:
   - uid: 852
     components:
     - type: Transform
-      pos: 2.5,-6.5
       parent: 2
+      pos: 2.5,-6.5
   - uid: 853
     components:
     - type: Transform
-      pos: 3.5,-6.5
       parent: 2
+      pos: 3.5,-6.5
   - uid: 858
     components:
     - type: Transform
-      pos: 2.5,5.5
       parent: 2
+      pos: 2.5,5.5
   - uid: 859
     components:
     - type: Transform
-      pos: -9.5,3.5
       parent: 2
+      pos: -9.5,3.5
 - proto: ESSpawnerRandomMaintLootStructure
   entities:
   - uid: 748
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 7.5,-6.5
-      parent: 2
   - uid: 749
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 7.5,-7.5
-      parent: 2
   - uid: 750
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 7.5,-8.5
-      parent: 2
   - uid: 752
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -4.5,-6.5
-      parent: 2
   - uid: 760
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -7.5,5.5
-      parent: 2
   - uid: 761
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -7.5,4.5
-      parent: 2
   - uid: 762
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -7.5,3.5
-      parent: 2
   - uid: 763
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 3.5,7.5
-      parent: 2
   - uid: 765
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 1.5,3.5
-      parent: 2
   - uid: 766
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 1.5,4.5
-      parent: 2
   - uid: 768
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -3.5,7.5
-      parent: 2
   - uid: 769
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -2.5,7.5
-      parent: 2
   - uid: 844
     components:
     - type: Transform
-      pos: 10.5,8.5
       parent: 2
+      pos: 10.5,8.5
   - uid: 845
     components:
     - type: Transform
-      pos: 10.5,7.5
       parent: 2
+      pos: 10.5,7.5
 - proto: ESSpawnerRandomTrashJunk100
   entities:
   - uid: 65
     components:
     - type: Transform
-      pos: -5.5,-4.5
       parent: 2
+      pos: -5.5,-4.5
   - uid: 155
     components:
     - type: Transform
-      pos: 5.5,-4.5
       parent: 2
+      pos: 5.5,-4.5
 - proto: ESSpawnerRandomTrashJunk25
   entities:
   - uid: 71
     components:
     - type: Transform
-      pos: -4.5,-2.5
       parent: 2
+      pos: -4.5,-2.5
   - uid: 72
     components:
     - type: Transform
-      pos: -3.5,-3.5
       parent: 2
+      pos: -3.5,-3.5
   - uid: 164
     components:
     - type: Transform
-      pos: -5.5,3.5
       parent: 2
+      pos: -5.5,3.5
   - uid: 165
     components:
     - type: Transform
-      pos: -4.5,3.5
       parent: 2
+      pos: -4.5,3.5
   - uid: 166
     components:
     - type: Transform
-      pos: -2.5,4.5
       parent: 2
+      pos: -2.5,4.5
   - uid: 167
     components:
     - type: Transform
-      pos: -0.5,3.5
       parent: 2
+      pos: -0.5,3.5
 - proto: ESSpawnerRandomTrashJunk50
   entities:
   - uid: 68
     components:
     - type: Transform
-      pos: -3.5,-4.5
       parent: 2
+      pos: -3.5,-4.5
   - uid: 69
     components:
     - type: Transform
-      pos: -4.5,-3.5
       parent: 2
+      pos: -4.5,-3.5
   - uid: 70
     components:
     - type: Transform
-      pos: -5.5,-2.5
       parent: 2
+      pos: -5.5,-2.5
   - uid: 139
     components:
     - type: Transform
-      pos: 10.5,-0.5
       parent: 2
+      pos: 10.5,-0.5
   - uid: 140
     components:
     - type: Transform
-      pos: 10.5,-1.5
       parent: 2
+      pos: 10.5,-1.5
   - uid: 141
     components:
     - type: Transform
-      pos: 11.5,-0.5
       parent: 2
+      pos: 11.5,-0.5
   - uid: 142
     components:
     - type: Transform
-      pos: 9.5,1.5
       parent: 2
+      pos: 9.5,1.5
   - uid: 143
     components:
     - type: Transform
-      pos: 9.5,2.5
       parent: 2
+      pos: 9.5,2.5
   - uid: 144
     components:
     - type: Transform
-      pos: 11.5,2.5
       parent: 2
+      pos: 11.5,2.5
   - uid: 145
     components:
     - type: Transform
-      pos: 11.5,-4.5
       parent: 2
+      pos: 11.5,-4.5
   - uid: 146
     components:
     - type: Transform
-      pos: 10.5,-4.5
       parent: 2
+      pos: 10.5,-4.5
   - uid: 147
     components:
     - type: Transform
-      pos: 9.5,-3.5
       parent: 2
+      pos: 9.5,-3.5
 - proto: ESSpawnerRandomTrashJunk75
   entities:
   - uid: 66
     components:
     - type: Transform
-      pos: -5.5,-3.5
       parent: 2
+      pos: -5.5,-3.5
   - uid: 67
     components:
     - type: Transform
-      pos: -4.5,-4.5
       parent: 2
+      pos: -4.5,-4.5
 - proto: ESVendingMachineCigs
   entities:
   - uid: 148
     components:
     - type: Transform
-      pos: 4.5,5.5
       parent: 2
+      pos: 4.5,5.5
 - proto: ESWeaponPistol9mmSilenced
   entities:
   - uid: 136
     components:
     - type: Transform
-      pos: 9.5,-0.5
       parent: 2
+      pos: 9.5,-0.5
 - proto: filingCabinetRandom
   entities:
   - uid: 413
     components:
     - type: Transform
-      pos: -12.5,-2.5
       parent: 2
+      pos: -12.5,-2.5
   - uid: 414
     components:
     - type: Transform
+      parent: 2
       pos: -11.5,-2.5
-      parent: 2
-- proto: GeneratorBasic15kW
-  entities:
-  - uid: 364
-    components:
-    - type: Transform
-      pos: 7.5,11.5
-      parent: 2
-  - uid: 371
-    components:
-    - type: Transform
-      pos: 6.5,11.5
-      parent: 2
-- proto: GhostWarpPoint
-  entities:
-  - uid: 1
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 2
-- proto: Girder
-  entities:
-  - uid: 751
-    components:
-    - type: Transform
-      pos: 4.5,-6.5
-      parent: 2
-  - uid: 764
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 2
-- proto: Grille
-  entities:
-  - uid: 17
-    components:
-    - type: Transform
-      pos: 4.5,-2.5
-      parent: 2
-  - uid: 31
-    components:
-    - type: Transform
-      pos: 4.5,-4.5
-      parent: 2
-  - uid: 73
-    components:
-    - type: Transform
-      pos: 8.5,-4.5
-      parent: 2
-  - uid: 74
-    components:
-    - type: Transform
-      pos: 8.5,-0.5
-      parent: 2
-  - uid: 75
-    components:
-    - type: Transform
-      pos: 8.5,2.5
-      parent: 2
-  - uid: 91
-    components:
-    - type: Transform
-      pos: 12.5,1.5
-      parent: 2
-  - uid: 92
-    components:
-    - type: Transform
-      pos: 12.5,-1.5
-      parent: 2
-  - uid: 97
-    components:
-    - type: Transform
-      pos: 12.5,-4.5
-      parent: 2
-  - uid: 229
-    components:
-    - type: Transform
-      pos: -11.5,-6.5
-      parent: 2
-  - uid: 230
-    components:
-    - type: Transform
-      pos: -12.5,-6.5
-      parent: 2
-  - uid: 231
-    components:
-    - type: Transform
-      pos: -13.5,-6.5
-      parent: 2
-  - uid: 232
-    components:
-    - type: Transform
-      pos: -14.5,-6.5
-      parent: 2
-  - uid: 233
-    components:
-    - type: Transform
-      pos: -15.5,-6.5
-      parent: 2
-  - uid: 241
-    components:
-    - type: Transform
-      pos: -10.5,-0.5
-      parent: 2
-  - uid: 242
-    components:
-    - type: Transform
-      pos: -10.5,1.5
-      parent: 2
-  - uid: 276
-    components:
-    - type: Transform
-      pos: -8.5,-6.5
-      parent: 2
-  - uid: 280
-    components:
-    - type: Transform
-      pos: -6.5,-0.5
-      parent: 2
-  - uid: 301
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -13.5,11.5
-      parent: 2
-  - uid: 393
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -16.5,-10.5
-      parent: 2
-  - uid: 394
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -14.5,-10.5
-      parent: 2
-  - uid: 395
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -12.5,-10.5
-      parent: 2
-  - uid: 396
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,-10.5
-      parent: 2
-  - uid: 397
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-10.5
-      parent: 2
-  - uid: 398
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -8.5,-10.5
-      parent: 2
-  - uid: 399
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-10.5
-      parent: 2
-  - uid: 767
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,7.5
-      parent: 2
-  - uid: 774
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -5.5,11.5
-      parent: 2
-  - uid: 777
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,11.5
-      parent: 2
-  - uid: 846
-    components:
-    - type: Transform
-      pos: 10.5,9.5
-      parent: 2
-- proto: HospitalCurtainsOpen
-  entities:
-  - uid: 431
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,3.5
-      parent: 2
-  - uid: 435
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,4.5
-      parent: 2
-  - uid: 436
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,2.5
-      parent: 2
-  - uid: 437
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -15.5,0.5
-      parent: 2
 - proto: FlippoLighter
   entities:
   - uid: 850
     components:
     - type: Transform
-      pos: 10.71973,11.405067
       parent: 2
+      pos: 10.71973,11.405067
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 364
+    components:
+    - type: Transform
+      parent: 2
+      pos: 7.5,11.5
+  - uid: 371
+    components:
+    - type: Transform
+      parent: 2
+      pos: 6.5,11.5
+- proto: GhostWarpPoint
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      parent: 2
+      pos: -1.5,-1.5
+- proto: Girder
+  entities:
+  - uid: 751
+    components:
+    - type: Transform
+      parent: 2
+      pos: 4.5,-6.5
+  - uid: 764
+    components:
+    - type: Transform
+      parent: 2
+      pos: 1.5,5.5
+- proto: Grille
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      parent: 2
+      pos: 4.5,-2.5
+  - uid: 31
+    components:
+    - type: Transform
+      parent: 2
+      pos: 4.5,-4.5
+  - uid: 73
+    components:
+    - type: Transform
+      parent: 2
+      pos: 8.5,-4.5
+  - uid: 74
+    components:
+    - type: Transform
+      parent: 2
+      pos: 8.5,-0.5
+  - uid: 75
+    components:
+    - type: Transform
+      parent: 2
+      pos: 8.5,2.5
+  - uid: 91
+    components:
+    - type: Transform
+      parent: 2
+      pos: 12.5,1.5
+  - uid: 92
+    components:
+    - type: Transform
+      parent: 2
+      pos: 12.5,-1.5
+  - uid: 97
+    components:
+    - type: Transform
+      parent: 2
+      pos: 12.5,-4.5
+  - uid: 229
+    components:
+    - type: Transform
+      parent: 2
+      pos: -11.5,-6.5
+  - uid: 230
+    components:
+    - type: Transform
+      parent: 2
+      pos: -12.5,-6.5
+  - uid: 231
+    components:
+    - type: Transform
+      parent: 2
+      pos: -13.5,-6.5
+  - uid: 232
+    components:
+    - type: Transform
+      parent: 2
+      pos: -14.5,-6.5
+  - uid: 233
+    components:
+    - type: Transform
+      parent: 2
+      pos: -15.5,-6.5
+  - uid: 241
+    components:
+    - type: Transform
+      parent: 2
+      pos: -10.5,-0.5
+  - uid: 242
+    components:
+    - type: Transform
+      parent: 2
+      pos: -10.5,1.5
+  - uid: 276
+    components:
+    - type: Transform
+      parent: 2
+      pos: -8.5,-6.5
+  - uid: 280
+    components:
+    - type: Transform
+      parent: 2
+      pos: -6.5,-0.5
+  - uid: 301
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -13.5,11.5
+  - uid: 393
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -16.5,-10.5
+  - uid: 394
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-10.5
+  - uid: 395
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -12.5,-10.5
+  - uid: 396
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -11.5,-10.5
+  - uid: 397
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-10.5
+  - uid: 398
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-10.5
+  - uid: 399
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-10.5
+  - uid: 767
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+  - uid: 774
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -5.5,11.5
+  - uid: 777
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+  - uid: 846
+    components:
+    - type: Transform
+      parent: 2
+      pos: 10.5,9.5
+- proto: HospitalCurtainsOpen
+  entities:
+  - uid: 431
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -11.5,3.5
+  - uid: 435
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -15.5,4.5
+  - uid: 436
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -15.5,2.5
+  - uid: 437
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -15.5,0.5
 - proto: Lamp
   entities:
   - uid: 134
     components:
     - type: Transform
-      pos: 9.512113,-4.169538
       parent: 2
+      pos: 9.512113,-4.169538
     - type: HandheldLight
       toggleActionEntity: 135
     - type: ContainerContainer
       containers:
         cell_slot: !type:ContainerSlot
-          showEnts: False
-          occludes: True
           ent: null
-        actions: !type:Container
           showEnts: False
           occludes: True
+        actions: !type:Container
           ents:
           - 135
+          showEnts: False
+          occludes: True
     - type: Physics
       canCollide: True
     - type: ActionsContainer
   - uid: 449
     components:
     - type: Transform
-      pos: -13.5,-2.5
       parent: 2
+      pos: -13.5,-2.5
 - proto: LockerCabinet
   entities:
   - uid: 150
     components:
     - type: Transform
+      parent: 2
       pos: -0.5,4.5
-      parent: 2
-- proto: LootSpawnerRandomCrateEngineering
-  entities:
-  - uid: 457
-    components:
-    - type: Transform
-      pos: 7.5,9.5
-      parent: 2
 - proto: MedicalBed
   entities:
   - uid: 432
     components:
     - type: Transform
-      pos: -15.5,4.5
       parent: 2
+      pos: -15.5,4.5
   - uid: 433
     components:
     - type: Transform
-      pos: -15.5,2.5
       parent: 2
+      pos: -15.5,2.5
   - uid: 434
     components:
     - type: Transform
-      pos: -15.5,0.5
       parent: 2
-- proto: MedkitCombatFilled
+      pos: -15.5,0.5
+- proto: MedkitFilled
   entities:
   - uid: 428
     components:
     - type: Transform
-      pos: -12.5,1.5
       parent: 2
+      pos: -12.5,1.5
   - uid: 429
     components:
     - type: Transform
-      pos: -11.5,1.5
       parent: 2
+      pos: -11.5,1.5
 - proto: Morgue
   entities:
   - uid: 184
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -11.5,9.5
-      parent: 2
   - uid: 185
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -11.5,8.5
-      parent: 2
   - uid: 186
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -11.5,7.5
-      parent: 2
   - uid: 188
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -15.5,9.5
-      parent: 2
   - uid: 189
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -15.5,8.5
-      parent: 2
   - uid: 190
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -15.5,7.5
-      parent: 2
 - proto: OperatingTable
   entities:
   - uid: 430
     components:
     - type: Transform
-      pos: -11.5,3.5
       parent: 2
+      pos: -11.5,3.5
 - proto: PaperBin5
   entities:
   - uid: 447
     components:
     - type: Transform
-      pos: -17.5,-2.5
       parent: 2
+      pos: -17.5,-2.5
 - proto: PianoInstrument
   entities:
   - uid: 61
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
-      parent: 2
 - proto: PosterContrabandC20r
   entities:
   - uid: 726
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -17.5,-7.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandCC64KAd
@@ -3484,9 +3507,9 @@ entities:
   - uid: 725
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandEnergySwords
@@ -3494,8 +3517,8 @@ entities:
   - uid: 733
     components:
     - type: Transform
-      pos: 2.5,2.5
       parent: 2
+      pos: 2.5,2.5
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandEnlistGorlex
@@ -3503,9 +3526,9 @@ entities:
   - uid: 727
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -6.5,1.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandFreeSyndicateEncryptionKey
@@ -3513,9 +3536,9 @@ entities:
   - uid: 735
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 4.5,-1.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandFunPolice
@@ -3523,8 +3546,8 @@ entities:
   - uid: 728
     components:
     - type: Transform
-      pos: -14.5,-1.5
       parent: 2
+      pos: -14.5,-1.5
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandHackingGuide
@@ -3532,9 +3555,9 @@ entities:
   - uid: 736
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 4.5,10.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandInterdyne
@@ -3542,9 +3565,9 @@ entities:
   - uid: 729
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -12.5,-1.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandNuclearDeviceInformational
@@ -3552,8 +3575,8 @@ entities:
   - uid: 730
     components:
     - type: Transform
-      pos: -9.5,2.5
       parent: 2
+      pos: -9.5,2.5
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandRevolver
@@ -3561,9 +3584,9 @@ entities:
   - uid: 731
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -6.5,-3.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandSyndicatePistol
@@ -3571,9 +3594,9 @@ entities:
   - uid: 732
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -10.5,-2.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterContrabandSyndicateRecruitment
@@ -3581,9 +3604,9 @@ entities:
   - uid: 390
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 8.5,0.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitAnatomyPoster
@@ -3591,8 +3614,8 @@ entities:
   - uid: 734
     components:
     - type: Transform
-      pos: -12.5,5.5
       parent: 2
+      pos: -12.5,5.5
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitIan
@@ -3600,9 +3623,9 @@ entities:
   - uid: 737
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 1.5,-12.5
-      parent: 2
     - type: Fixtures
       fixtures: {}
 - proto: PosterLegitNanotrasenLogo
@@ -3610,15 +3633,15 @@ entities:
   - uid: 711
     components:
     - type: Transform
-      pos: 0.5,-8.5
       parent: 2
+      pos: 0.5,-8.5
     - type: Fixtures
       fixtures: {}
   - uid: 712
     components:
     - type: Transform
-      pos: 2.5,-8.5
       parent: 2
+      pos: 2.5,-8.5
     - type: Fixtures
       fixtures: {}
 - proto: PottedPlant10
@@ -3626,1599 +3649,1561 @@ entities:
   - uid: 862
     components:
     - type: Transform
-      pos: -0.5,-11.5
       parent: 2
+      pos: -0.5,-11.5
   - uid: 863
     components:
     - type: Transform
-      pos: 3.5,-11.5
       parent: 2
+      pos: 3.5,-11.5
 - proto: PottedPlant17
   entities:
   - uid: 389
     components:
     - type: Transform
-      pos: -7.5,1.5
       parent: 2
+      pos: -7.5,1.5
   - uid: 407
     components:
     - type: Transform
-      pos: -8.5,-7.5
       parent: 2
+      pos: -8.5,-7.5
 - proto: PottedPlant21
   entities:
   - uid: 174
     components:
     - type: Transform
-      pos: 3.5,-4.5
       parent: 2
+      pos: 3.5,-4.5
 - proto: PottedPlantRandomPlastic
   entities:
   - uid: 162
     components:
     - type: Transform
-      pos: 4.5,3.5
       parent: 2
+      pos: 4.5,3.5
 - proto: PoweredDimSmallLight
   entities:
   - uid: 667
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -9.5,5.5
-      parent: 2
   - uid: 668
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: 2.5,4.5
-      parent: 2
   - uid: 669
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -2.5,6.5
-      parent: 2
   - uid: 670
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 9.5,4.5
-      parent: 2
   - uid: 671
     components:
     - type: Transform
-      pos: 5.5,-6.5
       parent: 2
+      pos: 5.5,-6.5
   - uid: 672
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
-      parent: 2
-- proto: Poweredlight
-  entities:
-  - uid: 658
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-2.5
-      parent: 2
-  - uid: 659
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-0.5
-      parent: 2
-  - uid: 660
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,1.5
-      parent: 2
-  - uid: 663
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,3.5
-      parent: 2
-  - uid: 664
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -16.5,-8.5
-      parent: 2
-  - uid: 665
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -5.5,-3.5
-      parent: 2
 - proto: PoweredlightEmpty
   entities:
   - uid: 662
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: -17.5,-4.5
-      parent: 2
 - proto: PoweredSmallLight
   entities:
   - uid: 182
     components:
     - type: Transform
-      pos: 6.5,11.5
       parent: 2
+      pos: 6.5,11.5
   - uid: 661
     components:
     - type: Transform
-      pos: -3.5,4.5
       parent: 2
+      pos: -3.5,4.5
   - uid: 666
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -12.5,6.5
-      parent: 2
   - uid: 673
     components:
     - type: Transform
-      pos: 10.5,2.5
       parent: 2
+      pos: 10.5,2.5
   - uid: 674
     components:
     - type: Transform
-      pos: 10.5,-0.5
       parent: 2
+      pos: 10.5,-0.5
   - uid: 675
     components:
     - type: Transform
-      pos: 10.5,-3.5
       parent: 2
+      pos: 10.5,-3.5
 - proto: Rack
   entities:
   - uid: 183
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 2
+      pos: 10.5,4.5
   - uid: 637
     components:
     - type: Transform
-      pos: 7.5,10.5
       parent: 2
+      pos: 7.5,10.5
   - uid: 755
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
-      parent: 2
   - uid: 756
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -2.5,-9.5
-      parent: 2
   - uid: 770
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -1.5,7.5
-      parent: 2
 - proto: ReinforcedWindow
   entities:
   - uid: 112
     components:
     - type: Transform
-      pos: 12.5,1.5
       parent: 2
+      pos: 12.5,1.5
   - uid: 113
     components:
     - type: Transform
-      pos: 12.5,-1.5
       parent: 2
+      pos: 12.5,-1.5
   - uid: 114
     components:
     - type: Transform
-      pos: 12.5,-4.5
       parent: 2
+      pos: 12.5,-4.5
   - uid: 234
     components:
     - type: Transform
-      pos: -11.5,-6.5
       parent: 2
+      pos: -11.5,-6.5
   - uid: 235
     components:
     - type: Transform
-      pos: -12.5,-6.5
       parent: 2
+      pos: -12.5,-6.5
   - uid: 236
     components:
     - type: Transform
-      pos: -13.5,-6.5
       parent: 2
+      pos: -13.5,-6.5
   - uid: 237
     components:
     - type: Transform
-      pos: -14.5,-6.5
       parent: 2
+      pos: -14.5,-6.5
   - uid: 238
     components:
     - type: Transform
-      pos: -15.5,-6.5
       parent: 2
+      pos: -15.5,-6.5
   - uid: 400
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -16.5,-10.5
-      parent: 2
   - uid: 401
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -14.5,-10.5
-      parent: 2
   - uid: 402
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -12.5,-10.5
-      parent: 2
   - uid: 403
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -11.5,-10.5
-      parent: 2
   - uid: 404
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -10.5,-10.5
-      parent: 2
   - uid: 405
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -8.5,-10.5
-      parent: 2
   - uid: 406
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -6.5,-10.5
-      parent: 2
   - uid: 606
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -13.5,11.5
-      parent: 2
 - proto: SpawnPointLatejoin
   entities:
   - uid: 815
     components:
     - type: Transform
-      pos: -1.5,-0.5
       parent: 2
+      pos: -1.5,-0.5
   - uid: 816
     components:
     - type: Transform
-      pos: -3.5,-0.5
       parent: 2
+      pos: -3.5,-0.5
   - uid: 817
     components:
     - type: Transform
-      pos: 0.5,-0.5
       parent: 2
+      pos: 0.5,-0.5
   - uid: 819
     components:
     - type: Transform
-      pos: -3.5,-2.5
       parent: 2
+      pos: -3.5,-2.5
   - uid: 820
     components:
     - type: Transform
-      pos: -1.5,-2.5
       parent: 2
+      pos: -1.5,-2.5
   - uid: 821
     components:
     - type: Transform
-      pos: 0.5,-2.5
       parent: 2
+      pos: 0.5,-2.5
 - proto: Stool
   entities:
   - uid: 60
     components:
     - type: Transform
+      parent: 2
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
-      parent: 2
 - proto: StoolBar
   entities:
   - uid: 54
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -5.5,1.5
-      parent: 2
   - uid: 55
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -4.5,1.5
-      parent: 2
   - uid: 56
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -3.5,1.5
-      parent: 2
   - uid: 57
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
-      parent: 2
   - uid: 58
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
-      parent: 2
   - uid: 59
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -0.5,1.5
-      parent: 2
 - proto: SubstationBasic
   entities:
   - uid: 373
     components:
     - type: Transform
-      pos: 5.5,11.5
       parent: 2
+      pos: 5.5,11.5
 - proto: SyndicateBusinessCard
   entities:
   - uid: 678
     components:
     - type: Transform
-      pos: 1.5,-4.5
       parent: 2
+      pos: 1.5,-4.5
 - proto: Table
   entities:
   - uid: 426
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -11.5,1.5
-      parent: 2
   - uid: 427
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -12.5,1.5
-      parent: 2
   - uid: 438
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -15.5,1.5
-      parent: 2
   - uid: 439
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -15.5,-0.5
-      parent: 2
   - uid: 440
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -15.5,3.5
-      parent: 2
   - uid: 442
     components:
     - type: Transform
-      pos: -15.5,6.5
       parent: 2
+      pos: -15.5,6.5
   - uid: 443
     components:
     - type: Transform
-      pos: -14.5,6.5
       parent: 2
+      pos: -14.5,6.5
   - uid: 452
     components:
     - type: Transform
-      pos: 1.5,-4.5
       parent: 2
+      pos: 1.5,-4.5
   - uid: 717
     components:
     - type: Transform
-      pos: 0.5,-11.5
       parent: 2
+      pos: 0.5,-11.5
   - uid: 718
     components:
     - type: Transform
-      pos: 1.5,-11.5
       parent: 2
+      pos: 1.5,-11.5
   - uid: 719
     components:
     - type: Transform
-      pos: 2.5,-11.5
       parent: 2
+      pos: 2.5,-11.5
   - uid: 847
     components:
     - type: Transform
-      pos: 10.5,11.5
       parent: 2
+      pos: 10.5,11.5
 - proto: TableFrame
   entities:
   - uid: 176
     components:
     - type: Transform
-      pos: 3.5,-6.5
       parent: 2
+      pos: 3.5,-6.5
   - uid: 181
     components:
     - type: Transform
-      pos: 2.5,-6.5
       parent: 2
+      pos: 2.5,-6.5
 - proto: TableReinforced
   entities:
   - uid: 417
     components:
     - type: Transform
-      pos: -17.5,-2.5
       parent: 2
+      pos: -17.5,-2.5
   - uid: 418
     components:
     - type: Transform
-      pos: -13.5,-2.5
       parent: 2
+      pos: -13.5,-2.5
   - uid: 419
     components:
     - type: Transform
-      pos: -14.5,-2.5
       parent: 2
+      pos: -14.5,-2.5
   - uid: 420
     components:
     - type: Transform
-      pos: -13.5,-3.5
       parent: 2
+      pos: -13.5,-3.5
   - uid: 421
     components:
     - type: Transform
-      pos: -13.5,-4.5
       parent: 2
+      pos: -13.5,-4.5
 - proto: TableWood
   entities:
   - uid: 42
     components:
     - type: Transform
-      pos: -5.5,2.5
       parent: 2
+      pos: -5.5,2.5
   - uid: 43
     components:
     - type: Transform
-      pos: -4.5,2.5
       parent: 2
+      pos: -4.5,2.5
   - uid: 44
     components:
     - type: Transform
-      pos: -3.5,2.5
       parent: 2
+      pos: -3.5,2.5
   - uid: 45
     components:
     - type: Transform
-      pos: -2.5,2.5
       parent: 2
+      pos: -2.5,2.5
   - uid: 46
     components:
     - type: Transform
-      pos: -1.5,2.5
       parent: 2
+      pos: -1.5,2.5
   - uid: 47
     components:
     - type: Transform
-      pos: -0.5,2.5
       parent: 2
+      pos: -0.5,2.5
   - uid: 121
     components:
     - type: Transform
-      pos: 9.5,2.5
       parent: 2
+      pos: 9.5,2.5
   - uid: 122
     components:
     - type: Transform
-      pos: 9.5,-0.5
       parent: 2
+      pos: 9.5,-0.5
   - uid: 123
     components:
     - type: Transform
-      pos: 9.5,-4.5
       parent: 2
+      pos: 9.5,-4.5
 - proto: TintedWindow
   entities:
   - uid: 76
     components:
     - type: Transform
-      pos: 8.5,2.5
       parent: 2
+      pos: 8.5,2.5
   - uid: 77
     components:
     - type: Transform
-      pos: 8.5,-0.5
       parent: 2
+      pos: 8.5,-0.5
   - uid: 78
     components:
     - type: Transform
-      pos: 8.5,-4.5
       parent: 2
+      pos: 8.5,-4.5
   - uid: 79
     components:
     - type: Transform
-      pos: 4.5,-4.5
       parent: 2
+      pos: 4.5,-4.5
   - uid: 156
     components:
     - type: Transform
-      pos: 4.5,-2.5
       parent: 2
+      pos: 4.5,-2.5
 - proto: ToolboxSyndicateFilled
   entities:
   - uid: 244
     components:
     - type: Transform
-      pos: 10.5,4.5
       parent: 2
+      pos: 10.5,4.5
 - proto: VendingMachineBooze
   entities:
   - uid: 40
     components:
     - type: Transform
-      pos: -5.5,4.5
       parent: 2
+      pos: -5.5,4.5
 - proto: WallReinforced
   entities:
   - uid: 86
     components:
     - type: Transform
-      pos: 8.5,-5.5
       parent: 2
+      pos: 8.5,-5.5
   - uid: 87
     components:
     - type: Transform
-      pos: 9.5,-5.5
       parent: 2
+      pos: 9.5,-5.5
   - uid: 88
     components:
     - type: Transform
-      pos: 10.5,-5.5
       parent: 2
+      pos: 10.5,-5.5
   - uid: 89
     components:
     - type: Transform
-      pos: 11.5,-5.5
       parent: 2
+      pos: 11.5,-5.5
   - uid: 90
     components:
     - type: Transform
-      pos: 12.5,-5.5
       parent: 2
+      pos: 12.5,-5.5
   - uid: 93
     components:
     - type: Transform
-      pos: 12.5,-2.5
       parent: 2
+      pos: 12.5,-2.5
   - uid: 94
     components:
     - type: Transform
-      pos: 12.5,-3.5
       parent: 2
+      pos: 12.5,-3.5
   - uid: 95
     components:
     - type: Transform
-      pos: 12.5,-0.5
       parent: 2
+      pos: 12.5,-0.5
   - uid: 96
     components:
     - type: Transform
-      pos: 12.5,0.5
       parent: 2
+      pos: 12.5,0.5
   - uid: 98
     components:
     - type: Transform
-      pos: 12.5,2.5
       parent: 2
+      pos: 12.5,2.5
   - uid: 99
     components:
     - type: Transform
-      pos: 12.5,3.5
       parent: 2
+      pos: 12.5,3.5
   - uid: 100
     components:
     - type: Transform
-      pos: 11.5,3.5
       parent: 2
+      pos: 11.5,3.5
   - uid: 157
     components:
     - type: Transform
-      pos: 4.5,8.5
       parent: 2
+      pos: 4.5,8.5
   - uid: 170
     components:
     - type: Transform
-      pos: 11.5,11.5
       parent: 2
+      pos: 11.5,11.5
   - uid: 171
     components:
     - type: Transform
-      pos: 8.5,8.5
       parent: 2
+      pos: 8.5,8.5
   - uid: 172
     components:
     - type: Transform
-      pos: 5.5,8.5
       parent: 2
+      pos: 5.5,8.5
   - uid: 173
     components:
     - type: Transform
-      pos: 7.5,8.5
       parent: 2
+      pos: 7.5,8.5
   - uid: 175
     components:
     - type: Transform
-      pos: 11.5,12.5
       parent: 2
+      pos: 11.5,12.5
   - uid: 177
     components:
     - type: Transform
-      pos: 11.5,7.5
       parent: 2
+      pos: 11.5,7.5
   - uid: 178
     components:
     - type: Transform
-      pos: 11.5,6.5
       parent: 2
+      pos: 11.5,6.5
   - uid: 179
     components:
     - type: Transform
-      pos: 11.5,5.5
       parent: 2
+      pos: 11.5,5.5
   - uid: 180
     components:
     - type: Transform
-      pos: 11.5,4.5
       parent: 2
+      pos: 11.5,4.5
   - uid: 247
     components:
     - type: Transform
-      pos: -10.5,-5.5
       parent: 2
+      pos: -10.5,-5.5
   - uid: 248
     components:
     - type: Transform
-      pos: -10.5,-6.5
       parent: 2
+      pos: -10.5,-6.5
   - uid: 249
     components:
     - type: Transform
-      pos: -10.5,-3.5
       parent: 2
+      pos: -10.5,-3.5
   - uid: 250
     components:
     - type: Transform
-      pos: -10.5,-2.5
       parent: 2
+      pos: -10.5,-2.5
   - uid: 251
     components:
     - type: Transform
-      pos: -10.5,-1.5
       parent: 2
+      pos: -10.5,-1.5
   - uid: 252
     components:
     - type: Transform
-      pos: -11.5,-1.5
       parent: 2
+      pos: -11.5,-1.5
   - uid: 253
     components:
     - type: Transform
-      pos: -12.5,-1.5
       parent: 2
+      pos: -12.5,-1.5
   - uid: 254
     components:
     - type: Transform
-      pos: -13.5,-1.5
       parent: 2
+      pos: -13.5,-1.5
   - uid: 255
     components:
     - type: Transform
-      pos: -14.5,-1.5
       parent: 2
+      pos: -14.5,-1.5
   - uid: 256
     components:
     - type: Transform
-      pos: -15.5,-1.5
       parent: 2
+      pos: -15.5,-1.5
   - uid: 257
     components:
     - type: Transform
-      pos: -16.5,-1.5
       parent: 2
+      pos: -16.5,-1.5
   - uid: 258
     components:
     - type: Transform
-      pos: -17.5,-1.5
       parent: 2
+      pos: -17.5,-1.5
   - uid: 259
     components:
     - type: Transform
-      pos: -18.5,-1.5
       parent: 2
+      pos: -18.5,-1.5
   - uid: 260
     components:
     - type: Transform
-      pos: -18.5,-2.5
       parent: 2
+      pos: -18.5,-2.5
   - uid: 261
     components:
     - type: Transform
-      pos: -18.5,-3.5
       parent: 2
+      pos: -18.5,-3.5
   - uid: 262
     components:
     - type: Transform
-      pos: -18.5,-4.5
       parent: 2
+      pos: -18.5,-4.5
   - uid: 263
     components:
     - type: Transform
-      pos: -18.5,-5.5
       parent: 2
+      pos: -18.5,-5.5
   - uid: 264
     components:
     - type: Transform
-      pos: -18.5,-6.5
       parent: 2
+      pos: -18.5,-6.5
   - uid: 265
     components:
     - type: Transform
-      pos: -17.5,-6.5
       parent: 2
+      pos: -17.5,-6.5
   - uid: 266
     components:
     - type: Transform
-      pos: -16.5,-6.5
       parent: 2
+      pos: -16.5,-6.5
   - uid: 267
     components:
     - type: Transform
-      pos: -17.5,-7.5
       parent: 2
+      pos: -17.5,-7.5
   - uid: 268
     components:
     - type: Transform
-      pos: -17.5,-8.5
       parent: 2
+      pos: -17.5,-8.5
   - uid: 269
     components:
     - type: Transform
-      pos: -17.5,-9.5
       parent: 2
+      pos: -17.5,-9.5
   - uid: 270
     components:
     - type: Transform
-      pos: -17.5,-10.5
       parent: 2
+      pos: -17.5,-10.5
   - uid: 271
     components:
     - type: Transform
-      pos: -5.5,-10.5
       parent: 2
+      pos: -5.5,-10.5
   - uid: 286
     components:
     - type: Transform
-      pos: -16.5,-0.5
       parent: 2
+      pos: -16.5,-0.5
   - uid: 287
     components:
     - type: Transform
-      pos: -16.5,0.5
       parent: 2
+      pos: -16.5,0.5
   - uid: 288
     components:
     - type: Transform
-      pos: -16.5,1.5
       parent: 2
+      pos: -16.5,1.5
   - uid: 289
     components:
     - type: Transform
-      pos: -16.5,2.5
       parent: 2
+      pos: -16.5,2.5
   - uid: 290
     components:
     - type: Transform
-      pos: -16.5,3.5
       parent: 2
+      pos: -16.5,3.5
   - uid: 291
     components:
     - type: Transform
-      pos: -16.5,4.5
       parent: 2
+      pos: -16.5,4.5
   - uid: 292
     components:
     - type: Transform
-      pos: -16.5,5.5
       parent: 2
+      pos: -16.5,5.5
   - uid: 293
     components:
     - type: Transform
-      pos: -16.5,6.5
       parent: 2
+      pos: -16.5,6.5
   - uid: 294
     components:
     - type: Transform
-      pos: -16.5,7.5
       parent: 2
+      pos: -16.5,7.5
   - uid: 295
     components:
     - type: Transform
-      pos: -16.5,8.5
       parent: 2
+      pos: -16.5,8.5
   - uid: 296
     components:
     - type: Transform
-      pos: -16.5,9.5
       parent: 2
+      pos: -16.5,9.5
   - uid: 297
     components:
     - type: Transform
-      pos: -16.5,10.5
       parent: 2
+      pos: -16.5,10.5
   - uid: 298
     components:
     - type: Transform
-      pos: -15.5,10.5
       parent: 2
+      pos: -15.5,10.5
   - uid: 299
     components:
     - type: Transform
-      pos: -14.5,10.5
       parent: 2
+      pos: -14.5,10.5
   - uid: 300
     components:
     - type: Transform
-      pos: -14.5,11.5
       parent: 2
+      pos: -14.5,11.5
   - uid: 302
     components:
     - type: Transform
-      pos: -12.5,11.5
       parent: 2
+      pos: -12.5,11.5
   - uid: 303
     components:
     - type: Transform
-      pos: -12.5,10.5
       parent: 2
+      pos: -12.5,10.5
   - uid: 304
     components:
     - type: Transform
-      pos: -11.5,10.5
       parent: 2
+      pos: -11.5,10.5
   - uid: 305
     components:
     - type: Transform
-      pos: -10.5,10.5
       parent: 2
+      pos: -10.5,10.5
   - uid: 306
     components:
     - type: Transform
-      pos: -10.5,9.5
       parent: 2
+      pos: -10.5,9.5
   - uid: 307
     components:
     - type: Transform
-      pos: -10.5,8.5
       parent: 2
+      pos: -10.5,8.5
   - uid: 308
     components:
     - type: Transform
-      pos: -9.5,8.5
       parent: 2
+      pos: -9.5,8.5
   - uid: 309
     components:
     - type: Transform
-      pos: -8.5,8.5
       parent: 2
+      pos: -8.5,8.5
   - uid: 310
     components:
     - type: Transform
-      pos: -7.5,8.5
       parent: 2
+      pos: -7.5,8.5
   - uid: 311
     components:
     - type: Transform
-      pos: -6.5,8.5
       parent: 2
+      pos: -6.5,8.5
   - uid: 312
     components:
     - type: Transform
-      pos: -5.5,8.5
       parent: 2
+      pos: -5.5,8.5
   - uid: 313
     components:
     - type: Transform
-      pos: -4.5,8.5
       parent: 2
+      pos: -4.5,8.5
   - uid: 314
     components:
     - type: Transform
-      pos: -3.5,8.5
       parent: 2
+      pos: -3.5,8.5
   - uid: 315
     components:
     - type: Transform
-      pos: -2.5,8.5
       parent: 2
+      pos: -2.5,8.5
   - uid: 316
     components:
     - type: Transform
-      pos: -0.5,8.5
       parent: 2
+      pos: -0.5,8.5
   - uid: 317
     components:
     - type: Transform
-      pos: 0.5,8.5
       parent: 2
+      pos: 0.5,8.5
   - uid: 318
     components:
     - type: Transform
-      pos: 1.5,8.5
       parent: 2
+      pos: 1.5,8.5
   - uid: 319
     components:
     - type: Transform
-      pos: 2.5,8.5
       parent: 2
+      pos: 2.5,8.5
   - uid: 320
     components:
     - type: Transform
-      pos: 3.5,8.5
       parent: 2
+      pos: 3.5,8.5
   - uid: 336
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 5.5,12.5
-      parent: 2
   - uid: 337
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 4.5,11.5
-      parent: 2
   - uid: 361
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 4.5,9.5
-      parent: 2
   - uid: 365
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 8.5,11.5
-      parent: 2
   - uid: 366
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 6.5,12.5
-      parent: 2
   - uid: 368
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 7.5,12.5
-      parent: 2
   - uid: 369
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 8.5,9.5
-      parent: 2
   - uid: 370
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 8.5,10.5
-      parent: 2
   - uid: 372
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 8.5,12.5
-      parent: 2
   - uid: 483
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 4.5,10.5
-      parent: 2
   - uid: 484
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: 4.5,12.5
-      parent: 2
   - uid: 497
     components:
     - type: Transform
-      pos: -0.5,-12.5
       parent: 2
+      pos: -0.5,-12.5
   - uid: 605
     components:
     - type: Transform
+      parent: 2
       rot: 3.141592653589793 rad
       pos: -1.5,8.5
-      parent: 2
   - uid: 679
     components:
     - type: Transform
-      pos: -4.5,-10.5
       parent: 2
+      pos: -4.5,-10.5
   - uid: 680
     components:
     - type: Transform
-      pos: -2.5,-10.5
       parent: 2
+      pos: -2.5,-10.5
   - uid: 681
     components:
     - type: Transform
-      pos: -1.5,-10.5
       parent: 2
+      pos: -1.5,-10.5
   - uid: 682
     components:
     - type: Transform
-      pos: -3.5,-10.5
       parent: 2
+      pos: -3.5,-10.5
   - uid: 686
     components:
     - type: Transform
-      pos: -1.5,-12.5
       parent: 2
+      pos: -1.5,-12.5
   - uid: 688
     components:
     - type: Transform
-      pos: -1.5,-11.5
       parent: 2
+      pos: -1.5,-11.5
   - uid: 691
     components:
     - type: Transform
-      pos: 4.5,-9.5
       parent: 2
+      pos: 4.5,-9.5
   - uid: 692
     components:
     - type: Transform
-      pos: 5.5,-9.5
       parent: 2
+      pos: 5.5,-9.5
   - uid: 693
     components:
     - type: Transform
-      pos: 6.5,-9.5
       parent: 2
+      pos: 6.5,-9.5
   - uid: 694
     components:
     - type: Transform
-      pos: 7.5,-9.5
       parent: 2
+      pos: 7.5,-9.5
   - uid: 695
     components:
     - type: Transform
-      pos: 8.5,-9.5
       parent: 2
+      pos: 8.5,-9.5
   - uid: 696
     components:
     - type: Transform
-      pos: 8.5,-8.5
       parent: 2
+      pos: 8.5,-8.5
   - uid: 697
     components:
     - type: Transform
-      pos: 8.5,-7.5
       parent: 2
+      pos: 8.5,-7.5
   - uid: 698
     components:
     - type: Transform
-      pos: 8.5,-6.5
       parent: 2
+      pos: 8.5,-6.5
   - uid: 699
     components:
     - type: Transform
-      pos: 0.5,-12.5
       parent: 2
+      pos: 0.5,-12.5
   - uid: 700
     components:
     - type: Transform
-      pos: 1.5,-12.5
       parent: 2
+      pos: 1.5,-12.5
   - uid: 701
     components:
     - type: Transform
-      pos: 2.5,-12.5
       parent: 2
+      pos: 2.5,-12.5
   - uid: 702
     components:
     - type: Transform
-      pos: 3.5,-12.5
       parent: 2
+      pos: 3.5,-12.5
   - uid: 703
     components:
     - type: Transform
-      pos: 4.5,-12.5
       parent: 2
+      pos: 4.5,-12.5
   - uid: 704
     components:
     - type: Transform
-      pos: 4.5,-11.5
       parent: 2
+      pos: 4.5,-11.5
   - uid: 705
     components:
     - type: Transform
-      pos: 4.5,-10.5
       parent: 2
+      pos: 4.5,-10.5
   - uid: 757
     components:
     - type: Transform
-      pos: 9.5,12.5
       parent: 2
+      pos: 9.5,12.5
   - uid: 758
     components:
     - type: Transform
-      pos: 10.5,12.5
       parent: 2
+      pos: 10.5,12.5
   - uid: 839
     components:
     - type: Transform
-      pos: 11.5,10.5
       parent: 2
+      pos: 11.5,10.5
   - uid: 840
     components:
     - type: Transform
-      pos: 11.5,9.5
       parent: 2
+      pos: 11.5,9.5
   - uid: 841
     components:
     - type: Transform
-      pos: 11.5,8.5
       parent: 2
+      pos: 11.5,8.5
 - proto: WallSolid
   entities:
   - uid: 6
     components:
     - type: Transform
-      pos: 0.5,2.5
       parent: 2
+      pos: 0.5,2.5
   - uid: 7
     components:
     - type: Transform
-      pos: 0.5,3.5
       parent: 2
+      pos: 0.5,3.5
   - uid: 8
     components:
     - type: Transform
-      pos: 0.5,4.5
       parent: 2
+      pos: 0.5,4.5
   - uid: 9
     components:
     - type: Transform
-      pos: 0.5,5.5
       parent: 2
+      pos: 0.5,5.5
   - uid: 10
     components:
     - type: Transform
-      pos: 1.5,2.5
       parent: 2
+      pos: 1.5,2.5
   - uid: 11
     components:
     - type: Transform
-      pos: 2.5,2.5
       parent: 2
+      pos: 2.5,2.5
   - uid: 12
     components:
     - type: Transform
-      pos: 3.5,2.5
       parent: 2
+      pos: 3.5,2.5
   - uid: 13
     components:
     - type: Transform
-      pos: 4.5,2.5
       parent: 2
+      pos: 4.5,2.5
   - uid: 14
     components:
     - type: Transform
-      pos: 4.5,1.5
       parent: 2
+      pos: 4.5,1.5
   - uid: 15
     components:
     - type: Transform
-      pos: 4.5,-0.5
       parent: 2
+      pos: 4.5,-0.5
   - uid: 16
     components:
     - type: Transform
-      pos: 4.5,-1.5
       parent: 2
+      pos: 4.5,-1.5
   - uid: 18
     components:
     - type: Transform
-      pos: 4.5,0.5
       parent: 2
+      pos: 4.5,0.5
   - uid: 19
     components:
     - type: Transform
-      pos: 4.5,-5.5
       parent: 2
+      pos: 4.5,-5.5
   - uid: 20
     components:
     - type: Transform
-      pos: 3.5,-5.5
       parent: 2
+      pos: 3.5,-5.5
   - uid: 21
     components:
     - type: Transform
-      pos: 2.5,-5.5
       parent: 2
+      pos: 2.5,-5.5
   - uid: 22
     components:
     - type: Transform
-      pos: 1.5,-5.5
       parent: 2
+      pos: 1.5,-5.5
   - uid: 23
     components:
     - type: Transform
-      pos: 0.5,-5.5
       parent: 2
+      pos: 0.5,-5.5
   - uid: 24
     components:
     - type: Transform
-      pos: -0.5,-5.5
       parent: 2
+      pos: -0.5,-5.5
   - uid: 25
     components:
     - type: Transform
-      pos: -1.5,-5.5
       parent: 2
+      pos: -1.5,-5.5
   - uid: 26
     components:
     - type: Transform
-      pos: -2.5,-5.5
       parent: 2
+      pos: -2.5,-5.5
   - uid: 27
     components:
     - type: Transform
-      pos: -3.5,-5.5
       parent: 2
+      pos: -3.5,-5.5
   - uid: 28
     components:
     - type: Transform
-      pos: -4.5,-5.5
       parent: 2
+      pos: -4.5,-5.5
   - uid: 29
     components:
     - type: Transform
-      pos: -5.5,-5.5
       parent: 2
+      pos: -5.5,-5.5
   - uid: 30
     components:
     - type: Transform
-      pos: -6.5,-5.5
       parent: 2
+      pos: -6.5,-5.5
   - uid: 32
     components:
     - type: Transform
-      pos: -6.5,5.5
       parent: 2
+      pos: -6.5,5.5
   - uid: 33
     components:
     - type: Transform
-      pos: -6.5,4.5
       parent: 2
+      pos: -6.5,4.5
   - uid: 34
     components:
     - type: Transform
-      pos: -6.5,3.5
       parent: 2
+      pos: -6.5,3.5
   - uid: 35
     components:
     - type: Transform
-      pos: -6.5,2.5
       parent: 2
+      pos: -6.5,2.5
   - uid: 36
     components:
     - type: Transform
-      pos: -5.5,5.5
       parent: 2
+      pos: -5.5,5.5
   - uid: 37
     components:
     - type: Transform
-      pos: -4.5,5.5
       parent: 2
+      pos: -4.5,5.5
   - uid: 38
     components:
     - type: Transform
-      pos: -3.5,5.5
       parent: 2
+      pos: -3.5,5.5
   - uid: 39
     components:
     - type: Transform
-      pos: -2.5,5.5
       parent: 2
+      pos: -2.5,5.5
   - uid: 41
     components:
     - type: Transform
-      pos: -0.5,5.5
       parent: 2
+      pos: -0.5,5.5
   - uid: 84
     components:
     - type: Transform
-      pos: 5.5,-5.5
       parent: 2
+      pos: 5.5,-5.5
   - uid: 85
     components:
     - type: Transform
-      pos: 7.5,-5.5
       parent: 2
+      pos: 7.5,-5.5
   - uid: 101
     components:
     - type: Transform
-      pos: 10.5,3.5
       parent: 2
+      pos: 10.5,3.5
   - uid: 102
     components:
     - type: Transform
-      pos: 9.5,3.5
       parent: 2
+      pos: 9.5,3.5
   - uid: 103
     components:
     - type: Transform
-      pos: 8.5,3.5
       parent: 2
+      pos: 8.5,3.5
   - uid: 104
     components:
     - type: Transform
-      pos: 8.5,0.5
       parent: 2
+      pos: 8.5,0.5
   - uid: 105
     components:
     - type: Transform
-      pos: 9.5,0.5
       parent: 2
+      pos: 9.5,0.5
   - uid: 106
     components:
     - type: Transform
-      pos: 10.5,0.5
       parent: 2
+      pos: 10.5,0.5
   - uid: 107
     components:
     - type: Transform
-      pos: 11.5,0.5
       parent: 2
+      pos: 11.5,0.5
   - uid: 108
     components:
     - type: Transform
-      pos: 11.5,-2.5
       parent: 2
+      pos: 11.5,-2.5
   - uid: 109
     components:
     - type: Transform
-      pos: 10.5,-2.5
       parent: 2
+      pos: 10.5,-2.5
   - uid: 110
     components:
     - type: Transform
-      pos: 9.5,-2.5
       parent: 2
+      pos: 9.5,-2.5
   - uid: 111
     components:
     - type: Transform
-      pos: 8.5,-2.5
       parent: 2
+      pos: 8.5,-2.5
   - uid: 151
     components:
     - type: Transform
-      pos: 4.5,6.5
       parent: 2
+      pos: 4.5,6.5
   - uid: 152
     components:
     - type: Transform
-      pos: 8.5,4.5
       parent: 2
+      pos: 8.5,4.5
   - uid: 154
     components:
     - type: Transform
-      pos: 8.5,6.5
       parent: 2
+      pos: 8.5,6.5
   - uid: 158
     components:
     - type: Transform
-      pos: 4.5,7.5
       parent: 2
+      pos: 4.5,7.5
   - uid: 159
     components:
     - type: Transform
-      pos: 3.5,6.5
       parent: 2
+      pos: 3.5,6.5
   - uid: 160
     components:
     - type: Transform
-      pos: 3.5,5.5
       parent: 2
+      pos: 3.5,5.5
   - uid: 161
     components:
     - type: Transform
-      pos: 3.5,4.5
       parent: 2
+      pos: 3.5,4.5
   - uid: 272
     components:
     - type: Transform
-      pos: -5.5,-6.5
       parent: 2
+      pos: -5.5,-6.5
   - uid: 273
     components:
     - type: Transform
-      pos: -5.5,-9.5
       parent: 2
+      pos: -5.5,-9.5
   - uid: 274
     components:
     - type: Transform
-      pos: -6.5,-6.5
       parent: 2
+      pos: -6.5,-6.5
   - uid: 275
     components:
     - type: Transform
-      pos: -5.5,-7.5
       parent: 2
+      pos: -5.5,-7.5
   - uid: 277
     components:
     - type: Transform
-      pos: -6.5,-4.5
       parent: 2
+      pos: -6.5,-4.5
   - uid: 278
     components:
     - type: Transform
-      pos: -6.5,-3.5
       parent: 2
+      pos: -6.5,-3.5
   - uid: 279
     components:
     - type: Transform
-      pos: -6.5,-2.5
       parent: 2
+      pos: -6.5,-2.5
   - uid: 281
     components:
     - type: Transform
-      pos: -6.5,1.5
       parent: 2
+      pos: -6.5,1.5
   - uid: 321
     components:
     - type: Transform
-      pos: -15.5,5.5
       parent: 2
+      pos: -15.5,5.5
   - uid: 322
     components:
     - type: Transform
-      pos: -14.5,5.5
       parent: 2
+      pos: -14.5,5.5
   - uid: 323
     components:
     - type: Transform
-      pos: -12.5,5.5
       parent: 2
+      pos: -12.5,5.5
   - uid: 324
     components:
     - type: Transform
-      pos: -11.5,5.5
       parent: 2
+      pos: -11.5,5.5
   - uid: 325
     components:
     - type: Transform
-      pos: -10.5,5.5
       parent: 2
+      pos: -10.5,5.5
   - uid: 327
     components:
     - type: Transform
-      pos: -10.5,7.5
       parent: 2
+      pos: -10.5,7.5
   - uid: 328
     components:
     - type: Transform
-      pos: -10.5,4.5
       parent: 2
+      pos: -10.5,4.5
   - uid: 329
     components:
     - type: Transform
-      pos: -10.5,3.5
       parent: 2
+      pos: -10.5,3.5
   - uid: 330
     components:
     - type: Transform
-      pos: -10.5,2.5
       parent: 2
+      pos: -10.5,2.5
   - uid: 334
     components:
     - type: Transform
-      pos: -7.5,2.5
       parent: 2
+      pos: -7.5,2.5
   - uid: 335
     components:
     - type: Transform
-      pos: -9.5,2.5
       parent: 2
+      pos: -9.5,2.5
   - uid: 657
     components:
     - type: Transform
-      pos: 8.5,7.5
       parent: 2
+      pos: 8.5,7.5
   - uid: 683
     components:
     - type: Transform
-      pos: -1.5,-9.5
       parent: 2
+      pos: -1.5,-9.5
   - uid: 684
     components:
     - type: Transform
-      pos: -1.5,-8.5
       parent: 2
+      pos: -1.5,-8.5
   - uid: 685
     components:
     - type: Transform
-      pos: -0.5,-8.5
       parent: 2
+      pos: -0.5,-8.5
   - uid: 689
     components:
     - type: Transform
-      pos: 3.5,-8.5
       parent: 2
+      pos: 3.5,-8.5
   - uid: 690
     components:
     - type: Transform
-      pos: 4.5,-8.5
       parent: 2
+      pos: 4.5,-8.5
   - uid: 706
     components:
     - type: Transform
-      pos: 0.5,-8.5
       parent: 2
+      pos: 0.5,-8.5
   - uid: 707
     components:
     - type: Transform
-      pos: 2.5,-8.5
       parent: 2
+      pos: 2.5,-8.5
 - proto: Window
   entities:
   - uid: 239
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -10.5,1.5
-      parent: 2
   - uid: 240
     components:
     - type: Transform
+      parent: 2
       rot: -1.5707963267948966 rad
       pos: -10.5,-0.5
-      parent: 2
   - uid: 246
     components:
     - type: Transform
-      pos: -8.5,-6.5
       parent: 2
+      pos: -8.5,-6.5
   - uid: 282
     components:
     - type: Transform
-      pos: -6.5,-0.5
       parent: 2
+      pos: -6.5,-0.5
 ...

--- a/Resources/Maps/_ES/toast.yml
+++ b/Resources/Maps/_ES/toast.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 08/12/2026 04:41:54
-  entityCount: 14886
+  time: 08/19/2026 16:42:24
+  entityCount: 14814
 maps:
 - 3
 grids:
@@ -3910,11 +3910,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 20.5,-32.5
-  - uid: 4860
-    components:
-    - type: Transform
-      parent: 2
-      pos: -45.5,-46.5
 - proto: AirlockDetectiveLocked
   entities:
   - uid: 5074
@@ -4273,6 +4268,11 @@ entities:
       parent: 2
       rot: -1.5707963267948966 rad
       pos: 9.5,1.5
+  - uid: 809
+    components:
+    - type: Transform
+      parent: 2
+      pos: -45.5,-46.5
   - uid: 1633
     components:
     - type: Transform
@@ -4371,6 +4371,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -2.5,-26.5
+  - uid: 803
+    components:
+    - type: Transform
+      parent: 2
+      pos: -49.5,-45.5
   - uid: 897
     components:
     - type: Transform
@@ -4523,11 +4528,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 20.5,-38.5
-  - uid: 3185
-    components:
-    - type: Transform
-      parent: 2
-      pos: -49.5,-45.5
 - proto: AirlockMaintDetectiveLocked
   entities:
   - uid: 5337
@@ -5056,6 +5056,26 @@ entities:
       pos: -11.5,-9.5
     - type: Fixtures
       fixtures: {}
+  - uid: 816
+    components:
+    - type: MetaData
+      name: Bathroom APC
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -37.5,10.5
+    - type: Fixtures
+      fixtures: {}
+  - uid: 863
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-8.5
+    - type: ESTraitorBuggable
+      department: Security
+    - type: Fixtures
+      fixtures: {}
   - uid: 874
     components:
     - type: MetaData
@@ -5186,6 +5206,16 @@ entities:
       department: Medical
     - type: Fixtures
       fixtures: {}
+  - uid: 1848
+    components:
+    - type: MetaData
+      name: Security APC
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-23.5
+    - type: Fixtures
+      fixtures: {}
   - uid: 2052
     components:
     - type: MetaData
@@ -5194,6 +5224,18 @@ entities:
       parent: 2
       rot: 3.141592653589793 rad
       pos: -7.5,-37.5
+    - type: Fixtures
+      fixtures: {}
+  - uid: 2084
+    components:
+    - type: MetaData
+      name: Engineering Front Desk APC
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-15.5
+    - type: ESTraitorBuggable
+      department: Engineering
     - type: Fixtures
       fixtures: {}
   - uid: 2161
@@ -5265,16 +5307,6 @@ entities:
       pos: 11.5,-34.5
     - type: Fixtures
       fixtures: {}
-  - uid: 3144
-    components:
-    - type: MetaData
-      name: Bathrooms APC
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -31.5,8.5
-    - type: Fixtures
-      fixtures: {}
   - uid: 3150
     components:
     - type: MetaData
@@ -5282,6 +5314,15 @@ entities:
     - type: Transform
       parent: 2
       pos: 12.5,-18.5
+    - type: Fixtures
+      fixtures: {}
+  - uid: 3243
+    components:
+    - type: MetaData
+      name: South Thruster APC
+    - type: Transform
+      parent: 2
+      pos: -23.5,-58.5
     - type: Fixtures
       fixtures: {}
   - uid: 3276
@@ -5303,18 +5344,6 @@ entities:
       pos: 17.5,-10.5
     - type: Fixtures
       fixtures: {}
-  - uid: 3296
-    components:
-    - type: MetaData
-      name: Security APC
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: -30.5,-23.5
-    - type: ESTraitorBuggable
-      department: Security
-    - type: Fixtures
-      fixtures: {}
   - uid: 3298
     components:
     - type: MetaData
@@ -5323,18 +5352,6 @@ entities:
       parent: 2
       rot: -1.5707963267948966 rad
       pos: -26.5,-11.5
-    - type: ESTraitorBuggable
-      department: Security
-    - type: Fixtures
-      fixtures: {}
-  - uid: 3299
-    components:
-    - type: MetaData
-      name: Brig APC
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -21.5,-8.5
     - type: ESTraitorBuggable
       department: Security
     - type: Fixtures
@@ -5365,18 +5382,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -38.5,-22.5
-    - type: ESTraitorBuggable
-      department: Engineering
-    - type: Fixtures
-      fixtures: {}
-  - uid: 3859
-    components:
-    - type: MetaData
-      name: Engineering Front Desk APC
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -38.5,-15.5
     - type: ESTraitorBuggable
       department: Engineering
     - type: Fixtures
@@ -5699,15 +5704,6 @@ entities:
       parent: 2
       rot: -1.5707963267948966 rad
       pos: 8.5,-42.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 10770
-    components:
-    - type: MetaData
-      name: South Thruster APC
-    - type: Transform
-      parent: 2
-      pos: -20.5,-58.5
     - type: Fixtures
       fixtures: {}
   - uid: 10841
@@ -6735,11 +6731,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -4.5,-22.5
-  - uid: 307
-    components:
-    - type: Transform
-      parent: 2
-      pos: -15.5,-22.5
   - uid: 308
     components:
     - type: Transform
@@ -6760,11 +6751,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -5.5,-21.5
-  - uid: 317
-    components:
-    - type: Transform
-      parent: 2
-      pos: -5.5,-20.5
   - uid: 320
     components:
     - type: Transform
@@ -6845,11 +6831,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 10.5,-14.5
-  - uid: 548
-    components:
-    - type: Transform
-      parent: 2
-      pos: 17.5,-10.5
   - uid: 554
     components:
     - type: Transform
@@ -6895,16 +6876,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 10.5,-12.5
-  - uid: 646
-    components:
-    - type: Transform
-      parent: 2
-      pos: 8.5,-4.5
-  - uid: 659
-    components:
-    - type: Transform
-      parent: 2
-      pos: 8.5,-9.5
   - uid: 660
     components:
     - type: Transform
@@ -6945,11 +6916,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 5.5,-4.5
-  - uid: 668
-    components:
-    - type: Transform
-      parent: 2
-      pos: 12.5,8.5
   - uid: 669
     components:
     - type: Transform
@@ -6969,7 +6935,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 6.5,-14.5
+      pos: 9.5,-9.5
   - uid: 673
     components:
     - type: Transform
@@ -7004,7 +6970,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 12.5,-18.5
+      pos: 9.5,-8.5
   - uid: 689
     components:
     - type: Transform
@@ -7014,7 +6980,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 6.5,-24.5
+      pos: 8.5,-8.5
   - uid: 697
     components:
     - type: Transform
@@ -7135,11 +7101,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -5.5,-19.5
-  - uid: 816
-    components:
-    - type: Transform
-      parent: 2
-      pos: -11.5,-9.5
   - uid: 817
     components:
     - type: Transform
@@ -7230,11 +7191,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -4.5,-7.5
-  - uid: 835
-    components:
-    - type: Transform
-      parent: 2
-      pos: -11.5,-11.5
   - uid: 836
     components:
     - type: Transform
@@ -7340,11 +7296,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -17.5,-11.5
-  - uid: 887
-    components:
-    - type: Transform
-      parent: 2
-      pos: -16.5,-11.5
   - uid: 888
     components:
     - type: Transform
@@ -7360,16 +7311,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -13.5,-11.5
-  - uid: 891
-    components:
-    - type: Transform
-      parent: 2
-      pos: -14.5,-12.5
-  - uid: 892
-    components:
-    - type: Transform
-      parent: 2
-      pos: -18.5,-8.5
   - uid: 893
     components:
     - type: Transform
@@ -7400,11 +7341,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -24.5,4.5
-  - uid: 934
-    components:
-    - type: Transform
-      parent: 2
-      pos: -24.5,7.5
   - uid: 937
     components:
     - type: Transform
@@ -7440,21 +7376,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -16.5,-20.5
-  - uid: 959
-    components:
-    - type: Transform
-      parent: 2
-      pos: -13.5,-20.5
   - uid: 960
     components:
     - type: Transform
       parent: 2
       pos: -19.5,-13.5
-  - uid: 961
-    components:
-    - type: Transform
-      parent: 2
-      pos: 18.5,-22.5
   - uid: 962
     components:
     - type: Transform
@@ -7485,11 +7411,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -18.5,-14.5
-  - uid: 990
-    components:
-    - type: Transform
-      parent: 2
-      pos: 19.5,-7.5
   - uid: 1007
     components:
     - type: Transform
@@ -7505,6 +7426,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 14.5,-2.5
+  - uid: 1053
+    components:
+    - type: Transform
+      parent: 2
+      pos: -16.5,-12.5
   - uid: 1200
     components:
     - type: Transform
@@ -7515,11 +7441,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 25.5,1.5
-  - uid: 1403
+  - uid: 1398
     components:
     - type: Transform
       parent: 2
-      pos: 21.5,-0.5
+      pos: 18.5,-25.5
   - uid: 1406
     components:
     - type: Transform
@@ -7575,6 +7501,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 19.5,-6.5
+  - uid: 1417
+    components:
+    - type: Transform
+      parent: 2
+      pos: -8.5,-36.5
   - uid: 1419
     components:
     - type: Transform
@@ -7685,11 +7616,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 10.5,6.5
-  - uid: 1448
-    components:
-    - type: Transform
-      parent: 2
-      pos: 21.5,7.5
   - uid: 1449
     components:
     - type: Transform
@@ -7850,11 +7776,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -31.5,11.5
-  - uid: 1542
-    components:
-    - type: Transform
-      parent: 2
-      pos: -31.5,8.5
   - uid: 1595
     components:
     - type: Transform
@@ -7910,16 +7831,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -17.5,3.5
-  - uid: 1708
+  - uid: 1715
     components:
     - type: Transform
       parent: 2
-      pos: -17.5,7.5
-  - uid: 1728
+      pos: 29.5,-21.5
+  - uid: 1716
     components:
     - type: Transform
       parent: 2
-      pos: -2.5,-40.5
+      pos: 29.5,-19.5
   - uid: 1729
     components:
     - type: Transform
@@ -8020,11 +7941,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -17.5,5.5
-  - uid: 1755
-    components:
-    - type: Transform
-      parent: 2
-      pos: 3.5,-38.5
   - uid: 1756
     components:
     - type: Transform
@@ -8075,16 +7991,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 19.5,-5.5
-  - uid: 1848
-    components:
-    - type: Transform
-      parent: 2
-      pos: 17.5,-26.5
-  - uid: 1862
-    components:
-    - type: Transform
-      parent: 2
-      pos: 26.5,9.5
   - uid: 1863
     components:
     - type: Transform
@@ -8145,31 +8051,16 @@ entities:
     - type: Transform
       parent: 2
       pos: 18.5,-26.5
-  - uid: 2080
-    components:
-    - type: Transform
-      parent: 2
-      pos: -7.5,-37.5
   - uid: 2081
     components:
     - type: Transform
       parent: 2
       pos: -7.5,-36.5
-  - uid: 2082
-    components:
-    - type: Transform
-      parent: 2
-      pos: -7.5,-35.5
   - uid: 2083
     components:
     - type: Transform
       parent: 2
       pos: -8.5,-35.5
-  - uid: 2084
-    components:
-    - type: Transform
-      parent: 2
-      pos: 5.5,1.5
   - uid: 2086
     components:
     - type: Transform
@@ -8180,11 +8071,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -24.5,-26.5
-  - uid: 2160
-    components:
-    - type: Transform
-      parent: 2
-      pos: 21.5,-38.5
   - uid: 2164
     components:
     - type: Transform
@@ -8200,11 +8086,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 20.5,-36.5
-  - uid: 2172
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-33.5
   - uid: 2173
     components:
     - type: Transform
@@ -8305,11 +8186,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 22.5,16.5
-  - uid: 2229
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-29.5
   - uid: 2230
     components:
     - type: Transform
@@ -8325,6 +8201,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 22.5,-27.5
+  - uid: 2248
+    components:
+    - type: Transform
+      parent: 2
+      pos: -18.5,-39.5
   - uid: 2287
     components:
     - type: Transform
@@ -8335,11 +8216,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 22.5,15.5
-  - uid: 2467
-    components:
-    - type: Transform
-      parent: 2
-      pos: 30.5,-28.5
   - uid: 2468
     components:
     - type: Transform
@@ -8390,11 +8266,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 27.5,-26.5
-  - uid: 2478
-    components:
-    - type: Transform
-      parent: 2
-      pos: 30.5,-20.5
   - uid: 2479
     components:
     - type: Transform
@@ -8465,11 +8336,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 32.5,-25.5
-  - uid: 2557
-    components:
-    - type: Transform
-      parent: 2
-      pos: -42.5,-41.5
   - uid: 2558
     components:
     - type: Transform
@@ -8490,11 +8356,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 10.5,-20.5
-  - uid: 2580
-    components:
-    - type: Transform
-      parent: 2
-      pos: -31.5,9.5
   - uid: 2638
     components:
     - type: Transform
@@ -8570,21 +8431,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 8.5,-12.5
-  - uid: 3301
-    components:
-    - type: Transform
-      parent: 2
-      pos: -30.5,-23.5
   - uid: 3302
     components:
     - type: Transform
       parent: 2
       pos: -29.5,-23.5
-  - uid: 3310
-    components:
-    - type: Transform
-      parent: 2
-      pos: -26.5,-11.5
   - uid: 3311
     components:
     - type: Transform
@@ -8615,11 +8466,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -28.5,-13.5
-  - uid: 3317
-    components:
-    - type: Transform
-      parent: 2
-      pos: -21.5,-8.5
   - uid: 3318
     components:
     - type: Transform
@@ -8750,11 +8596,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -24.5,-13.5
-  - uid: 3549
-    components:
-    - type: Transform
-      parent: 2
-      pos: 27.5,-1.5
   - uid: 3550
     components:
     - type: Transform
@@ -8775,6 +8616,16 @@ entities:
     - type: Transform
       parent: 2
       pos: 26.5,1.5
+  - uid: 3588
+    components:
+    - type: Transform
+      parent: 2
+      pos: 26.5,-31.5
+  - uid: 3589
+    components:
+    - type: Transform
+      parent: 2
+      pos: 25.5,-31.5
   - uid: 3662
     components:
     - type: Transform
@@ -8890,6 +8741,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -24.5,3.5
+  - uid: 3862
+    components:
+    - type: Transform
+      parent: 2
+      pos: 29.5,-20.5
   - uid: 3954
     components:
     - type: Transform
@@ -8899,7 +8755,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -48.5,-8.5
+      pos: 7.5,-8.5
   - uid: 4095
     components:
     - type: Transform
@@ -8939,7 +8795,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -44.5,-14.5
+      pos: -17.5,-12.5
   - uid: 4103
     components:
     - type: Transform
@@ -8984,7 +8840,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -38.5,-15.5
+      pos: -18.5,-7.5
   - uid: 4112
     components:
     - type: Transform
@@ -9039,7 +8895,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -46.5,-16.5
+      pos: -15.5,-12.5
   - uid: 4123
     components:
     - type: Transform
@@ -9175,11 +9031,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -40.5,-18.5
-  - uid: 4151
-    components:
-    - type: Transform
-      parent: 2
-      pos: -38.5,-22.5
   - uid: 4152
     components:
     - type: Transform
@@ -9280,16 +9131,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -48.5,-11.5
-  - uid: 4350
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-8.5
-  - uid: 4360
-    components:
-    - type: Transform
-      parent: 2
-      pos: -46.5,-8.5
   - uid: 4361
     components:
     - type: Transform
@@ -9415,11 +9256,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 13.5,-35.5
-  - uid: 4721
-    components:
-    - type: Transform
-      parent: 2
-      pos: -53.5,-8.5
   - uid: 4722
     components:
     - type: Transform
@@ -9745,11 +9581,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -57.5,-24.5
-  - uid: 4847
-    components:
-    - type: Transform
-      parent: 2
-      pos: -48.5,-3.5
   - uid: 4848
     components:
     - type: Transform
@@ -9855,16 +9686,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -26.5,-35.5
-  - uid: 5145
-    components:
-    - type: Transform
-      parent: 2
-      pos: -25.5,-35.5
-  - uid: 5146
-    components:
-    - type: Transform
-      parent: 2
-      pos: -26.5,-36.5
   - uid: 5147
     components:
     - type: Transform
@@ -9895,16 +9716,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -24.5,6.5
-  - uid: 5183
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-20.5
-  - uid: 5293
-    components:
-    - type: Transform
-      parent: 2
-      pos: -19.5,-40.5
   - uid: 5294
     components:
     - type: Transform
@@ -9915,11 +9726,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -19.5,-38.5
-  - uid: 5296
-    components:
-    - type: Transform
-      parent: 2
-      pos: -19.5,-36.5
   - uid: 5297
     components:
     - type: Transform
@@ -9985,11 +9791,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -9.5,-19.5
-  - uid: 5408
-    components:
-    - type: Transform
-      parent: 2
-      pos: -28.5,-42.5
   - uid: 5409
     components:
     - type: Transform
@@ -10010,11 +9811,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -26.5,-40.5
-  - uid: 5454
+  - uid: 5416
     components:
     - type: Transform
       parent: 2
-      pos: -28.5,11.5
+      pos: -18.5,-40.5
   - uid: 5455
     components:
     - type: Transform
@@ -10070,16 +9871,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -9.5,-17.5
-  - uid: 5898
-    components:
-    - type: Transform
-      parent: 2
-      pos: 16.5,-26.5
-  - uid: 5904
-    components:
-    - type: Transform
-      parent: 2
-      pos: -8.5,-28.5
   - uid: 5918
     components:
     - type: Transform
@@ -10205,11 +9996,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 13.5,-27.5
-  - uid: 6694
-    components:
-    - type: Transform
-      parent: 2
-      pos: -73.5,-0.5
   - uid: 6716
     components:
     - type: Transform
@@ -10225,11 +10011,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -19.5,-21.5
-  - uid: 6907
-    components:
-    - type: Transform
-      parent: 2
-      pos: -8.5,6.5
   - uid: 6908
     components:
     - type: Transform
@@ -10250,6 +10031,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -8.5,9.5
+  - uid: 7200
+    components:
+    - type: Transform
+      parent: 2
+      pos: 17.5,-26.5
   - uid: 7211
     components:
     - type: Transform
@@ -10270,11 +10056,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -35.5,10.5
-  - uid: 7215
-    components:
-    - type: Transform
-      parent: 2
-      pos: -46.5,2.5
   - uid: 7216
     components:
     - type: Transform
@@ -10415,11 +10196,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -45.5,14.5
-  - uid: 7244
-    components:
-    - type: Transform
-      parent: 2
-      pos: -51.5,8.5
   - uid: 7245
     components:
     - type: Transform
@@ -10485,21 +10261,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -42.5,6.5
-  - uid: 7258
-    components:
-    - type: Transform
-      parent: 2
-      pos: -55.5,-38.5
   - uid: 7259
     components:
     - type: Transform
       parent: 2
       pos: -57.5,-38.5
-  - uid: 7260
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-36.5
   - uid: 7261
     components:
     - type: Transform
@@ -10759,7 +10525,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -48.5,-23.5
+      pos: -23.5,-59.5
   - uid: 7670
     components:
     - type: Transform
@@ -11030,11 +10796,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -39.5,-30.5
-  - uid: 8050
-    components:
-    - type: Transform
-      parent: 2
-      pos: -66.5,7.5
   - uid: 8051
     components:
     - type: Transform
@@ -12045,11 +11806,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 26.5,-3.5
-  - uid: 8486
-    components:
-    - type: Transform
-      parent: 2
-      pos: 33.5,-12.5
   - uid: 8487
     components:
     - type: Transform
@@ -12810,11 +12566,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -2.5,14.5
-  - uid: 8815
-    components:
-    - type: Transform
-      parent: 2
-      pos: -2.5,13.5
   - uid: 8878
     components:
     - type: Transform
@@ -13710,11 +13461,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -35.5,-20.5
-  - uid: 9661
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-21.5
   - uid: 9665
     components:
     - type: Transform
@@ -13725,11 +13471,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -18.5,-3.5
-  - uid: 9667
-    components:
-    - type: Transform
-      parent: 2
-      pos: -19.5,-8.5
   - uid: 9668
     components:
     - type: Transform
@@ -13945,11 +13686,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -8.5,-0.5
-  - uid: 9717
-    components:
-    - type: Transform
-      parent: 2
-      pos: 3.5,6.5
   - uid: 9718
     components:
     - type: Transform
@@ -14170,11 +13906,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -5.5,7.5
-  - uid: 9787
-    components:
-    - type: Transform
-      parent: 2
-      pos: 4.5,-32.5
   - uid: 9788
     components:
     - type: Transform
@@ -14315,11 +14046,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 13.5,-30.5
-  - uid: 9816
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-32.5
   - uid: 9817
     components:
     - type: Transform
@@ -14520,11 +14246,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -19.5,3.5
-  - uid: 10287
-    components:
-    - type: Transform
-      parent: 2
-      pos: 8.5,-42.5
   - uid: 10317
     components:
     - type: Transform
@@ -14550,21 +14271,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 6.5,-45.5
-  - uid: 10334
-    components:
-    - type: Transform
-      parent: 2
-      pos: -49.5,-46.5
   - uid: 10335
     components:
     - type: Transform
       parent: 2
       pos: -48.5,-46.5
-  - uid: 10624
-    components:
-    - type: Transform
-      parent: 2
-      pos: -21.5,-16.5
   - uid: 11003
     components:
     - type: Transform
@@ -14600,16 +14311,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -9.5,0.5
-  - uid: 11399
-    components:
-    - type: Transform
-      parent: 2
-      pos: -9.5,1.5
-  - uid: 11413
-    components:
-    - type: Transform
-      parent: 2
-      pos: 7.5,-36.5
   - uid: 11414
     components:
     - type: Transform
@@ -16360,11 +16061,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -13.5,-35.5
-  - uid: 14513
-    components:
-    - type: Transform
-      parent: 2
-      pos: -74.5,-10.5
   - uid: 14514
     components:
     - type: Transform
@@ -16390,16 +16086,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -76.5,-12.5
-  - uid: 14715
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-58.5
-  - uid: 14716
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-59.5
   - uid: 14717
     components:
     - type: Transform
@@ -16420,16 +16106,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -23.5,-60.5
-  - uid: 14721
-    components:
-    - type: Transform
-      parent: 2
-      pos: -19.5,-60.5
-  - uid: 14722
-    components:
-    - type: Transform
-      parent: 2
-      pos: -51.5,29.5
   - uid: 14723
     components:
     - type: Transform
@@ -21448,6 +21124,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -16.5,-20.5
+  - uid: 307
+    components:
+    - type: Transform
+      parent: 2
+      pos: -15.5,-11.5
   - uid: 312
     components:
     - type: Transform
@@ -21458,11 +21139,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -16.5,-23.5
-  - uid: 319
+  - uid: 317
     components:
     - type: Transform
       parent: 2
-      pos: -8.5,-19.5
+      pos: -15.5,-12.5
   - uid: 328
     components:
     - type: Transform
@@ -21483,11 +21164,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -27.5,-24.5
-  - uid: 388
-    components:
-    - type: Transform
-      parent: 2
-      pos: 8.5,-4.5
   - uid: 389
     components:
     - type: Transform
@@ -21508,16 +21184,16 @@ entities:
     - type: Transform
       parent: 2
       pos: 10.5,-11.5
-  - uid: 505
-    components:
-    - type: Transform
-      parent: 2
-      pos: 17.5,-10.5
   - uid: 517
     components:
     - type: Transform
       parent: 2
       pos: 13.5,-14.5
+  - uid: 548
+    components:
+    - type: Transform
+      parent: 2
+      pos: -5.5,-21.5
   - uid: 561
     components:
     - type: Transform
@@ -21582,12 +21258,17 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 12.5,-18.5
+      pos: -5.5,-22.5
   - uid: 645
     components:
     - type: Transform
       parent: 2
       pos: -14.5,-25.5
+  - uid: 646
+    components:
+    - type: Transform
+      parent: 2
+      pos: -5.5,-23.5
   - uid: 647
     components:
     - type: Transform
@@ -21598,6 +21279,16 @@ entities:
     - type: Transform
       parent: 2
       pos: 12.5,-20.5
+  - uid: 659
+    components:
+    - type: Transform
+      parent: 2
+      pos: -5.5,-24.5
+  - uid: 668
+    components:
+    - type: Transform
+      parent: 2
+      pos: -5.5,-25.5
   - uid: 727
     components:
     - type: Transform
@@ -21627,22 +21318,12 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,-20.5
-  - uid: 803
+      pos: 17.5,-12.5
+  - uid: 835
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,-19.5
-  - uid: 809
-    components:
-    - type: Transform
-      parent: 2
-      pos: -7.5,-19.5
-  - uid: 863
-    components:
-    - type: Transform
-      parent: 2
-      pos: -6.5,-19.5
+      pos: 22.5,-27.5
   - uid: 876
     components:
     - type: Transform
@@ -21667,12 +21348,22 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -15.5,-22.5
+      pos: -18.5,-41.5
   - uid: 885
     components:
     - type: Transform
       parent: 2
       pos: -16.5,-17.5
+  - uid: 887
+    components:
+    - type: Transform
+      parent: 2
+      pos: -23.5,-59.5
+  - uid: 892
+    components:
+    - type: Transform
+      parent: 2
+      pos: -7.5,-26.5
   - uid: 901
     components:
     - type: Transform
@@ -21718,6 +21409,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -62.5,5.5
+  - uid: 934
+    components:
+    - type: Transform
+      parent: 2
+      pos: -7.5,-36.5
   - uid: 946
     components:
     - type: Transform
@@ -21743,11 +21439,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 18.5,-21.5
-  - uid: 951
-    components:
-    - type: Transform
-      parent: 2
-      pos: 18.5,-22.5
   - uid: 952
     components:
     - type: Transform
@@ -21758,16 +21449,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 17.5,-23.5
-  - uid: 989
-    components:
-    - type: Transform
-      parent: 2
-      pos: -17.5,7.5
   - uid: 1004
     components:
     - type: Transform
       parent: 2
-      pos: -24.5,7.5
+      pos: 3.5,-30.5
   - uid: 1013
     components:
     - type: Transform
@@ -21837,22 +21523,47 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 3.5,6.5
+      pos: -16.5,-12.5
+  - uid: 1122
+    components:
+    - type: Transform
+      parent: 2
+      pos: 14.5,-14.5
   - uid: 1150
     components:
     - type: Transform
       parent: 2
       pos: 14.5,-4.5
+  - uid: 1156
+    components:
+    - type: Transform
+      parent: 2
+      pos: -34.5,10.5
   - uid: 1185
     components:
     - type: Transform
       parent: 2
       pos: 19.5,-4.5
+  - uid: 1192
+    components:
+    - type: Transform
+      parent: 2
+      pos: -13.5,7.5
   - uid: 1269
     components:
     - type: Transform
       parent: 2
       pos: 9.5,-12.5
+  - uid: 1317
+    components:
+    - type: Transform
+      parent: 2
+      pos: 19.5,-27.5
+  - uid: 1318
+    components:
+    - type: Transform
+      parent: 2
+      pos: 17.5,-26.5
   - uid: 1332
     components:
     - type: Transform
@@ -21863,21 +21574,21 @@ entities:
     - type: Transform
       parent: 2
       pos: -27.5,-27.5
-  - uid: 1417
-    components:
-    - type: Transform
-      parent: 2
-      pos: 19.5,-7.5
   - uid: 1428
     components:
     - type: Transform
       parent: 2
       pos: 14.5,-3.5
-  - uid: 1538
+  - uid: 1448
     components:
     - type: Transform
       parent: 2
-      pos: -31.5,8.5
+      pos: -5.5,-26.5
+  - uid: 1542
+    components:
+    - type: Transform
+      parent: 2
+      pos: 18.5,-29.5
   - uid: 1646
     components:
     - type: Transform
@@ -21903,6 +21614,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -27.5,-23.5
+  - uid: 1728
+    components:
+    - type: Transform
+      parent: 2
+      pos: -27.5,-11.5
+  - uid: 1755
+    components:
+    - type: Transform
+      parent: 2
+      pos: -32.5,10.5
   - uid: 1793
     components:
     - type: Transform
@@ -21933,16 +21654,36 @@ entities:
     - type: Transform
       parent: 2
       pos: -8.5,-34.5
-  - uid: 2079
+  - uid: 2082
     components:
     - type: Transform
       parent: 2
-      pos: -7.5,-37.5
+      pos: -54.5,-8.5
+  - uid: 2160
+    components:
+    - type: Transform
+      parent: 2
+      pos: -19.5,-60.5
+  - uid: 2172
+    components:
+    - type: Transform
+      parent: 2
+      pos: -23.5,-60.5
+  - uid: 2193
+    components:
+    - type: Transform
+      parent: 2
+      pos: -26.5,-36.5
   - uid: 2196
     components:
     - type: Transform
       parent: 2
       pos: -11.5,-50.5
+  - uid: 2229
+    components:
+    - type: Transform
+      parent: 2
+      pos: -25.5,-36.5
   - uid: 2233
     components:
     - type: Transform
@@ -22013,26 +21754,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 33.5,-31.5
-  - uid: 2247
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-30.5
-  - uid: 2248
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-29.5
-  - uid: 2249
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-32.5
   - uid: 2250
     components:
     - type: Transform
       parent: 2
-      pos: 23.5,-33.5
+      pos: -26.5,-35.5
   - uid: 2251
     components:
     - type: Transform
@@ -22153,11 +21879,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 21.5,-37.5
-  - uid: 2275
-    components:
-    - type: Transform
-      parent: 2
-      pos: 21.5,-38.5
   - uid: 2276
     components:
     - type: Transform
@@ -22203,21 +21924,26 @@ entities:
     - type: Transform
       parent: 2
       pos: 18.5,-33.5
-  - uid: 2493
+  - uid: 2286
     components:
     - type: Transform
       parent: 2
-      pos: 30.5,-30.5
+      pos: 18.5,-26.5
+  - uid: 2455
+    components:
+    - type: Transform
+      parent: 2
+      pos: -6.5,-26.5
+  - uid: 2467
+    components:
+    - type: Transform
+      parent: 2
+      pos: -14.5,6.5
   - uid: 2494
     components:
     - type: Transform
       parent: 2
-      pos: 30.5,-29.5
-  - uid: 2495
-    components:
-    - type: Transform
-      parent: 2
-      pos: 30.5,-28.5
+      pos: 14.5,-13.5
   - uid: 2496
     components:
     - type: Transform
@@ -22292,7 +22018,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 30.5,-20.5
+      pos: -35.5,-20.5
   - uid: 2511
     components:
     - type: Transform
@@ -22408,11 +22134,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -3.5,-50.5
+  - uid: 2557
+    components:
+    - type: Transform
+      parent: 2
+      pos: 17.5,-11.5
   - uid: 2560
     components:
     - type: Transform
       parent: 2
-      pos: -42.5,-41.5
+      pos: -36.5,10.5
   - uid: 2563
     components:
     - type: Transform
@@ -22423,6 +22154,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 12.5,-19.5
+  - uid: 2580
+    components:
+    - type: Transform
+      parent: 2
+      pos: -36.5,-22.5
   - uid: 2594
     components:
     - type: Transform
@@ -22597,7 +22333,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 21.5,-39.5
+      pos: -14.5,-16.5
   - uid: 2675
     components:
     - type: Transform
@@ -22707,7 +22443,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -2.5,-40.5
+      pos: -16.5,6.5
   - uid: 2697
     components:
     - type: Transform
@@ -22752,7 +22488,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 3.5,-38.5
+      pos: 3.5,-31.5
   - uid: 2717
     components:
     - type: Transform
@@ -22832,7 +22568,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 6.5,-24.5
+      pos: 18.5,-30.5
   - uid: 2735
     components:
     - type: Transform
@@ -22957,7 +22693,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 8.5,-9.5
+      pos: 18.5,-27.5
   - uid: 2760
     components:
     - type: Transform
@@ -23148,16 +22884,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -13.5,-19.5
+  - uid: 3185
+    components:
+    - type: Transform
+      parent: 2
+      pos: -9.5,0.5
   - uid: 3222
     components:
     - type: Transform
       parent: 2
-      pos: -17.5,-11.5
-  - uid: 3227
-    components:
-    - type: Transform
-      parent: 2
-      pos: -18.5,-8.5
+      pos: 30.5,-19.5
   - uid: 3233
     components:
     - type: Transform
@@ -23208,41 +22944,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -10.5,-11.5
-  - uid: 3243
-    components:
-    - type: Transform
-      parent: 2
-      pos: -11.5,-11.5
   - uid: 3244
     components:
     - type: Transform
       parent: 2
-      pos: -12.5,-11.5
-  - uid: 3245
-    components:
-    - type: Transform
-      parent: 2
-      pos: -14.5,-11.5
-  - uid: 3246
-    components:
-    - type: Transform
-      parent: 2
-      pos: -15.5,-11.5
+      pos: -18.5,-40.5
   - uid: 3247
     components:
     - type: Transform
       parent: 2
-      pos: -16.5,-11.5
-  - uid: 3248
-    components:
-    - type: Transform
-      parent: 2
-      pos: -13.5,-11.5
-  - uid: 3249
-    components:
-    - type: Transform
-      parent: 2
-      pos: -11.5,-9.5
+      pos: -11.5,-27.5
   - uid: 3250
     components:
     - type: Transform
@@ -23288,11 +22999,31 @@ entities:
     - type: Transform
       parent: 2
       pos: -36.5,-25.5
+  - uid: 3299
+    components:
+    - type: Transform
+      parent: 2
+      pos: -9.5,-26.5
+  - uid: 3301
+    components:
+    - type: Transform
+      parent: 2
+      pos: -10.5,-26.5
   - uid: 3308
     components:
     - type: Transform
       parent: 2
       pos: 2.5,-49.5
+  - uid: 3310
+    components:
+    - type: Transform
+      parent: 2
+      pos: -12.5,-27.5
+  - uid: 3317
+    components:
+    - type: Transform
+      parent: 2
+      pos: -10.5,-27.5
   - uid: 3345
     components:
     - type: Transform
@@ -23538,11 +23269,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 27.5,-0.5
-  - uid: 3487
-    components:
-    - type: Transform
-      parent: 2
-      pos: 27.5,-1.5
   - uid: 3488
     components:
     - type: Transform
@@ -23563,26 +23289,16 @@ entities:
     - type: Transform
       parent: 2
       pos: 23.5,1.5
-  - uid: 3492
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,0.5
   - uid: 3493
     components:
     - type: Transform
       parent: 2
-      pos: 23.5,-0.5
-  - uid: 3494
-    components:
-    - type: Transform
-      parent: 2
-      pos: 22.5,-0.5
+      pos: -13.5,6.5
   - uid: 3495
     components:
     - type: Transform
       parent: 2
-      pos: 21.5,-0.5
+      pos: -17.5,6.5
   - uid: 3496
     components:
     - type: Transform
@@ -23633,11 +23349,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 26.5,8.5
-  - uid: 3506
-    components:
-    - type: Transform
-      parent: 2
-      pos: 26.5,9.5
   - uid: 3507
     components:
     - type: Transform
@@ -23662,7 +23373,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 21.5,7.5
+      pos: -33.5,10.5
   - uid: 3512
     components:
     - type: Transform
@@ -23718,11 +23429,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 11.5,8.5
-  - uid: 3523
-    components:
-    - type: Transform
-      parent: 2
-      pos: 12.5,8.5
   - uid: 3524
     components:
     - type: Transform
@@ -23807,17 +23513,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -30.5,-23.5
-  - uid: 3588
-    components:
-    - type: Transform
-      parent: 2
-      pos: -25.5,-11.5
-  - uid: 3589
-    components:
-    - type: Transform
-      parent: 2
-      pos: -26.5,-11.5
+      pos: 18.5,-28.5
   - uid: 3590
     components:
     - type: Transform
@@ -23828,11 +23524,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -22.5,-8.5
-  - uid: 3592
-    components:
-    - type: Transform
-      parent: 2
-      pos: -21.5,-8.5
   - uid: 3593
     components:
     - type: Transform
@@ -23888,11 +23579,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -13.5,-18.5
-  - uid: 3684
+  - uid: 3711
     components:
     - type: Transform
       parent: 2
-      pos: -13.5,-20.5
+      pos: 30.5,-26.5
+  - uid: 3859
+    components:
+    - type: Transform
+      parent: 2
+      pos: 30.5,-27.5
   - uid: 4002
     components:
     - type: Transform
@@ -23978,11 +23674,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -44.5,-13.5
-  - uid: 4023
-    components:
-    - type: Transform
-      parent: 2
-      pos: -44.5,-14.5
   - uid: 4024
     components:
     - type: Transform
@@ -24072,7 +23763,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -38.5,-22.5
+      pos: 20.5,-37.5
   - uid: 4043
     components:
     - type: Transform
@@ -24108,11 +23799,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -47.5,-16.5
-  - uid: 4050
-    components:
-    - type: Transform
-      parent: 2
-      pos: -46.5,-16.5
   - uid: 4051
     components:
     - type: Transform
@@ -24123,11 +23809,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -39.5,-15.5
-  - uid: 4053
-    components:
-    - type: Transform
-      parent: 2
-      pos: -38.5,-15.5
   - uid: 4092
     components:
     - type: Transform
@@ -24137,7 +23818,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -48.5,-8.5
+      pos: 3.5,-32.5
   - uid: 4319
     components:
     - type: Transform
@@ -24188,11 +23869,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -46.5,-7.5
-  - uid: 4356
-    components:
-    - type: Transform
-      parent: 2
-      pos: -46.5,-8.5
   - uid: 4359
     components:
     - type: Transform
@@ -24203,16 +23879,21 @@ entities:
     - type: Transform
       parent: 2
       pos: -40.5,-7.5
+  - uid: 4391
+    components:
+    - type: Transform
+      parent: 2
+      pos: 23.5,-27.5
+  - uid: 4408
+    components:
+    - type: Transform
+      parent: 2
+      pos: 23.5,-28.5
   - uid: 4719
     components:
     - type: Transform
       parent: 2
-      pos: -52.5,-8.5
-  - uid: 4720
-    components:
-    - type: Transform
-      parent: 2
-      pos: -53.5,-8.5
+      pos: -25.5,-10.5
   - uid: 4819
     components:
     - type: Transform
@@ -24263,11 +23944,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -48.5,-2.5
-  - uid: 4846
+  - uid: 4847
     components:
     - type: Transform
       parent: 2
-      pos: -48.5,-3.5
+      pos: -54.5,-7.5
   - uid: 4867
     components:
     - type: Transform
@@ -24288,6 +23969,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -17.5,-12.5
+  - uid: 4985
+    components:
+    - type: Transform
+      parent: 2
+      pos: -53.5,-7.5
   - uid: 5082
     components:
     - type: Transform
@@ -24303,6 +23989,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -27.5,-28.5
+  - uid: 5146
+    components:
+    - type: Transform
+      parent: 2
+      pos: -21.5,-60.5
   - uid: 5155
     components:
     - type: Transform
@@ -24318,6 +24009,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -22.5,9.5
+  - uid: 5183
+    components:
+    - type: Transform
+      parent: 2
+      pos: -52.5,-7.5
   - uid: 5194
     components:
     - type: Transform
@@ -24333,6 +24029,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -1.5,-49.5
+  - uid: 5408
+    components:
+    - type: Transform
+      parent: 2
+      pos: -26.5,-10.5
   - uid: 5413
     components:
     - type: Transform
@@ -24348,11 +24049,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -28.5,-41.5
-  - uid: 5416
-    components:
-    - type: Transform
-      parent: 2
-      pos: -28.5,-42.5
   - uid: 5417
     components:
     - type: Transform
@@ -24402,7 +24098,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -25.5,-35.5
+      pos: -12.5,-26.5
   - uid: 5427
     components:
     - type: Transform
@@ -24432,7 +24128,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -19.5,-36.5
+      pos: -35.5,10.5
   - uid: 5433
     components:
     - type: Transform
@@ -24467,7 +24163,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -19.5,-40.5
+      pos: -13.5,8.5
   - uid: 5440
     components:
     - type: Transform
@@ -24497,7 +24193,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -9.5,-19.5
+      pos: -8.5,-26.5
   - uid: 5450
     components:
     - type: Transform
@@ -24517,7 +24213,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -28.5,11.5
+      pos: -13.5,-26.5
   - uid: 5458
     components:
     - type: Transform
@@ -24587,7 +24283,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 3.5,6.5
+      pos: -22.5,-60.5
   - uid: 5483
     components:
     - type: Transform
@@ -24718,11 +24414,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -14.5,10.5
-  - uid: 5679
-    components:
-    - type: Transform
-      parent: 2
-      pos: -17.5,8.5
   - uid: 5708
     components:
     - type: Transform
@@ -24732,7 +24423,17 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -9.5,-17.5
+      pos: -15.5,6.5
+  - uid: 5800
+    components:
+    - type: Transform
+      parent: 2
+      pos: -27.5,-10.5
+  - uid: 5898
+    components:
+    - type: Transform
+      parent: 2
+      pos: -48.5,-46.5
   - uid: 5906
     components:
     - type: Transform
@@ -24742,7 +24443,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -9.5,-18.5
+      pos: 15.5,-12.5
   - uid: 6155
     components:
     - type: Transform
@@ -24762,7 +24463,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -73.5,-0.5
+      pos: 16.5,-12.5
   - uid: 6676
     components:
     - type: Transform
@@ -24798,16 +24499,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -36.5,-8.5
-  - uid: 6808
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-8.5
-  - uid: 6809
-    components:
-    - type: Transform
-      parent: 2
-      pos: 16.5,-26.5
   - uid: 6818
     components:
     - type: Transform
@@ -24883,11 +24574,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -8.5,7.5
-  - uid: 6906
+  - uid: 6907
     components:
     - type: Transform
       parent: 2
-      pos: -8.5,6.5
+      pos: 20.5,-27.5
   - uid: 6914
     components:
     - type: Transform
@@ -24903,6 +24594,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -23.5,-21.5
+  - uid: 6980
+    components:
+    - type: Transform
+      parent: 2
+      pos: -36.5,-21.5
   - uid: 6997
     components:
     - type: Transform
@@ -25067,7 +24763,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -35.5,-36.5
+      pos: -36.5,-20.5
   - uid: 7033
     components:
     - type: Transform
@@ -25113,11 +24809,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -45.5,-46.5
-  - uid: 7042
-    components:
-    - type: Transform
-      parent: 2
-      pos: -47.5,-45.5
   - uid: 7043
     components:
     - type: Transform
@@ -25222,7 +24913,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -55.5,-38.5
+      pos: 3.5,-31.5
   - uid: 7147
     components:
     - type: Transform
@@ -25468,16 +25159,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -46.5,3.5
-  - uid: 7199
-    components:
-    - type: Transform
-      parent: 2
-      pos: -46.5,2.5
-  - uid: 7200
-    components:
-    - type: Transform
-      parent: 2
-      pos: -51.5,8.5
   - uid: 7201
     components:
     - type: Transform
@@ -25518,6 +25199,21 @@ entities:
     - type: Transform
       parent: 2
       pos: -47.5,6.5
+  - uid: 7215
+    components:
+    - type: Transform
+      parent: 2
+      pos: 21.5,-27.5
+  - uid: 7244
+    components:
+    - type: Transform
+      parent: 2
+      pos: 6.5,-13.5
+  - uid: 7258
+    components:
+    - type: Transform
+      parent: 2
+      pos: -10.5,0.5
   - uid: 7645
     components:
     - type: Transform
@@ -25527,7 +25223,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -48.5,-23.5
+      pos: 14.5,-12.5
   - uid: 7648
     components:
     - type: Transform
@@ -25683,6 +25379,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -37.5,-23.5
+  - uid: 7881
+    components:
+    - type: Transform
+      parent: 2
+      pos: -19.5,-41.5
   - uid: 7933
     components:
     - type: Transform
@@ -25902,7 +25603,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -66.5,7.5
+      pos: -2.5,9.5
   - uid: 8125
     components:
     - type: Transform
@@ -26047,7 +25748,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 33.5,-12.5
+      pos: -2.5,10.5
   - uid: 8665
     components:
     - type: Transform
@@ -26103,11 +25804,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -2.5,15.5
-  - uid: 8811
-    components:
-    - type: Transform
-      parent: 2
-      pos: -2.5,13.5
   - uid: 8812
     components:
     - type: Transform
@@ -26188,11 +25884,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -59.5,0.5
-  - uid: 9302
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-20.5
   - uid: 9313
     components:
     - type: Transform
@@ -26208,21 +25899,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 14.5,-2.5
-  - uid: 9662
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-23.5
-  - uid: 9663
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-22.5
-  - uid: 9664
-    components:
-    - type: Transform
-      parent: 2
-      pos: -35.5,-21.5
   - uid: 9709
     components:
     - type: Transform
@@ -26323,16 +25999,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 4.5,-30.5
-  - uid: 9785
-    components:
-    - type: Transform
-      parent: 2
-      pos: 4.5,-31.5
-  - uid: 9786
-    components:
-    - type: Transform
-      parent: 2
-      pos: 4.5,-32.5
   - uid: 9830
     components:
     - type: Transform
@@ -26418,11 +26084,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 7.5,-43.5
-  - uid: 10313
-    components:
-    - type: Transform
-      parent: 2
-      pos: 8.5,-42.5
   - uid: 10314
     components:
     - type: Transform
@@ -26453,21 +26114,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -45.5,-47.5
-  - uid: 10333
-    components:
-    - type: Transform
-      parent: 2
-      pos: -49.5,-46.5
   - uid: 10781
     components:
     - type: Transform
       parent: 2
       pos: -22.5,-16.5
-  - uid: 10831
-    components:
-    - type: Transform
-      parent: 2
-      pos: -21.5,-16.5
   - uid: 10846
     components:
     - type: Transform
@@ -26533,11 +26184,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 19.5,-5.5
-  - uid: 11216
-    components:
-    - type: Transform
-      parent: 2
-      pos: 6.5,-14.5
   - uid: 11230
     components:
     - type: Transform
@@ -26563,11 +26209,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -10.5,1.5
-  - uid: 11383
-    components:
-    - type: Transform
-      parent: 2
-      pos: -9.5,1.5
   - uid: 11408
     components:
     - type: Transform
@@ -26588,11 +26229,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 8.5,-36.5
-  - uid: 11412
-    components:
-    - type: Transform
-      parent: 2
-      pos: 7.5,-36.5
   - uid: 11520
     components:
     - type: Transform
@@ -26638,11 +26274,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 4.5,1.5
-  - uid: 12418
-    components:
-    - type: Transform
-      parent: 2
-      pos: 5.5,1.5
   - uid: 12419
     components:
     - type: Transform
@@ -26733,11 +26364,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -8.5,-30.5
-  - uid: 12437
-    components:
-    - type: Transform
-      parent: 2
-      pos: -8.5,-28.5
   - uid: 12438
     components:
     - type: Transform
@@ -26853,41 +26479,16 @@ entities:
     - type: Transform
       parent: 2
       pos: -75.5,-10.5
-  - uid: 14505
-    components:
-    - type: Transform
-      parent: 2
-      pos: -74.5,-10.5
   - uid: 14710
     components:
     - type: Transform
       parent: 2
       pos: -19.5,-61.5
-  - uid: 14711
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-61.5
   - uid: 14712
     components:
     - type: Transform
       parent: 2
       pos: -20.5,-60.5
-  - uid: 14713
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-59.5
-  - uid: 14714
-    components:
-    - type: Transform
-      parent: 2
-      pos: -20.5,-58.5
-  - uid: 14731
-    components:
-    - type: Transform
-      parent: 2
-      pos: -51.5,29.5
   - uid: 14732
     components:
     - type: Transform
@@ -26908,8 +26509,278 @@ entities:
     - type: Transform
       parent: 2
       pos: -48.5,30.5
+- proto: CableMVStack1
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      parent: 2
+      pos: -13.5,-12.5
+  - uid: 343
+    components:
+    - type: Transform
+      parent: 2
+      pos: -15.5,-12.5
+  - uid: 4151
+    components:
+    - type: Transform
+      parent: 2
+      pos: -17.5,-11.5
+  - uid: 4226
+    components:
+    - type: Transform
+      parent: 2
+      pos: -12.5,-11.5
 - proto: CableTerminal
   entities:
+  - uid: 388
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -17.5,-8.5
+  - uid: 505
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -5.5,-21.5
+  - uid: 891
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -14.5,-22.5
+  - uid: 951
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+  - uid: 959
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-9.5
+  - uid: 961
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 11.5,8.5
+  - uid: 989
+    components:
+    - type: Transform
+      parent: 2
+      pos: 6.5,-13.5
+  - uid: 990
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: 12.5,-19.5
+  - uid: 1121
+    components:
+    - type: Transform
+      parent: 2
+      pos: -13.5,-19.5
+  - uid: 1123
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -17.5,6.5
+  - uid: 1125
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-0.5
+  - uid: 1126
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 20.5,7.5
+  - uid: 1403
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: 26.5,8.5
+  - uid: 1538
+    components:
+    - type: Transform
+      parent: 2
+      pos: 21.5,-37.5
+  - uid: 1708
+    components:
+    - type: Transform
+      parent: 2
+      pos: 23.5,-28.5
+  - uid: 1862
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -27.5,-11.5
+  - uid: 1902
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-8.5
+  - uid: 2079
+    components:
+    - type: Transform
+      parent: 2
+      pos: 27.5,-0.5
+  - uid: 2080
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -49.5,-8.5
+  - uid: 2150
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -47.5,-16.5
+  - uid: 2168
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -36.5,-8.5
+  - uid: 2192
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -54.5,-8.5
+  - uid: 2247
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -20.5,-21.5
+  - uid: 2249
+    components:
+    - type: Transform
+      parent: 2
+      pos: -19.5,-35.5
+  - uid: 2275
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -28.5,10.5
+  - uid: 2478
+    components:
+    - type: Transform
+      parent: 2
+      pos: -46.5,3.5
+  - uid: 2493
+    components:
+    - type: Transform
+      parent: 2
+      pos: -51.5,9.5
+  - uid: 2495
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -35.5,-37.5
+  - uid: 3144
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -48.5,-46.5
+  - uid: 3148
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-16.5
+  - uid: 3227
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -75.5,-10.5
+  - uid: 3245
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -19.5,-41.5
+  - uid: 3246
+    components:
+    - type: Transform
+      parent: 2
+      pos: -51.5,30.5
+  - uid: 3248
+    components:
+    - type: Transform
+      parent: 2
+      pos: -8.5,7.5
+  - uid: 3249
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: 17.5,-11.5
+  - uid: 3296
+    components:
+    - type: Transform
+      parent: 2
+      pos: 6.5,-23.5
+  - uid: 3487
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -15.5,-11.5
+  - uid: 3492
+    components:
+    - type: Transform
+      parent: 2
+      pos: 18.5,-21.5
+  - uid: 3494
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -24.5,6.5
+  - uid: 3506
+    components:
+    - type: Transform
+      parent: 2
+      pos: 19.5,-6.5
+  - uid: 3523
+    components:
+    - type: Transform
+      parent: 2
+      pos: -7.5,-36.5
+  - uid: 3549
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: 23.5,-34.5
+  - uid: 3592
+    components:
+    - type: Transform
+      parent: 2
+      pos: 30.5,-19.5
+  - uid: 3684
+    components:
+    - type: Transform
+      parent: 2
+      pos: 30.5,-27.5
   - uid: 3761
     components:
     - type: Transform
@@ -26931,6 +26802,176 @@ entities:
     - type: Transform
       parent: 2
       pos: -39.5,-24.5
+  - uid: 4023
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -42.5,-42.5
+  - uid: 4050
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -2.5,-41.5
+  - uid: 4053
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-38.5
+  - uid: 4227
+    components:
+    - type: Transform
+      parent: 2
+      pos: -11.5,-8.5
+  - uid: 4350
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -9.5,0.5
+  - uid: 4356
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+  - uid: 4360
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 2.5,6.5
+  - uid: 4386
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -29.5,-23.5
+  - uid: 4720
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -10.5,-11.5
+  - uid: 4721
+    components:
+    - type: Transform
+      parent: 2
+      pos: -44.5,-13.5
+  - uid: 4846
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -38.5,-23.5
+  - uid: 4860
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -39.5,-15.5
+  - uid: 5145
+    components:
+    - type: Transform
+      parent: 2
+      pos: -46.5,-7.5
+  - uid: 5186
+    components:
+    - type: Transform
+      parent: 2
+      pos: -48.5,-2.5
+  - uid: 5293
+    components:
+    - type: Transform
+      parent: 2
+      pos: -28.5,-41.5
+  - uid: 5296
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -26.5,-35.5
+  - uid: 5454
+    components:
+    - type: Transform
+      parent: 2
+      pos: -73.5,0.5
+  - uid: 5679
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-26.5
+  - uid: 5904
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -56.5,-38.5
+  - uid: 6694
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -48.5,-24.5
+  - uid: 6808
+    components:
+    - type: Transform
+      parent: 2
+      pos: -66.5,8.5
+  - uid: 6809
+    components:
+    - type: Transform
+      parent: 2
+      pos: 33.5,-11.5
+  - uid: 6906
+    components:
+    - type: Transform
+      parent: 2
+      pos: -2.5,14.5
+  - uid: 6979
+    components:
+    - type: Transform
+      parent: 2
+      pos: -35.5,-20.5
+  - uid: 7042
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-32.5
+  - uid: 7199
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-42.5
+  - uid: 7260
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-36.5
+  - uid: 7311
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -8.5,-29.5
+  - uid: 7898
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -23.5,-59.5
+  - uid: 8045
+    components:
+    - type: Transform
+      parent: 2
+      rot: -1.5707963267948966 rad
+      pos: -36.5,10.5
   - uid: 8495
     components:
     - type: Transform
@@ -37389,20 +37430,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -62.5,13.5
-- proto: ESHolopadCommandStationAdmin
-  entities:
-  - uid: 1121
-    components:
-    - type: Transform
-      parent: 2
-      pos: -2.5,7.5
-- proto: ESHolopadSecurityOffice
-  entities:
-  - uid: 3148
-    components:
-    - type: Transform
-      parent: 2
-      pos: -24.5,-17.5
 - proto: ESKitBarricade
   entities:
   - uid: 14206
@@ -48992,14 +49019,6 @@ entities:
       pos: -20.5,-22.5
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 9534
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -45.5,-2.5
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 10119
     components:
     - type: Transform
@@ -58391,12 +58410,16 @@ entities:
       parent: 2
       rot: 1.5707963267948966 rad
       pos: -48.5,-2.5
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 13438
     components:
     - type: Transform
       parent: 2
       rot: 1.5707963267948966 rad
       pos: -47.5,-2.5
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 13445
     components:
     - type: Transform
@@ -58594,6 +58617,8 @@ entities:
       parent: 2
       rot: 1.5707963267948966 rad
       pos: -46.5,-2.5
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraightAlt2
   entities:
   - uid: 263
@@ -59724,6 +59749,14 @@ entities:
       parent: 2
       rot: 1.5707963267948966 rad
       pos: -17.5,4.5
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 8050
+    components:
+    - type: Transform
+      parent: 2
+      rot: 3.141592653589793 rad
+      pos: -45.5,-2.5
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 9527
@@ -64609,200 +64642,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -18.5,-40.5
-- proto: HolopadCargoFront
-  entities:
-  - uid: 1715
-    components:
-    - type: Transform
-      parent: 2
-      pos: -0.5,-33.5
-- proto: HolopadCargoMailroom
-  entities:
-  - uid: 1716
-    components:
-    - type: Transform
-      parent: 2
-      pos: -1.5,-37.5
-- proto: HolopadCommandBridge
-  entities:
-  - uid: 2192
-    components:
-    - type: Transform
-      parent: 2
-      pos: 28.5,-34.5
-- proto: HolopadCommandBridgeHallway
-  entities:
-  - uid: 2193
-    components:
-    - type: Transform
-      parent: 2
-      pos: 22.5,-31.5
-- proto: HolopadCommandCaptain
-  entities:
-  - uid: 2455
-    components:
-    - type: Transform
-      parent: 2
-      pos: 29.5,-24.5
-- proto: HolopadCommandMeetingRoom
-  entities:
-  - uid: 2150
-    components:
-    - type: Transform
-      parent: 2
-      pos: 20.5,-35.5
-- proto: HolopadCommandVault
-  entities:
-  - uid: 2168
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-27.5
-- proto: HolopadEngineeringFront
-  entities:
-  - uid: 4386
-    components:
-    - type: Transform
-      parent: 2
-      pos: -36.5,-18.5
-- proto: HolopadEngineeringMain
-  entities:
-  - uid: 4226
-    components:
-    - type: Transform
-      parent: 2
-      pos: -41.5,-20.5
-- proto: HolopadEngineeringStorage
-  entities:
-  - uid: 4227
-    components:
-    - type: Transform
-      parent: 2
-      pos: -36.5,-25.5
-- proto: HolopadEngineeringTelecoms
-  entities:
-  - uid: 4408
-    components:
-    - type: Transform
-      parent: 2
-      pos: -40.5,-8.5
-- proto: HolopadGeneralDisposals
-  entities:
-  - uid: 7881
-    components:
-    - type: Transform
-      parent: 2
-      pos: -57.5,-38.5
-- proto: HolopadMedicalBreakroom
-  entities:
-  - uid: 1318
-    components:
-    - type: Transform
-      parent: 2
-      pos: 8.5,7.5
-- proto: HolopadMedicalChemistry
-  entities:
-  - uid: 10995
-    components:
-    - type: Transform
-      parent: 2
-      pos: 9.5,-5.5
-- proto: HolopadMedicalCryopods
-  entities:
-  - uid: 1317
-    components:
-    - type: Transform
-      parent: 2
-      pos: 16.5,9.5
-- proto: HolopadMedicalFront
-  entities:
-  - uid: 1156
-    components:
-    - type: Transform
-      parent: 2
-      pos: 10.5,-0.5
-- proto: HolopadMedicalMorgue
-  entities:
-  - uid: 1398
-    components:
-    - type: Transform
-      parent: 2
-      pos: 30.5,6.5
-- proto: HolopadMedicalSurgery
-  entities:
-  - uid: 1192
-    components:
-    - type: Transform
-      parent: 2
-      pos: 18.5,-0.5
-- proto: HolopadScienceRnd
-  entities:
-  - uid: 1126
-    components:
-    - type: Transform
-      parent: 2
-      pos: 5.5,-6.5
-- proto: HolopadScienceRobotics
-  entities:
-  - uid: 1125
-    components:
-    - type: Transform
-      parent: 2
-      pos: 5.5,-19.5
-- proto: HolopadSecurityBrig
-  entities:
-  - uid: 3711
-    components:
-    - type: Transform
-      parent: 2
-      pos: -22.5,-8.5
-  - uid: 7311
-    components:
-    - type: Transform
-      parent: 2
-      pos: -27.5,-22.5
-- proto: HolopadSecurityDetective
-  entities:
-  - uid: 5800
-    components:
-    - type: Transform
-      parent: 2
-      pos: -27.5,-35.5
-- proto: HolopadServiceBar
-  entities:
-  - uid: 1122
-    components:
-    - type: Transform
-      parent: 2
-      pos: -6.5,-6.5
-- proto: HolopadServiceJanitor
-  entities:
-  - uid: 343
-    components:
-    - type: Transform
-      parent: 2
-      pos: -4.5,-23.5
-- proto: HolopadServiceKitchen
-  entities:
-  - uid: 1123
-    components:
-    - type: Transform
-      parent: 2
-      pos: -6.5,-13.5
-- proto: HolopadServiceLibrary
-  entities:
-  - uid: 8045
-    components:
-    - type: Transform
-      parent: 2
-      pos: -67.5,10.5
-- proto: HolopadServiceNewsroom
-  entities:
-  - uid: 4391
-    components:
-    - type: Transform
-      parent: 2
-      pos: -17.5,5.5
 - proto: HospitalCurtainsOpen
   entities:
   - uid: 7840
@@ -64959,335 +64798,6 @@ entities:
     - type: Transform
       parent: 2
       pos: 24.518803,-26.407389
-- proto: IntercomAll
-  entities:
-  - uid: 4985
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: -42.5,-5.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomCommand
-  entities:
-  - uid: 5186
-    components:
-    - type: Transform
-      parent: 2
-      pos: -3.5,10.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9536
-    components:
-    - type: Transform
-      parent: 2
-      pos: -28.5,7.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9537
-    components:
-    - type: Transform
-      parent: 2
-      pos: 23.5,-29.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9538
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: 29.5,-28.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9539
-    components:
-    - type: Transform
-      parent: 2
-      pos: 31.5,-15.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomCommon
-  entities:
-  - uid: 9559
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -52.5,8.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9560
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -30.5,-9.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9561
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -30.5,-42.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9563
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-34.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9565
-    components:
-    - type: Transform
-      parent: 2
-      pos: -9.5,-2.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9566
-    components:
-    - type: Transform
-      parent: 2
-      pos: 0.5,3.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9568
-    components:
-    - type: Transform
-      parent: 2
-      pos: 16.5,-28.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 14525
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -40.5,9.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomConstructed
-  entities:
-  - uid: 8912
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: 7.5,15.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomEngineering
-  entities:
-  - uid: 3862
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: -38.5,-16.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9540
-    components:
-    - type: Transform
-      parent: 2
-      pos: -19.5,-36.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9541
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -39.5,-28.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9542
-    components:
-    - type: Transform
-      parent: 2
-      pos: -43.5,-14.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9543
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -46.5,-3.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9544
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -53.5,-10.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomMedical
-  entities:
-  - uid: 1053
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: 12.5,-0.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9546
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: 17.5,-2.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9547
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: 5.5,5.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9548
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: 12.5,10.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomScience
-  entities:
-  - uid: 9549
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: 3.5,-10.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9550
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-19.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomSecurity
-  entities:
-  - uid: 6979
-    components:
-    - type: Transform
-      parent: 2
-      pos: -26.5,-20.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 6980
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -34.5,-38.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 7898
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -30.5,-20.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9562
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: -30.5,-36.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9570
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -24.5,-28.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomService
-  entities:
-  - uid: 9552
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-13.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9553
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: -11.5,-17.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9556
-    components:
-    - type: Transform
-      parent: 2
-      pos: -17.5,-5.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9567
-    components:
-    - type: Transform
-      parent: 2
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-34.5
-    - type: Fixtures
-      fixtures: {}
-- proto: IntercomSupply
-  entities:
-  - uid: 1902
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -4.5,-35.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9555
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-46.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 9558
-    components:
-    - type: Transform
-      parent: 2
-      rot: -1.5707963267948966 rad
-      pos: 3.5,-36.5
-    - type: Fixtures
-      fixtures: {}
-  - uid: 12284
-    components:
-    - type: Transform
-      parent: 2
-      rot: 3.141592653589793 rad
-      pos: -10.5,-48.5
-    - type: Fixtures
-      fixtures: {}
 - proto: IVStand
   entities:
   - uid: 1176

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -98,10 +98,10 @@
     examinable: true
     nodes:
       input:
-        !type:CableDeviceNode
+        !type:CableTerminalPortNode
         nodeGroupID: MVPower
       output:
-        !type:CableDeviceNode
+        !type:CableTerminalPortNode
         nodeGroupID: Apc
   - type: PowerMonitoringDevice
     group: APC

--- a/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/cable_terminal.yml
@@ -50,6 +50,9 @@
         powerMV:
           !type:CableTerminalNode
           nodeGroupID: MVPower
+        apc: #ES: for APC terms because wires under walls are icky
+          !type:CableTerminalNode
+          nodeGroupID: apc #what if we just call this node group something different for no reason
 
 - type: entity
   id: CableTerminalUncuttable


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Made APCs use the cable terminals in preparation for wires not being able to go under walls


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

misc changes:
<img width="171" height="241" alt="image" src="https://github.com/user-attachments/assets/ae44f004-81bf-4825-bd17-d60f989cfec3" />
added an lv cable down to caps nuke terminal so generator placement is easier

<img width="341" height="513" alt="image" src="https://github.com/user-attachments/assets/c318af9f-e0cc-464d-8574-d92994418287" />
made EVA AA again

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: APCs now use a cable terminal to get power.
- tweak: EVA storage can now be accessed by anyone.
