### PR TITLE
Small radio changes

### DIFF
--- a/Content.Shared/_ES/Chat/Radio/ESRadioSystem.cs
+++ b/Content.Shared/_ES/Chat/Radio/ESRadioSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Power.EntitySystems;
 using Content.Shared.Radio.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Audio;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
@@ -54,10 +55,11 @@ public sealed partial class ESRadioSystem : EntitySystem
 
     private void OnSendChatMessageAttempt(Entity<ESRadioChatChannelComponent> ent, ref ESSendChatMessageAttemptEvent args)
     {
+        var source = Transform(args.Source);
         var channel = _chat.GetChannel(ent.Owner);
 
         var needsServer = !_exemptQuery.HasComp(args.Source) && !ent.Comp.RequireServer;
-        if (!needsServer && !HasActiveServer(channel))
+        if (!needsServer && !HasActiveServer(channel, source.MapID))
         {
             args.Cancel();
             return;
@@ -118,10 +120,13 @@ public sealed partial class ESRadioSystem : EntitySystem
     /// <summary>
     /// Checks if a given chat channel has a corresponding telecom server.
     /// </summary>
-    public bool HasActiveServer(ProtoId<ESChatChannelPrototype> channelId)
+    public bool HasActiveServer(ProtoId<ESChatChannelPrototype> channelId, MapId map)
     {
-        foreach (var (uid, _, keys) in EntityQueryEnumerator<TelecomServerComponent, EncryptionKeyHolderComponent>())
+        foreach (var (uid, _, keys, xform) in EntityQueryEnumerator<TelecomServerComponent, EncryptionKeyHolderComponent, TransformComponent>())
         {
+            if (xform.MapID != map)
+                continue;
+
             if (_powerReceiver.IsPowered(uid) &&
                 keys.Channels.Contains(channelId))
             {

--- a/Content.Shared/_ES/Radio/Components/ESRadioScramblerComponent.cs
+++ b/Content.Shared/_ES/Radio/Components/ESRadioScramblerComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.DoAfter;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._ES.Radio.Components;
@@ -12,7 +13,19 @@ public sealed partial class ESRadioScramblerComponent : Component
 
     [DataField]
     public TimeSpan RepairDelay = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// How long after sabotaging this machine until you can repair it again.
+    /// </summary>
+    [DataField]
+    public TimeSpan RepairBlockDelay = TimeSpan.FromMinutes(5);
+
+    [DataField]
+    public EntProtoId RepairBlockStatusEffect = "ESStatusEffectRadioScramblerRepairBlocked";
 }
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ESRadioScramblerRepairBlockedStatusEffectComponent : Component;
 
 [Serializable, NetSerializable]
 public enum ESRadioScramblerVisuals : byte

--- a/Content.Shared/_ES/Radio/ESRadioScramblerSystem.cs
+++ b/Content.Shared/_ES/Radio/ESRadioScramblerSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared._ES.SecretIdentity.Traitor;
 using Content.Shared._ES.Sparks;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
+using Content.Shared.StatusEffectNew;
 using Content.Shared.Verbs;
 
 namespace Content.Shared._ES.Radio;
@@ -12,13 +13,14 @@ public sealed partial class ESRadioScramblerSystem : EntitySystem
 {
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
-    [Dependency] private ESSabotageSystem _sabotage = default!;
     [Dependency] private ESSparksSystem _sparks = default!;
+    [Dependency] private StatusEffectsSystem _statusEffects = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<ESRadioScramblerComponent, ESUndergoDegradationEvent>(OnUndergoDegradation);
+        SubscribeLocalEvent<ESRadioScramblerComponent, ESSabotageAttemptEvent>(OnSabotageAttempt);
         SubscribeLocalEvent<ESRadioScramblerComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<ESRadioScramblerComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerb);
         SubscribeLocalEvent<ESRadioScramblerComponent, ESRepairRadioScramblerDoAfterEvent>(OnRepairDoAfter);
@@ -26,8 +28,21 @@ public sealed partial class ESRadioScramblerSystem : EntitySystem
 
     private void OnUndergoDegradation(Entity<ESRadioScramblerComponent> ent, ref ESUndergoDegradationEvent args)
     {
+        if (args.User is { } user)
+        {
+            _statusEffects.TryAddStatusEffectDuration(user,
+                ent.Comp.RepairBlockStatusEffect,
+                ent.Comp.RepairBlockDelay);
+        }
+
         SetHacked(ent, true);
         args.Handled = true;
+    }
+
+    private void OnSabotageAttempt(Entity<ESRadioScramblerComponent> ent, ref ESSabotageAttemptEvent args)
+    {
+        if (ent.Comp.Hacked)
+            args.Cancelled = true;
     }
 
     private void OnExamined(Entity<ESRadioScramblerComponent> ent, ref ExaminedEvent args)
@@ -41,13 +56,13 @@ public sealed partial class ESRadioScramblerSystem : EntitySystem
             return;
 
         var user = args.User;
-        var canSabo = _sabotage.CanSabotage(args.User, ent.Owner, ignoreCompletion: true);
+        var hasSaboed = _statusEffects.HasEffectComp<ESRadioScramblerRepairBlockedStatusEffectComponent>(user);
 
         args.Verbs.Add(new AlternativeVerb
         {
             Text = Loc.GetString("es-radio-scrambler-repair-verb"),
-            Disabled = !ent.Comp.Hacked || canSabo,
-            Message = ent.Comp.Hacked && canSabo ? Loc.GetString("es-radio-scrambler-repair-verb-blocked") : null,
+            Disabled = !ent.Comp.Hacked || hasSaboed,
+            Message = ent.Comp.Hacked && hasSaboed ? Loc.GetString("es-radio-scrambler-repair-verb-blocked") : null,
             Act = () =>
             {
                 _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, ent.Comp.RepairDelay, new ESRepairRadioScramblerDoAfterEvent(), ent, ent)

--- a/Content.Shared/_ES/Radio/ESRadioScramblerSystem.cs
+++ b/Content.Shared/_ES/Radio/ESRadioScramblerSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._ES.Degradation;
 using Content.Shared._ES.Radio.Components;
+using Content.Shared._ES.SecretIdentity.Traitor;
 using Content.Shared._ES.Sparks;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -11,6 +12,7 @@ public sealed partial class ESRadioScramblerSystem : EntitySystem
 {
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private ESSabotageSystem _sabotage = default!;
     [Dependency] private ESSparksSystem _sparks = default!;
 
     /// <inheritdoc/>
@@ -39,11 +41,13 @@ public sealed partial class ESRadioScramblerSystem : EntitySystem
             return;
 
         var user = args.User;
+        var canSabo = _sabotage.CanSabotage(args.User, ent.Owner, ignoreCompletion: true);
 
         args.Verbs.Add(new AlternativeVerb
         {
             Text = Loc.GetString("es-radio-scrambler-repair-verb"),
-            Disabled = !ent.Comp.Hacked,
+            Disabled = !ent.Comp.Hacked || canSabo,
+            Message = ent.Comp.Hacked && canSabo ? Loc.GetString("es-radio-scrambler-repair-verb-blocked") : null,
             Act = () =>
             {
                 _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, user, ent.Comp.RepairDelay, new ESRepairRadioScramblerDoAfterEvent(), ent, ent)

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESSabotageSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESSabotageSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
     ///     Returns true if the user should be capable of sabotaging the given target.
     /// </summary>
     [PublicAPI]
-    public bool CanSabotage(EntityUid user, Entity<ESSabotageTargetComponent?> target, bool ignoreCompletion = false)
+    public bool CanSabotage(EntityUid user, Entity<ESSabotageTargetComponent?> target)
     {
         if (!Resolve(target, ref target.Comp))
             return false;
@@ -48,6 +48,11 @@ public sealed partial class ESSabotageSystem : EntitySystem
         if (_mind.GetMind(user) is not { } mind)
             return false;
 
+        var ev = new ESSabotageAttemptEvent(user);
+        RaiseLocalEvent(target, ref ev);
+        if (ev.Cancelled)
+            return false;
+
         // overriding, for vandal etc
         if (HasComp<ESCanAlwaysSabotageComponent>(user) || HasComp<ESCanAlwaysSabotageComponent>(mind))
             return true;
@@ -57,7 +62,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
             if (!_entityWhitelist.IsWhitelistPass(objective.Comp.Whitelist, target))
                 continue;
 
-            if (!ignoreCompletion && _objective.IsCompleted(objective.Owner))
+            if (_objective.IsCompleted(objective.Owner))
                 continue;
 
             return true;
@@ -76,6 +81,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
         {
             Priority = 1,
             Text = Loc.GetString("es-sabotage-verb-text"),
+            Disabled = !args.CanAccess || !args.CanInteract,
             DoContactInteraction = true,
             Act = () =>
             {
@@ -124,13 +130,16 @@ public sealed partial class ESSabotageSystem : EntitySystem
 }
 
 [Serializable, NetSerializable]
-public sealed partial class ESSabotageDoAfterEvent : DoAfterEvent
-{
-    public override DoAfterEvent Clone() => this;
-}
+public sealed partial class ESSabotageDoAfterEvent : SimpleDoAfterEvent;
 
 /// <summary>
 /// Event broadcast whenever a sabotage is completed successfully.
 /// </summary>
 [ByRefEvent]
 public readonly record struct ESSabotageCompletedEvent(EntityUid User, EntityUid Target);
+
+/// <summary>
+/// Event raised on a sabotage target to check whether it can currently be sabotaged.
+/// </summary>
+[ByRefEvent]
+public record struct ESSabotageAttemptEvent(EntityUid User, bool Cancelled = false);

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESSabotageSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESSabotageSystem.cs
@@ -36,8 +36,11 @@ public sealed partial class ESSabotageSystem : EntitySystem
     ///     Returns true if the user should be capable of sabotaging the given target.
     /// </summary>
     [PublicAPI]
-    public bool CanSabotage(EntityUid user, Entity<ESSabotageTargetComponent> target)
+    public bool CanSabotage(EntityUid user, Entity<ESSabotageTargetComponent?> target, bool ignoreCompletion = false)
     {
+        if (!Resolve(target, ref target.Comp))
+            return false;
+
         // for localhost debugging
         if (_admin.HasAdminFlag(user, AdminFlags.Debug))
             return true;
@@ -51,9 +54,13 @@ public sealed partial class ESSabotageSystem : EntitySystem
 
         foreach (var objective in _objective.GetObjectives<ESSabotageConditionComponent>(mind))
         {
-            if (_entityWhitelist.IsWhitelistPass(objective.Comp.Whitelist, target) &&
-                !_objective.IsCompleted(objective.Owner))
-                return true;
+            if (!_entityWhitelist.IsWhitelistPass(objective.Comp.Whitelist, target))
+                continue;
+
+            if (!ignoreCompletion && _objective.IsCompleted(objective.Owner))
+                continue;
+
+            return true;
         }
 
         return false;
@@ -61,7 +68,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
 
     private void OnGetVerbs(Entity<ESSabotageTargetComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!CanSabotage(args.User, ent))
+        if (!CanSabotage(args.User, ent.AsNullable()))
             return;
 
         var user = args.User;
@@ -96,7 +103,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
         if (args.Cancelled || args.Handled)
             return;
 
-        if (!CanSabotage(args.User, ent))
+        if (!CanSabotage(args.User, ent.AsNullable()))
             return;
 
         _degradation.Degrade(ent, args.User);
@@ -109,7 +116,7 @@ public sealed partial class ESSabotageSystem : EntitySystem
 
     private void OnExamined(Entity<ESSabotageTargetComponent> ent, ref ExaminedEvent args)
     {
-        if (!CanSabotage(args.Examiner, ent))
+        if (!CanSabotage(args.Examiner, ent.AsNullable()))
             return;
 
         args.PushMarkup(Loc.GetString("es-sabotage-examine-text"));

--- a/Resources/Locale/en-US/_ES/radio/scrambler.ftl
+++ b/Resources/Locale/en-US/_ES/radio/scrambler.ftl
@@ -1,4 +1,5 @@
 es-radio-scrambler-repair-verb = Repair
+es-radio-scrambler-repair-verb-blocked = I won't repair this!
 es-radio-scrambler-examine = {$hacked ->
     [true] The processor is [color=crimson]malfunctioning[/color] and needs to be repaired!
     *[false] The processor is [color=limegreen]operational[/color].

--- a/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Ears/headsets_alt.yml
@@ -18,7 +18,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyStationMaster
+      - EncryptionKeyCommon
+      - EncryptionKeyCommand
   - type: Sprite
     sprite: Clothing/Ears/Headsets/command.rsi
   - type: Clothing

--- a/Resources/Prototypes/_ES/Entities/Structures/Machines/tcomms.yml
+++ b/Resources/Prototypes/_ES/Entities/Structures/Machines/tcomms.yml
@@ -56,3 +56,10 @@
     count: 2
   - type: WiresPanel
   - type: WiresVisuals
+
+
+- type: entity
+  parent: StatusEffectBase
+  id: ESStatusEffectRadioScramblerRepairBlocked
+  components:
+  - type: ESRadioScramblerRepairBlockedStatusEffect


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2533 
Closes #2556 
Closes #2464 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Radios are no longer available in arrivals or on the warp drive.
- tweak: Command members no longer get access to all radio channels, now they only receive common and command.
- tweak: Players with objectives to sabotage the telecomms processor can no longer repair it.
