### PR TITLE
last marauder updates, hopefully

### DIFF
--- a/Content.Server/Pointing/EntitySystems/PointingSystem.cs
+++ b/Content.Server/Pointing/EntitySystems/PointingSystem.cs
@@ -46,7 +46,7 @@ namespace Content.Server.Pointing.EntitySystems
         [Dependency] private IAdminLogManager _adminLogger = default!;
         [Dependency] private ExamineSystemShared _examine = default!;
 
-        private TimeSpan _pointDelay = TimeSpan.FromSeconds(0.5f);
+        private TimeSpan _pointDelay = TimeSpan.FromSeconds(0.1f);
 
         /// <summary>
         ///     A dictionary of players to the last time that they

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -51,6 +51,7 @@
       - id: ClothingHandsChameleon
       - id: ClothingHeadsetChameleon
       - id: ClothingShoesChameleon
+      - id: ClothingMaskGasVoiceChameleon
       - id: ESChameleonControllerImplanter
     - id: ESEmag
     - id: C4
@@ -74,7 +75,7 @@
     - id: ESWeaponRevolver357
     - id: ESSpeedLoader357
     - id: ESWeaponKnife
-    - id: StimulantPen
+    - id: ExGrenade
 
 # Subverter
 - type: entity

--- a/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
+++ b/Resources/Prototypes/_ES/Catalog/Fills/Crates/caches.yml
@@ -51,7 +51,6 @@
       - id: ClothingHandsChameleon
       - id: ClothingHeadsetChameleon
       - id: ClothingShoesChameleon
-      - id: ClothingMaskGasVoiceChameleon
       - id: ESChameleonControllerImplanter
     - id: ESEmag
     - id: C4

--- a/Resources/Prototypes/_ES/Catalog/Tables/traitor.yml
+++ b/Resources/Prototypes/_ES/Catalog/Tables/traitor.yml
@@ -1,22 +1,4 @@
 - type: entityTable
-  id: SubverterWeapons
-  table:
-    group:
-    - group:
-      - all:
-        - id: ESWeaponPistol9mm
-        - id: ESMagazine9mm
-        weight: 8
-      - all:
-        - id: ESWeaponDoubleBarrelShotgun
-        - id: ESShotgunShellsBoxBuckshot
-        weight: 2
-      - all:
-        - id: ESWeaponRevolver357
-        - id: ESSpeedLoader357
-        weight: 2
-
-- type: entityTable
   id: MaintsTraitorLoot
   table:
     group:

--- a/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Marauder.xml
+++ b/Resources/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities/Traitors/Marauder.xml
@@ -5,13 +5,13 @@
     Marauders are a heavy-hitting force-of-nature, and the strongest traitor secret identity in terms of direct attack power. Their kit makes them highly effective at more up-front assassinations.
 
 ## Tools of the Trade
-    Their cache contains a .357 revolver, a spare .357 speedloader, a knife, and a stimulant medipen.
+    Their cache contains a .357 revolver, a spare .357 speedloader, a knife, and an explosive grenade.
 
     <Box>
         <GuideEntityEmbed Entity="ESWeaponRevolver357"/>
         <GuideEntityEmbed Entity="ESSpeedLoader357"/>
         <GuideEntityEmbed Entity="ESWeaponKnife"/>
-        <GuideEntityEmbed Entity="StimulantPen"/>
+        <GuideEntityEmbed Entity="ExGrenade"/>
     </Box>
 
 ### .357 Revolver
@@ -20,8 +20,8 @@
 ### Knife
     A fantastic tool for killing people who are in its range without needing to waste ammo. It's particularly useful at being able to speed up the death of downed targets.
 
-### Stimulant Medipen
-    A one-time-use medipen that increases your movement speed, along with suppressing pain & cleansing any chloral hydrate from your system. It's best used mid-combat, as it flushes out of your system quickly.
+### Explosive Grenade
+	Highly versatile and great for dealing massive damage to players in a pinch. Though it can sometimes do okay damage to weak structures like machines and windows, it's much better used as an offensive tool.
 
 	<GuideReagentEmbed Reagent="Stimulants"/>
 


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
updated the marauder cache for the last time hopefully. stimulant pen was not interesting so now they have their grenade back. i also missed the grenade a lot.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Replaced the marauder's stimulant pen with an explosive grenade.
