### PR TITLE
Ex-Syndie Modifier

### DIFF
--- a/Content.Client/_ES/Mind/Ui/ESCharacterWindow.xaml.cs
+++ b/Content.Client/_ES/Mind/Ui/ESCharacterWindow.xaml.cs
@@ -167,9 +167,21 @@ public sealed partial class ESCharacterWindow : FancyWindow
             var secretIdentity = _prototype.Index(secretIdentityId);
             var organization = _prototype.Index(secretIdentity.Organization);
 
+            var modifierName = "null";
+            var modifierColor = Color.White;
+            if (_secretIdentity.TryGetSecretIdentityModifier((mind, mindComp), out var modifierId))
+            {
+                var modifier = _prototype.Index(modifierId);
+
+                modifierName = Loc.GetString(modifier.Name);
+                modifierColor = modifier.Color;
+            }
+
             SecretIdentityLabel.UnsafeSetMarkup(Loc.GetString("es-character-window-secret-identity-fmt",
                 ("name", Loc.GetString(secretIdentity.Name)),
-                ("color", secretIdentity.Color)));
+                ("color", secretIdentity.Color),
+                ("modifierName", modifierName),
+                ("modifierColor", modifierColor)));
 
             OrganizationLabel.UnsafeSetMarkup(Loc.GetString("es-character-window-organization-fmt",
                 ("name", Loc.GetString(organization.Name)),
@@ -181,7 +193,9 @@ public sealed partial class ESCharacterWindow : FancyWindow
         {
             SecretIdentityLabel.UnsafeSetMarkup(Loc.GetString("es-character-window-secret-identity-fmt",
                 ("name", Loc.GetString("generic-unknown-title")),
-                ("color", Color.White)));
+                ("color", Color.White),
+                ("modifierName", string.Empty),
+                ("modifierColor", Color.White)));
 
             OrganizationLabel.UnsafeSetMarkup(Loc.GetString("es-character-window-organization-fmt",
                 ("name", Loc.GetString("generic-unknown-title")),

--- a/Content.Client/_ES/Stagehand/Ui/ESStagehandObserveControl.xaml
+++ b/Content.Client/_ES/Stagehand/Ui/ESStagehandObserveControl.xaml
@@ -17,6 +17,7 @@
                     </VFillStack>
                     <VFillStack>
                         <RichTextLabel Name="SecretIdentityLabel" Access="Public" HorizontalAlignment="Right"/>
+                        <RichTextLabel Name="ModifierLabel" Access="Public" HorizontalAlignment="Right"/>
                         <RichTextLabel Name="OrganizationLabel" Access="Public" HorizontalAlignment="Right"/>
                     </VFillStack>
                 </HFillStack>

--- a/Content.Client/_ES/Stagehand/Ui/StagehandObserveUIController.cs
+++ b/Content.Client/_ES/Stagehand/Ui/StagehandObserveUIController.cs
@@ -147,6 +147,7 @@ public sealed partial class StagehandObserveUIController : UIController, IOnStat
         observe.CurrentEntity = uid;
 
         var secretIdentity = _secretIdentity?.GetSecretIdentityOrNull((uid, mind));
+        var modifier = _secretIdentity?.GetSecretIdentityModifierOrNull((uid, mind));
         var organization = _secretIdentity?.GetOrganizationOrNull((uid, mind));
 
         observe.NameLabel.UnsafeSetMarkup(Loc.GetString("es-observe-menu-label-name-big", ("text", character.Name)));
@@ -161,6 +162,14 @@ public sealed partial class StagehandObserveUIController : UIController, IOnStat
             observe.SecretIdentityLabel.UnsafeSetMarkup(
                 Loc.GetString("es-observe-menu-label-name-big", ("text", Loc.GetString(secretIdentityPrototype.Name))),
                 secretIdentityPrototype.Color);
+        }
+
+        observe.ModifierLabel.Clear();
+        if (_prototype.TryIndex(modifier, out var modifierPrototype))
+        {
+            observe.ModifierLabel.UnsafeSetMarkup(
+                Loc.GetString("es-observe-menu-label-fmt", ("text", Loc.GetString(modifierPrototype.Name))),
+                modifierPrototype.Color);
         }
 
         observe.OrganizationLabel.Clear();

--- a/Content.Server/_ES/SecretIdentity/ESSecretIdentitySystem.cs
+++ b/Content.Server/_ES/SecretIdentity/ESSecretIdentitySystem.cs
@@ -272,7 +272,7 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
 
         if (applyModifiers)
         {
-            ApplySecretIdentityModifiers(mind, secretIdentity, role.Value);
+            ApplySecretIdentityModifier(mind, secretIdentity, role.Value);
             if (role.Value.Comp2.Modifier is { } modifier)
             {
                 // stick modifier out front.
@@ -306,7 +306,7 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
         }
     }
 
-    private void ApplySecretIdentityModifiers(
+    private void ApplySecretIdentityModifier(
         Entity<MindComponent> mind,
         ESSecretIdentityPrototype secretIdentity,
         Entity<MindRoleComponent, ESSecretIdentityRoleComponent> role)
@@ -316,8 +316,11 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
             return;
 
         var modifierId = _random.Pick(secretIdentity.Modifiers);
+        var modifier = PrototypeManager.Index(modifierId);
         role.Comp2.Modifier = modifierId;
         Dirty(role, role.Comp2);
+
+        RaiseLocalEvent(mind, (object) modifier.Event);
     }
 
     public override void RemoveSecretIdentity(Entity<MindComponent> mind)

--- a/Content.Server/_ES/SecretIdentity/ESSecretIdentitySystem.cs
+++ b/Content.Server/_ES/SecretIdentity/ESSecretIdentitySystem.cs
@@ -13,10 +13,12 @@ using Content.Shared.EntityTable;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Mind;
+using Content.Shared.Random.Helpers;
 using Content.Shared.Roles.Components;
 using Robust.Server.Player;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
 using Robust.Shared.Utility;
 
 namespace Content.Server._ES.SecretIdentity;
@@ -25,6 +27,7 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
 {
     [Dependency] private IESSharedChatManager _chat = default!;
     [Dependency] private IPlayerManager _player = default!;
+    [Dependency] private IRobustRandom _random = default!;
     [Dependency] private ActionsSystem _actions = default!;
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] private GameTicker _gameTicker = default!;
@@ -116,28 +119,32 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
             return Loc.GetString("generic-unknown-title");
 
         // You should always have SOME identity
-        DebugTools.Assert(mind.Comp.SecretIdentities.Count != 0);
+        DebugTools.Assert(mind.Comp.Memories.Count != 0);
 
-        var firstSecretIdentity = PrototypeManager.Index(mind.Comp.SecretIdentities.First());
-
-        var outString = Loc.GetString("es-roundend-secret-identity-fmt",
-            ("name", Loc.GetString(firstSecretIdentity.Name)),
-            ("color", firstSecretIdentity.Color));
-
-        for (var i = 1; i < mind.Comp.SecretIdentities.Count; ++i)
+        var identities = new List<string>();
+        foreach (var memory in mind.Comp.Memories)
         {
-            var secretIdentity = PrototypeManager.Index(mind.Comp.SecretIdentities[i]);
-            var secretIdentityString = Loc.GetString("es-roundend-secret-identity-fmt",
-                ("name", Loc.GetString(secretIdentity.Name)),
-                ("color", secretIdentity.Color));
+            var secretIdentity = PrototypeManager.Index(memory.Identity);
 
-            // Chain all the identities together.
-            outString = Loc.GetString("es-roundend-secret-identity-link-fmt",
-                ("secretIdentity1", outString),
-                ("secretIdentity2", secretIdentityString));
+            string secretIdentityString;
+            if (PrototypeManager.TryIndex(memory.Modifier, out var modifier))
+            {
+                secretIdentityString = Loc.GetString("es-roundend-secret-identity-modifier-fmt",
+                    ("name", Loc.GetString(secretIdentity.Name)),
+                    ("color", secretIdentity.Color),
+                    ("modifierName", Loc.GetString(modifier.Name)),
+                    ("modifierColor", modifier.Color));
+            }
+            else
+            {
+                secretIdentityString = Loc.GetString("es-roundend-secret-identity-fmt",
+                    ("name", Loc.GetString(secretIdentity.Name)),
+                    ("color", secretIdentity.Color));
+            }
+            identities.Add(secretIdentityString);
         }
 
-        return outString;
+        return string.Join(Loc.GetString("es-roundend-secret-identity-link"), identities);
     }
 
     private void OnGameRuleStarted(Entity<ESOrganizationRuleComponent> ent, ref GameRuleStartedEvent args)
@@ -206,7 +213,10 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
         return true;
     }
 
-    public override void ApplySecretIdentity(Entity<MindComponent> mind, ProtoId<ESSecretIdentityPrototype> secretIdentityId, Entity<ESOrganizationRuleComponent>? organization = null)
+    public override void ApplySecretIdentity(Entity<MindComponent> mind,
+        ProtoId<ESSecretIdentityPrototype> secretIdentityId,
+        Entity<ESOrganizationRuleComponent>? organization = null,
+        bool applyModifiers = false)
     {
         var secretIdentity = PrototypeManager.Index(secretIdentityId);
 
@@ -239,15 +249,6 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
                 Loc.GetString("es-objective-tooltip-secret-identity"));
         }
 
-        var msg = Loc.GetString("es-secret-identity-selected-chat-message",
-            ("role", Loc.GetString(secretIdentity.Name)),
-            ("description", Loc.GetString(secretIdentity.Description)));
-
-        if (_player.TryGetSessionById(mind.Comp.UserId, out var session))
-        {
-            _chat.SendServerMessage(msg, session, Color.Plum);
-        }
-
         if (mind.Comp.OwnedEntity is { } ownedEntity)
         {
             _stationSpawning.EquipStartingGear(ownedEntity, secretIdentity.Gear);
@@ -264,11 +265,28 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
         }
         EntityManager.AddComponents(mind, secretIdentity.MindComponents);
 
-        var memoryComponent = EnsureComp<ESSecretIdentityMemoryComponent>(mind);
-        memoryComponent.SecretIdentities.Add(secretIdentity);
-
         organization.Value.Comp.OrganizationMemberMinds.Add(mind);
         Objective.RegenerateObjectiveList(mind.Owner);
+
+        var roleName = Loc.GetString(secretIdentity.Name);
+
+        if (applyModifiers)
+        {
+            ApplySecretIdentityModifiers(mind, secretIdentity, role.Value);
+            if (role.Value.Comp2.Modifier is { } modifier)
+            {
+                // stick modifier out front.
+                var modifierPrototype = PrototypeManager.Index(modifier);
+                roleName = $"{Loc.GetString(modifierPrototype.Name)} {roleName}";
+            }
+        }
+
+        var memoryComponent = EnsureComp<ESSecretIdentityMemoryComponent>(mind);
+        memoryComponent.Memories.Add(new ESSecretIdentityMemory()
+        {
+            Identity = secretIdentityId,
+            Modifier = role.Value.Comp2.Modifier,
+        });
 
         // Our rule was only added in the beginning, now we should start it properly.
         if (!ruleExists)
@@ -278,6 +296,28 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
 
         var ev = new ESSecretIdentityChangedEvent(mind, secretIdentity, null);
         RaiseLocalEvent(organization.Value, ref ev, true);
+
+        if (_player.TryGetSessionById(mind.Comp.UserId, out var session))
+        {
+            var msg = Loc.GetString("es-secret-identity-selected-chat-message",
+                ("role", roleName),
+                ("description", Loc.GetString(secretIdentity.Description)));
+            _chat.SendServerMessage(msg, session, Color.Plum);
+        }
+    }
+
+    private void ApplySecretIdentityModifiers(
+        Entity<MindComponent> mind,
+        ESSecretIdentityPrototype secretIdentity,
+        Entity<MindRoleComponent, ESSecretIdentityRoleComponent> role)
+    {
+        if (!_random.Prob(secretIdentity.ModifierChance) ||
+            secretIdentity.Modifiers.Count == 0)
+            return;
+
+        var modifierId = _random.Pick(secretIdentity.Modifiers);
+        role.Comp2.Modifier = modifierId;
+        Dirty(role, role.Comp2);
     }
 
     public override void RemoveSecretIdentity(Entity<MindComponent> mind)
@@ -330,8 +370,8 @@ public sealed partial class ESSecretIdentitySystem : ESSharedSecretIdentitySyste
         if (eraseHistory)
         {
             var comp = EnsureComp<ESSecretIdentityMemoryComponent>(mind);
-            if (comp.SecretIdentities.Count != 0)
-                comp.SecretIdentities.RemoveAt(comp.SecretIdentities.Count - 1);
+            if (comp.Memories.Count != 0)
+                comp.Memories.RemoveAt(comp.Memories.Count - 1);
         }
         ApplySecretIdentity(mind, secretIdentityId, organization);
 

--- a/Content.Server/_ES/SecretIdentity/Masquerades/ESMasqueradeSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Masquerades/ESMasqueradeSystem.cs
@@ -114,7 +114,7 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
                 if (!_secretIdentity.IsPlayerValid(secretIdentity, player))
                     continue;
 
-                _secretIdentity.ApplySecretIdentity(mind.Value, secretIdentityId);
+                _secretIdentity.ApplySecretIdentity(mind.Value, secretIdentityId, applyModifiers: true);
 
                 players.RemoveAt(i);
                 goto exit; // escape to next identity.
@@ -128,7 +128,7 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
                 if (!TryGetMindOrLog(player, out var mind))
                     continue;
 
-                _secretIdentity.ApplySecretIdentity(mind.Value, secretIdentityId);
+                _secretIdentity.ApplySecretIdentity(mind.Value, secretIdentityId, applyModifiers: true);
 
                 players.RemoveAt(i);
                 goto exit; // escape to next identity.
@@ -171,7 +171,7 @@ public sealed partial class ESMasqueradeSystem : GameRuleSystem<ESMasqueradeRule
         if (!TryGetOrganizationForSecretIdentityOrLog(secretIdentity, rule, out var organization))
             return;
 
-        _secretIdentity.ApplySecretIdentity(mind.Value, secretIdentity, organization.Value);
+        _secretIdentity.ApplySecretIdentity(mind.Value, secretIdentity, organization.Value, applyModifiers: true);
     }
 
     private bool TryGetOrganizationForSecretIdentityOrLog(ProtoId<ESSecretIdentityPrototype> secretIdentity,

--- a/Content.Server/_ES/SecretIdentity/Traitor/ESSecretIdentityCacheSystem.cs
+++ b/Content.Server/_ES/SecretIdentity/Traitor/ESSecretIdentityCacheSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._ES.SecretIdentity.Traitor.Components;
 using Content.Shared._ES.SpawnRegion;
 using Content.Shared.EntityTable;
 using Content.Shared.Localizations;
+using Content.Shared.Mind;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -16,6 +17,7 @@ public sealed partial class ESSecretIdentityCacheSystem : ESSharedSecretIdentity
 {
     [Dependency] private EntityTableSystem _entityTable = default!;
     [Dependency] private NavMapSystem _navMap = default!;
+    [Dependency] private ESSecretIdentitySystem _secretIdentity = default!;
     [Dependency] private ESSharedSpawnRegionSystem _spawnRegion = default!;
 
     /// <inheritdoc/>
@@ -23,7 +25,22 @@ public sealed partial class ESSecretIdentityCacheSystem : ESSharedSecretIdentity
     {
         base.Initialize();
 
+        SubscribeLocalEvent<MindComponent, ESAddCacheSecretIdentityModifierEvent>(OnAddCacheModifier);
         SubscribeLocalEvent<ESSecretIdentityCacheSpawnerComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnAddCacheModifier(Entity<MindComponent> ent, ref ESAddCacheSecretIdentityModifierEvent args)
+    {
+        if (!TryComp<ESCharacterComponent>(ent, out var character))
+            return;
+
+        var comp = EnsureComp<ESSecretIdentityCacheSpawnerComponent>(ent);
+
+        foreach (var cache in _entityTable.GetSpawns(args.CacheProto))
+        {
+            TrySpawnCache((ent, comp), cache, args.Region, character.Station, out _);
+        }
+        _secretIdentity.RefreshCharacterInfoBlurb(ent.AsNullable());
     }
 
     private void OnMapInit(Entity<ESSecretIdentityCacheSpawnerComponent> ent, ref MapInitEvent args)
@@ -31,34 +48,24 @@ public sealed partial class ESSecretIdentityCacheSystem : ESSharedSecretIdentity
         if (!TryComp<ESCharacterComponent>(ent, out var character))
             return;
 
-        var coords = new List<EntityCoordinates>();
         foreach (var cache in _entityTable.GetSpawns(ent.Comp.CacheProto))
         {
-            if (TrySpawnCache(ent, (ent, character), cache, out var c))
-                coords.Add(c.Value);
+            TrySpawnCache(ent, cache, ent.Comp.Region, character.Station, out _);
         }
 
-        var locationStrings = new List<string>();
-        foreach (var coord in coords)
-        {
-            var mapCoord = TransformSystem.ToMapCoordinates(coord);
-            var (x, y) = (Vector2i) mapCoord.Position.Rounded();
-            var loc = FormattedMessage.RemoveMarkupPermissive(_navMap.GetNearestBeaconString(mapCoord));
-
-            locationStrings.Add(Loc.GetString("es-ceiling-cache-location-format", ("location", loc), ("x", x), ("y", y)));
-        }
-
-        ent.Comp.LocationString = Loc.GetString("es-ceiling-cache-location-briefing",
-            ("locations", ContentLocalizationManager.FormatList(locationStrings)),
-            ("count", locationStrings.Count));
-        Dirty(ent);
+        _secretIdentity.RefreshCharacterInfoBlurb(ent.Owner);
     }
 
-    private bool TrySpawnCache(Entity<ESSecretIdentityCacheSpawnerComponent> ent, Entity<ESCharacterComponent> character, EntProtoId cache, [NotNullWhen(true)] out EntityCoordinates? coords)
+    public bool TrySpawnCache(
+        Entity<ESSecretIdentityCacheSpawnerComponent> ent,
+        EntProtoId cache,
+        ProtoId<ESSpawnRegionPrototype> region,
+        EntityUid station,
+        [NotNullWhen(true)] out EntityCoordinates? coords)
     {
         if (!_spawnRegion.TryGetRandomCoordsInRegion(
-                ent.Comp.Region,
-                character.Comp.Station,
+                region,
+                station,
                 out coords,
                 checkPlayerLOS: false,
                 minPlayerDistance: 0f))
@@ -72,6 +79,18 @@ public sealed partial class ESSecretIdentityCacheSystem : ESSharedSecretIdentity
         comp.MindId = ent;
         comp.CacheLoot = cache;
         Dirty(spawner, comp);
+
+        // Update Briefing
+        var mapCoord = TransformSystem.ToMapCoordinates(coords.Value);
+        var (x, y) = (Vector2i) mapCoord.Position.Rounded();
+        var loc = FormattedMessage.RemoveMarkupPermissive(_navMap.GetNearestBeaconString(mapCoord));
+
+        ent.Comp.Locations.Add(Loc.GetString("es-ceiling-cache-location-format", ("location", loc), ("x", x), ("y", y)));
+
+        ent.Comp.LocationString = Loc.GetString("es-ceiling-cache-location-briefing",
+            ("locations", ContentLocalizationManager.FormatList(ent.Comp.Locations)),
+            ("count", ent.Comp.Locations.Count));
+        Dirty(ent);
 
         return true;
     }

--- a/Content.Shared/_ES/SecretIdentity/Components/ESSecretIdentityMemoryComponent.cs
+++ b/Content.Shared/_ES/SecretIdentity/Components/ESSecretIdentityMemoryComponent.cs
@@ -13,5 +13,15 @@ public sealed partial class ESSecretIdentityMemoryComponent : Component
     /// The secret identities that this mind has had, in order from oldest to newest.
     /// </summary>
     [DataField]
-    public List<ProtoId<ESSecretIdentityPrototype>> SecretIdentities = [];
+    public List<ESSecretIdentityMemory> Memories = [];
+}
+
+[DataDefinition]
+public partial record struct ESSecretIdentityMemory
+{
+    [DataField]
+    public ProtoId<ESSecretIdentityPrototype> Identity;
+
+    [DataField]
+    public ProtoId<ESSecretIdentityModifierPrototype>? Modifier;
 }

--- a/Content.Shared/_ES/SecretIdentity/Components/ESSecretIdentityRoleComponent.cs
+++ b/Content.Shared/_ES/SecretIdentity/Components/ESSecretIdentityRoleComponent.cs
@@ -18,6 +18,12 @@ public sealed partial class ESSecretIdentityRoleComponent : Component
     public ProtoId<ESSecretIdentityPrototype>? SecretIdentity;
 
     /// <summary>
+    /// Modifier applied to this secret identity.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<ESSecretIdentityModifierPrototype>? Modifier;
+
+    /// <summary>
     /// Actions added to the entity from the secret identity.
     /// </summary>
     [DataField]

--- a/Content.Shared/_ES/SecretIdentity/ESSecretIdentityModifierPrototype.cs
+++ b/Content.Shared/_ES/SecretIdentity/ESSecretIdentityModifierPrototype.cs
@@ -1,0 +1,26 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._ES.SecretIdentity;
+
+/// <summary>
+/// Modifiers applied from <see cref="ESSecretIdentityPrototype"/> that add additional behavior.
+/// </summary>
+[Prototype("esSecretIdentityModifier")]
+public sealed partial class ESSecretIdentityModifierPrototype : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// The player-facing name of the modifier
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name;
+
+    /// <summary>
+    /// The color of the modifier in the UI
+    /// </summary>
+    [DataField]
+    public Color Color = Color.White;
+}

--- a/Content.Shared/_ES/SecretIdentity/ESSecretIdentityModifierPrototype.cs
+++ b/Content.Shared/_ES/SecretIdentity/ESSecretIdentityModifierPrototype.cs
@@ -1,4 +1,5 @@
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared._ES.SecretIdentity;
 
@@ -23,4 +24,11 @@ public sealed partial class ESSecretIdentityModifierPrototype : IPrototype
     /// </summary>
     [DataField]
     public Color Color = Color.White;
+
+    [DataField(required: true)]
+    public ESSecretIdentifierModifierEvent Event = default!;
 }
+
+[Serializable, NetSerializable]
+[ImplicitDataDefinitionForInheritors]
+public abstract partial class ESSecretIdentifierModifierEvent : EntityEventArgs;

--- a/Content.Shared/_ES/SecretIdentity/ESSecretIdentityPrototype.cs
+++ b/Content.Shared/_ES/SecretIdentity/ESSecretIdentityPrototype.cs
@@ -58,6 +58,18 @@ public sealed partial class ESSecretIdentityPrototype : IPrototype, IInheritingP
     public LocId Description;
 
     /// <summary>
+    /// Chance that modifiers are rolled for this secret identites
+    /// </summary>
+    [DataField]
+    public float ModifierChance;
+
+    /// <summary>
+    /// Weighted list of different modifiers
+    /// </summary>
+    [DataField]
+    public Dictionary<ProtoId<ESSecretIdentityModifierPrototype>, float> Modifiers = new();
+
+    /// <summary>
     /// Set of tips that apply to this secret identity specifically.
     /// </summary>
     [DataField]

--- a/Content.Shared/_ES/SecretIdentity/ESSharedSecretIdentitySystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/ESSharedSecretIdentitySystem.cs
@@ -218,6 +218,25 @@ public abstract partial class ESSharedSecretIdentitySystem : EntitySystem
     }
 
     /// <summary>
+    /// Retrieves the current secret identity modifier from a mind, failing if one isn't present.
+    /// </summary>
+    public bool TryGetSecretIdentityModifier(Entity<MindComponent?> mind, [NotNullWhen(true)] out ProtoId<ESSecretIdentityModifierPrototype>? modifier)
+    {
+        modifier = null;
+        if (!Role.MindHasRole<ESSecretIdentityRoleComponent>(mind, out var role))
+            return false;
+
+        modifier = role.Value.Comp2.Modifier;
+        return modifier != null;
+    }
+
+    public ProtoId<ESSecretIdentityModifierPrototype>? GetSecretIdentityModifierOrNull(Entity<MindComponent?> mind)
+    {
+        TryGetSecretIdentityModifier(mind, out var modifier);
+        return modifier;
+    }
+
+    /// <summary>
     /// Variant of <see cref="TryGetSecretIdentity(EntityUid, out ProtoId{ESSecretIdentityPrototype}?)"/> that does not involve the mind.
     /// So in situations like a phantom where the mind has left the body, this will still return the correct result.
     /// </summary>
@@ -326,9 +345,11 @@ public abstract partial class ESSharedSecretIdentitySystem : EntitySystem
     ///     This allows "bad" game states like giving secret identities to roles they're incompatible with, and will automatically
     ///     start organizations as necessary.
     /// </remarks>
-    public virtual void ApplySecretIdentity(Entity<MindComponent> mind,
+    public virtual void ApplySecretIdentity(
+        Entity<MindComponent> mind,
         ProtoId<ESSecretIdentityPrototype> secretIdentityId,
-        Entity<ESOrganizationRuleComponent>? organization = null)
+        Entity<ESOrganizationRuleComponent>? organization = null,
+        bool applyModifiers = false)
     {
         // No Op
     }

--- a/Content.Shared/_ES/SecretIdentity/Traitor/Components/ESSecretIdentityCacheSpawnerComponent.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/Components/ESSecretIdentityCacheSpawnerComponent.cs
@@ -13,7 +13,10 @@ public sealed partial class ESSecretIdentityCacheSpawnerComponent : Component
     public ProtoId<ESSpawnRegionPrototype> Region = "ESMaintenance";
 
     [DataField(required: true)]
-    public EntityTableSelector CacheProto;
+    public EntityTableSelector CacheProto = new NoneSelector();
+
+    [DataField]
+    public List<string> Locations = [];
 
     [DataField, AutoNetworkedField]
     public string LocationString = string.Empty;

--- a/Content.Shared/_ES/SecretIdentity/Traitor/ESSharedSecretIdentityCacheSystem.cs
+++ b/Content.Shared/_ES/SecretIdentity/Traitor/ESSharedSecretIdentityCacheSystem.cs
@@ -1,7 +1,9 @@
 using Content.Shared._ES.Core.Timer;
 using Content.Shared._ES.SecretIdentity.Traitor.Components;
+using Content.Shared._ES.SpawnRegion;
 using Content.Shared.Alert;
 using Content.Shared.DoAfter;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Mind;
 using Content.Shared.Mobs;
@@ -136,7 +138,7 @@ public abstract partial class ESSharedSecretIdentityCacheSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp))
             return;
 
-        var pos = Transform(ent).Coordinates;
+        var pos = user.HasValue ? Transform(user.Value).Coordinates : Transform(ent).Coordinates;
         var cache = PredictedSpawnAtPosition(ent.Comp.CacheLoot, pos);
         PredictedQueueDel(ent);
         _popup.PopupEntity(Loc.GetString("es-ceiling-cache-popup"), ent);
@@ -150,6 +152,16 @@ public abstract partial class ESSharedSecretIdentityCacheSystem : EntitySystem
             RaiseLocalEvent(ent.Comp.MindId.Value, ref ev);
         }
     }
+}
+
+[Serializable, NetSerializable]
+public sealed partial class ESAddCacheSecretIdentityModifierEvent : ESSecretIdentifierModifierEvent
+{
+    [DataField]
+    public ProtoId<ESSpawnRegionPrototype> Region = "ESMaintenance";
+
+    [DataField]
+    public EntityTableSelector CacheProto = new NoneSelector();
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_ES/character/display.ftl
+++ b/Resources/Locale/en-US/_ES/character/display.ftl
@@ -1,7 +1,10 @@
 es-character-info-title = Character
 es-character-window-name-fmt = [font size=16][bold]{$name}[/bold][/font]
 es-character-window-job-fmt = [color=gray][bold]{$name}[/bold][/color]
-es-character-window-secret-identity-fmt = [color={$color}][font size=16][bold]{$name}[/bold][/font][/color]
+es-character-window-secret-identity-fmt = [font size=16][bold]{ $modifierName ->
+        [null] {""}
+        *[Other] [color={$modifierColor}]{$modifierName} [/color]
+    }[color={$color}]{$name}[/color][/bold][/font]
 es-character-window-organization-fmt = [color={$color}][font size=14][bold]{$name}[/bold][/font][/color]
 
 es-character-window-objective-title = [font size=14][bold]Objectives:[/bold][/font]

--- a/Resources/Locale/en-US/_ES/secret-identities/masks.ftl
+++ b/Resources/Locale/en-US/_ES/secret-identities/masks.ftl
@@ -87,6 +87,9 @@ es-secret-identity-leapleech-desc = As a Leapleech, take damage from multiple cr
 es-secret-identity-sleeper-agent-name = Sleeper Agent
 es-secret-identity-sleeper-agent-desc = As a Sleeper Agent, you're a member of crew and win with them. When a traitor dies, you have a chance to switch sides and gain a new secret identity.
 
+# Modifiers
+es-secret-identity-modifier-ex-syndicate = Ex-Syndie
+
 # Meta
 es-objective-issuer-secret-identity = Secret Identity
 

--- a/Resources/Locale/en-US/_ES/secret-identities/roundend.ftl
+++ b/Resources/Locale/en-US/_ES/secret-identities/roundend.ftl
@@ -8,7 +8,8 @@ es-roundend-secret-identity-player-summary = {$name} [color=gray]({$username})[/
     *[Other] with the following objectives:
 }
 es-roundend-secret-identity-fmt = [color={$color}][bold]{$name}[/bold][/color]
-es-roundend-secret-identity-link-fmt = {$secretIdentity1}-turned-{$secretIdentity2}
+es-roundend-secret-identity-modifier-fmt = [bold][color={$modifierColor}]{$modifierName}[/color] [color={$color}]{$name}[/color][/bold]
+es-roundend-secret-identity-link = -turned-
 es-roundend-secret-identity-player-group = [font size=14][color={$color}][bold]{$name}[/bold][/color][/font]
 
 es-roundend-masquerade-reveal = [font size=16]Annnd that's a wrap! Today's show was themed "{$masquerade}", which {$description}.[/font]

--- a/Resources/Prototypes/_ES/SecretIdentities/Modifiers/modifiers.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/Modifiers/modifiers.yml
@@ -2,3 +2,6 @@
   id: ExSyndicate
   name: es-secret-identity-modifier-ex-syndicate
   color: red
+  event: !type:ESAddCacheSecretIdentityModifierEvent
+    cacheProto:
+      tableId: ESTraitorCaches

--- a/Resources/Prototypes/_ES/SecretIdentities/Modifiers/modifiers.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/Modifiers/modifiers.yml
@@ -1,0 +1,4 @@
+- type: esSecretIdentityModifier
+  id: ExSyndicate
+  name: es-secret-identity-modifier-ex-syndicate
+  color: red

--- a/Resources/Prototypes/_ES/SecretIdentities/base.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/base.yml
@@ -20,7 +20,7 @@
   id: ESBaseCrew
   organization: Crew
   abstract: true
-  modifierChance: 0.085
+  modifierChance: 0.066
   modifiers:
     ExSyndicate: 1
 

--- a/Resources/Prototypes/_ES/SecretIdentities/base.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/base.yml
@@ -20,6 +20,9 @@
   id: ESBaseCrew
   organization: Crew
   abstract: true
+  modifierChance: 1 # TODO TESTING ONLY 0.066 # 1 / 15
+  modifiers:
+    ExSyndicate: 1
 
 - type: esSecretIdentity
   parent: ESBaseCommandRestricted

--- a/Resources/Prototypes/_ES/SecretIdentities/base.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/base.yml
@@ -20,7 +20,7 @@
   id: ESBaseCrew
   organization: Crew
   abstract: true
-  modifierChance: 1 # TODO TESTING ONLY 0.066 # 1 / 15
+  modifierChance: 0.085
   modifiers:
     ExSyndicate: 1
 

--- a/Resources/Prototypes/_ES/SecretIdentities/base.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/base.yml
@@ -17,6 +17,11 @@
   - ESDetective
 
 - type: esSecretIdentity
+  id: ESBaseCrew
+  organization: Crew
+  abstract: true
+
+- type: esSecretIdentity
   parent: ESBaseCommandRestricted
   id: ESBaseParasite
   organization: Parasite

--- a/Resources/Prototypes/_ES/SecretIdentities/crew.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/crew.yml
@@ -1,7 +1,7 @@
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: ArmsDealer
   name: es-secret-identity-arms-dealer-name
-  organization: Crew
   description: es-secret-identity-arms-dealer-desc
   color: lime
   weight: 0.75
@@ -16,9 +16,9 @@
       amount: 3
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Arsonist
   name: es-secret-identity-arsonist-name
-  organization: Crew
   description: es-secret-identity-arsonist-desc
   color: red
   weight: 0.25
@@ -28,18 +28,18 @@
     id: ESObjectiveArsonistLightFires
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Avenger
   name: es-secret-identity-avenger-name
-  organization: Crew
   description: es-secret-identity-avenger-desc
   color: peachpuff
   objectives:
     id: ESObjectiveAvengerProtectRandom
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Cannibal
   name: es-secret-identity-cannibal-name
-  organization: Crew
   description: es-secret-identity-cannibal-desc
   color: darkorange
   actions:
@@ -50,9 +50,9 @@
     - id: ESObjectiveCannibal
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Cryojunkie
   name: es-secret-identity-cryojunkie-name
-  organization: Crew
   description: es-secret-identity-cryojunkie-desc
   color: lightblue
   weight: 0.5
@@ -62,9 +62,9 @@
   - type: ESCryoJunkieMind
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Guzzler
   name: es-secret-identity-guzzler-name
-  organization: Crew
   description: es-secret-identity-guzzler-desc
   color: cyan
   weight: 0.15
@@ -75,9 +75,9 @@
     - id: ESObjectiveGuzzleSpecialInterest
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Hater
   name: es-secret-identity-hater-name
-  organization: Crew
   description: es-secret-identity-hater-desc
   color: peru
   assignmentOrder: 11 # Needs to be assigned after other identities
@@ -87,9 +87,9 @@
     - id: ESObjectiveHaterDontKill
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Mercenary
   name: es-secret-identity-mercenary-name
-  organization: Crew
   description: es-secret-identity-mercenary-desc
   color: ruber
   objectives:
@@ -100,9 +100,9 @@
       id: ESCacheCrewMercenary
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Nobleman
   name: es-secret-identity-nobleman-name
-  organization: Crew
   description: es-secret-identity-nobleman-desc
   color: gold
   weight: 0.25
@@ -111,9 +111,9 @@
     - id: ESObjectiveNoblemanDontKill
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Phantom
   name: es-secret-identity-phantom-name
-  organization: Crew
   description: es-secret-identity-phantom-desc
   color: plum
   weight: 0.5
@@ -124,9 +124,9 @@
     - id: ESObjectivePhantomDie
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Pickpocket
   name: es-secret-identity-pickpocket-name
-  organization: Crew
   description: es-secret-identity-pickpocket-desc
   color: olivedrab
   weight: 0.75
@@ -138,9 +138,9 @@
     - id: ESObjectivePickpocketSteal
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Secretary
   name: es-secret-identity-secretary-name
-  organization: Crew
   description: es-secret-identity-secretary-desc
   color: palegreen
   assignmentOrder: 11 # Needs to be assigned after other identities
@@ -149,9 +149,9 @@
     - id: ESObjectiveSecretaryAssist
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Stalker
   name: es-secret-identity-stalker-name
-  organization: Crew
   description: es-secret-identity-stalker-desc
   color: lightsteelblue
   actions:
@@ -163,9 +163,9 @@
     - id: ESObjectiveStalkerSave
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: Tragedian
   name: es-secret-identity-tragedian-name
-  organization: Crew
   description: es-secret-identity-tragedian-desc
   color: royalblue
   objectives:
@@ -179,7 +179,7 @@
   - type: ESAlwaysHearStagehandEmote
 
 - type: esSecretIdentity
-  parent: ESBaseCommandRestricted
+  parent: [ ESBaseCommandRestricted, ESBaseCrew ]
   id: Vandal
   name: es-secret-identity-vandal-name
   organization: Crew
@@ -199,9 +199,9 @@
       amount: 1, 2
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: VIP
   name: es-secret-identity-vip-name
-  organization: Crew
   description: es-secret-identity-vip-desc
   color: gold
   tips:
@@ -216,9 +216,9 @@
     - ESItemCardVIP
 
 - type: esSecretIdentity
+  parent: ESBaseCrew
   id: WarpDisciple
   name: es-secret-identity-warp-disciple-name
-  organization: Crew
   description: es-secret-identity-warp-disciple-desc
   color: blueviolet
   tips:

--- a/Resources/Prototypes/_ES/SecretIdentities/traitor.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/traitor.yml
@@ -87,6 +87,8 @@
   name: es-secret-identity-sleeper-agent-name
   description: es-secret-identity-sleeper-agent-desc
   color: darkturquoise
+  modifiers:
+    { }
   weight: 0 # otherwise it can roll in randomasquerades with no traitors. temp fix
   tips:
   - SleeperAgentBalance

--- a/Resources/Prototypes/_ES/SecretIdentities/traitor.yml
+++ b/Resources/Prototypes/_ES/SecretIdentities/traitor.yml
@@ -82,10 +82,9 @@
 
 # Non-traitor identities that are dependent on traitors
 - type: esSecretIdentity
-  parent: ESBaseCommandRestricted # same restriction as traitors
+  parent: [ ESBaseCommandRestricted, ESBaseCrew ] # same restriction as traitors
   id: SleeperAgent
   name: es-secret-identity-sleeper-agent-name
-  organization: Crew
   description: es-secret-identity-sleeper-agent-desc
   color: darkturquoise
   weight: 0 # otherwise it can roll in randomasquerades with no traitors. temp fix


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Adds in the ex-syndie secret identity modifier, which gives you a random traitor cache. Currently rolls on all crew roles (minus sleeper agent) with an 6.6% chance to be assigned.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

<img width="1428" height="1053" alt="image" src="https://github.com/user-attachments/assets/b8b9612d-c59e-44ae-9691-f05da3ad317c" />
<img width="954" height="256" alt="image" src="https://github.com/user-attachments/assets/1d6820c2-4444-4d76-ad44-ca0afcddc816" />
<img width="689" height="631" alt="image" src="https://github.com/user-attachments/assets/6d914240-3614-4046-88e0-b02a7af5db93" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Crew roles (barring sleeper agent) now have the chance to spawn as "Ex-Syndicate" variants, giving them an additional equipment cache.