### PR TITLE
Handle mopping tiles

### DIFF
--- a/Content.Shared/Fluids/SharedAbsorbentSystem.cs
+++ b/Content.Shared/Fluids/SharedAbsorbentSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.Popups;
 using Content.Shared.Timing;
 using Content.Shared.Weapons.Melee;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
@@ -50,14 +51,24 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         args.Handled = true;
     }
 
+    // ES START
     private void OnAfterInteract(Entity<AbsorbentComponent> ent, ref AfterInteractEvent args)
     {
-        if (!args.CanReach || args.Handled || args.Target is not { } target)
+        if (!args.CanReach || args.Handled)
             return;
 
-        Mop(ent, args.User, target);
+        if (args.Target != null)
+        {
+            Mop(ent, args.User, args.Target.Value);
+        }
+        else
+        {
+            Mop(ent, args.User, args.ClickLocation);
+        }
+
         args.Handled = true;
     }
+    // ES END
 
     private void OnAbsorbentSolutionChange(Entity<AbsorbentComponent> ent, ref SolutionContainerChangedEvent args)
     {
@@ -87,11 +98,24 @@ public abstract partial class SharedAbsorbentSystem : EntitySystem
         _item.VisualsChanged(ent);
     }
 
-    [Obsolete("Use Entity<T> variant")]
-    public void Mop(EntityUid user, EntityUid target, EntityUid used, AbsorbentComponent component)
+    // ES START
+    public void Mop(Entity<AbsorbentComponent> absorbEnt, EntityUid user, EntityCoordinates coordinates)
     {
-        Mop((used, component), user, target);
+        if (_transform.GetGrid(coordinates) is not { } gridUid)
+        {
+            // Not on grid, do nothing.
+            return;
+        }
+
+        var gridComp = Comp<MapGridComponent>(gridUid);
+        var anchoredEntities = _mapSystem.GetAnchoredEntities((gridUid, gridComp), coordinates);
+
+        foreach (var anchoredEntity in anchoredEntities)
+        {
+            Mop(absorbEnt, user, anchoredEntity);
+        }
     }
+    // ES END
 
     public void Mop(Entity<AbsorbentComponent> absorbEnt, EntityUid user, EntityUid target)
     {


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
You can now click a tile to mop up everything on it instead of having to pixelhunt puddles

Just a quick and simple QOL improvement until better cleaning mechanics get implemented

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->
[Screencast_20260823_150330.webm](https://github.com/user-attachments/assets/e9cbdb7c-2346-4299-a15f-4d3db1d423c1)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: When mopping, clicking a tile now cleans any puddles present.