### PR TITLE
Predicted crew manifest

### DIFF
--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -36,6 +36,9 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
             return;
         }
 
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
         // TODO move this to a component state and ensure the net ids.
         var programs = GetCartridgeComponents(_entManager.GetEntityList(loaderUiState.Programs));
         UpdateAvailablePrograms(programs);
@@ -135,8 +138,7 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
     private void SendCartridgeUiReadyEvent(EntityUid cartridgeUid)
     {
         var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.UIReady);
-        if (_timing.IsFirstTimePredicted)
-            SendPredictedMessage(message);
+        SendPredictedMessage(message);
     }
 
     private UIFragment? RetrieveCartridgeUI(EntityUid? cartridgeUid)

--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -16,16 +16,12 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
     [ViewVariables]
     private Control? _activeUiFragment;
-
-    private IEntityManager _entManager;
-    private IGameTiming _timing;
+    [Dependency] private IGameTiming _timing = default!;
 
     protected CartridgeLoaderBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
-        _entManager = IoCManager.Resolve<IEntityManager>();
-        _timing = IoCManager.Resolve<IGameTiming>();
-    }
 
+    }
     protected override void UpdateState(BoundUserInterfaceState state)
     {
         base.UpdateState(state);
@@ -40,10 +36,10 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
             return;
 
         // TODO move this to a component state and ensure the net ids.
-        var programs = GetCartridgeComponents(_entManager.GetEntityList(loaderUiState.Programs));
+        var programs = GetCartridgeComponents(EntMan.GetEntityList(loaderUiState.Programs));
         UpdateAvailablePrograms(programs);
 
-        var activeUI = _entManager.GetEntity(loaderUiState.ActiveUI);
+        var activeUI = EntMan.GetEntity(loaderUiState.ActiveUI);
 
         _activeProgram = activeUI;
 
@@ -71,7 +67,7 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
     protected void ActivateCartridge(EntityUid cartridgeUid)
     {
-        var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Activate);
+        var message = new CartridgeLoaderUiMessage(EntMan.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Activate);
         SendPredictedMessage(message);
     }
 
@@ -80,19 +76,19 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
         if (!_activeProgram.HasValue)
             return;
 
-        var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(_activeProgram.Value), CartridgeUiMessageAction.Deactivate);
+        var message = new CartridgeLoaderUiMessage(EntMan.GetNetEntity(_activeProgram.Value), CartridgeUiMessageAction.Deactivate);
         SendPredictedMessage(message);
     }
 
     protected void InstallCartridge(EntityUid cartridgeUid)
     {
-        var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Install);
+        var message = new CartridgeLoaderUiMessage(EntMan.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Install);
         SendPredictedMessage(message);
     }
 
     protected void UninstallCartridge(EntityUid cartridgeUid)
     {
-        var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Uninstall);
+        var message = new CartridgeLoaderUiMessage(EntMan.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.Uninstall);
         SendPredictedMessage(message);
     }
 
@@ -137,7 +133,7 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
 
     private void SendCartridgeUiReadyEvent(EntityUid cartridgeUid)
     {
-        var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.UIReady);
+        var message = new CartridgeLoaderUiMessage(EntMan.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.UIReady);
         SendPredictedMessage(message);
     }
 

--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Timing;
 namespace Content.Client.CartridgeLoader;
 
 
-public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
+public abstract partial class CartridgeLoaderBoundUserInterface : BoundUserInterface
 {
     [ViewVariables]
     private EntityUid? _activeProgram;

--- a/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
+++ b/Content.Client/CartridgeLoader/CartridgeLoaderBoundUserInterface.cs
@@ -1,6 +1,7 @@
 using Content.Client.UserInterface.Fragments;
 using Content.Shared.CartridgeLoader;
 using Robust.Client.UserInterface;
+using Robust.Shared.Timing;
 
 namespace Content.Client.CartridgeLoader;
 
@@ -17,10 +18,12 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
     private Control? _activeUiFragment;
 
     private IEntityManager _entManager;
+    private IGameTiming _timing;
 
     protected CartridgeLoaderBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
         _entManager = IoCManager.Resolve<IEntityManager>();
+        _timing = IoCManager.Resolve<IGameTiming>();
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
@@ -132,7 +135,8 @@ public abstract class CartridgeLoaderBoundUserInterface : BoundUserInterface
     private void SendCartridgeUiReadyEvent(EntityUid cartridgeUid)
     {
         var message = new CartridgeLoaderUiMessage(_entManager.GetNetEntity(cartridgeUid), CartridgeUiMessageAction.UIReady);
-        SendMessage(message);
+        if (_timing.IsFirstTimePredicted)
+            SendPredictedMessage(message);
     }
 
     private UIFragment? RetrieveCartridgeUI(EntityUid? cartridgeUid)

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.EUI;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords;
 using Content.Server.StationRecords.Systems;
+using Content.Shared._ES.CrewManifest;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
 using Content.Shared.CrewManifest;

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -246,6 +246,11 @@ public sealed partial class CrewManifestSystem : EntitySystem
 
         entries.Entries = entriesSort.Select(x => x.entry).ToArray();
         _cachedEntries[station] = entries;
+
+        // store results on the station entity and replicate to clients
+        var comp = EnsureComp<CrewManifestComponent>(station);
+        comp.Entries = entries;
+        Dirty(station, comp);
     }
 }
 

--- a/Content.Server/CrewManifest/CrewManifestSystem.cs
+++ b/Content.Server/CrewManifest/CrewManifestSystem.cs
@@ -27,13 +27,6 @@ public sealed partial class CrewManifestSystem : EntitySystem
     [Dependency] private IConfigurationManager _configManager = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
 
-    /// <summary>
-    ///     Cached crew manifest entries. The alternative is to outright
-    ///     rebuild the crew manifest every time the state is requested:
-    ///     this is inefficient.
-    /// </summary>
-    private readonly Dictionary<EntityUid, CrewManifestEntries> _cachedEntries = new();
-
     private readonly Dictionary<EntityUid, Dictionary<ICommonSession, CrewManifestEui>> _openEuis = new();
 
     public override void Initialize()
@@ -59,7 +52,6 @@ public sealed partial class CrewManifestSystem : EntitySystem
         }
 
         _openEuis.Clear();
-        _cachedEntries.Clear();
     }
 
     private void OnRequestCrewManifest(RequestCrewManifestMessage message, EntitySessionEventArgs args)
@@ -115,8 +107,8 @@ public sealed partial class CrewManifestSystem : EntitySystem
     /// <returns>The name and crew manifest entries (unordered) of the station.</returns>
     public (string name, CrewManifestEntries? entries) GetCrewManifest(EntityUid station)
     {
-        var valid = _cachedEntries.TryGetValue(station, out var manifest);
-        return (valid ? MetaData(station).EntityName : string.Empty, valid ? manifest : null);
+        TryComp<CrewManifestComponent>(station, out var comp);
+        return (MetaData(station).EntityName, comp?.Entries);
     }
 
     private void UpdateEuis(EntityUid station)
@@ -246,7 +238,6 @@ public sealed partial class CrewManifestSystem : EntitySystem
         });
 
         entries.Entries = entriesSort.Select(x => x.entry).ToArray();
-        _cachedEntries[station] = entries;
 
         // store results on the station entity and replicate to clients
         var comp = EnsureComp<CrewManifestComponent>(station);

--- a/Content.Shared/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -3,7 +3,6 @@ using Content.Shared._ES.CrewManifest;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.CCVar;
-using Content.Shared.CrewManifest;
 using Content.Shared.Station;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;

--- a/Content.Shared/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -1,19 +1,19 @@
-using Content.Server.CrewManifest;
-using Content.Server.Station.Systems;
+using Content.Server.CartridgeLoader.Cartridges;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.CCVar;
+using Content.Shared.CrewManifest;
+using Content.Shared.Station;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 
-namespace Content.Server.CartridgeLoader.Cartridges;
+namespace Content.Shared.CartridgeLoader.Cartridges;
 
 public sealed partial class CrewManifestCartridgeSystem : EntitySystem
 {
     [Dependency] private CartridgeLoaderSystem _cartridgeLoader = default!;
     [Dependency] private IConfigurationManager _configManager = default!;
-    [Dependency] private CrewManifestSystem _crewManifest = default!;
-    [Dependency] private StationSystem _stationSystem = default!;
+    [Dependency] private SharedStationSystem _stationSystem = default!;
 
     private static readonly EntProtoId CartridgePrototypeName = "CrewManifestCartridge";
 
@@ -61,7 +61,11 @@ public sealed partial class CrewManifestCartridgeSystem : EntitySystem
         if (owningStation is null)
             return;
 
-        var (stationName, entries) = _crewManifest.GetCrewManifest(owningStation.Value);
+        if (!TryComp<CrewManifestComponent>(owningStation, out var manifestComp))
+            return;
+
+        var stationName = MetaData(owningStation.Value).EntityName;
+        var entries = manifestComp.Entries;
 
         var state = new CrewManifestUiState(stationName, entries);
         _cartridgeLoader.UpdateCartridgeUiState(loaderUid, state);

--- a/Content.Shared/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
+++ b/Content.Shared/CartridgeLoader/Cartridges/CrewManifestCartridgeSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.CartridgeLoader.Cartridges;
+using Content.Shared._ES.CrewManifest;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.CartridgeLoader.Cartridges;
 using Content.Shared.CCVar;

--- a/Content.Shared/CrewManifest/CrewManifestComponent.cs
+++ b/Content.Shared/CrewManifest/CrewManifestComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared.CrewManifest;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.CrewManifest;
+
+/// <summary>
+/// Component which replicates the crew manifest onto clients.
+/// This component is supposed to be attached to a station.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CrewManifestComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public CrewManifestEntries? Entries;
+}

--- a/Content.Shared/_ES/CrewManifest/CrewManifestComponent.cs
+++ b/Content.Shared/_ES/CrewManifest/CrewManifestComponent.cs
@@ -1,7 +1,7 @@
 using Content.Shared.CrewManifest;
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.CrewManifest;
+namespace Content.Shared._ES.CrewManifest;
 
 /// <summary>
 /// Component which replicates the crew manifest onto clients.


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
Crew manifest is predicted.

New shared CrewManifestComponent which is put on the station and dirtied by the sever-side CrewManifestSystem.
The crew manifest pda app system is moved to shared and reads the component off the station instead of using the CrewManifestSystem.
Also had to fix prediction bugs in CartridgeBoundUserInterface by upgrading to SendPredictedMessage and checking for IsFirstTimePredicted.

:cl:
- tweak: Crew manifest is now predicted