### PR TITLE
Change root guides to be explicitly specified

### DIFF
--- a/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
+++ b/Content.Client/Guidebook/Controls/GuidebookWindow.xaml.cs
@@ -201,11 +201,10 @@ public sealed partial class GuidebookWindow : FancyWindow, ILinkClickHandler, IA
     {
         if (rootEntries == null)
         {
-            HashSet<ProtoId<GuideEntryPrototype>> entries = [.. _entries.Keys];
-            foreach (var entry in _entries.Values)
-            {
-                entries.ExceptWith(entry.Children);
-            }
+            var entries = _entries.Values
+                .Where(e => e.Root)
+                .Select(e => (ProtoId<GuideEntryPrototype>) e.Id)
+                .ToHashSet();
 
             rootEntries = [.. entries];
         }

--- a/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
+++ b/Content.IntegrationTests/Tests/Guidebook/GuideEntryPrototypeTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Content.Client.Guidebook;
 using Content.Client.Guidebook.Richtext;
 using Content.IntegrationTests.Fixtures;
@@ -36,6 +38,34 @@ public sealed class GuideEntryPrototypeTests : GameTest
             var text = reader.ReadToEnd();
 
             Assert.That(parser.TryAddMarkup(new Document(), text), $"Failed to parse the guide entry's document.");
+        });
+    }
+
+    [Test]
+    public async Task NoOrphanGuideEntry()
+    {
+        var pair = Pair;
+        var client = pair.Client;
+        await client.WaitIdleAsync();
+        var protoMan = client.ResolveDependency<IPrototypeManager>();
+
+        await client.WaitAssertion(() =>
+        {
+            var orphanGuides = new HashSet<ProtoId<GuideEntryPrototype>>(protoMan
+                .EnumeratePrototypes<GuideEntryPrototype>()
+                .Select(p => (ProtoId<GuideEntryPrototype>) p.ID));
+            foreach (var guide in protoMan.EnumeratePrototypes<GuideEntryPrototype>())
+            {
+                orphanGuides.ExceptWith(guide.Children);
+            }
+
+            Assert.Multiple(() =>
+            {
+                foreach (var orphan in orphanGuides)
+                {
+                    Assert.That(protoMan.Index(orphan).Root, $"GuideEntryPrototype {orphan} has no parent but is not specified as a root! Did you forget to add it somewhere?");
+                }
+            });
         });
     }
 }

--- a/Content.Shared/Guidebook/GuideEntry.cs
+++ b/Content.Shared/Guidebook/GuideEntry.cs
@@ -29,6 +29,13 @@ public partial class GuideEntry
     [DataField(required: true)] public string Name = default!;
 
     /// <summary>
+    ///     Whether this guide is root-level and has no parents.
+    ///     Guides without parents not marked as Root are considered errors.
+    /// </summary>
+    [DataField]
+    public bool Root;
+
+    /// <summary>
     ///     The "children" of this guide for when guides are shown in a tree / table of contents.
     /// </summary>
     [DataField]

--- a/Resources/Prototypes/_ES/Guidebook/jobs.yml
+++ b/Resources/Prototypes/_ES/Guidebook/jobs.yml
@@ -3,6 +3,7 @@
   hidden: false
   name: Jobs
   priority: 3
+  root: true
   text: "/ServerInfo/_ES/Guidebook/Jobs.xml"
   children:
   - Assistant

--- a/Resources/Prototypes/_ES/Guidebook/lobby.yml
+++ b/Resources/Prototypes/_ES/Guidebook/lobby.yml
@@ -2,4 +2,5 @@
   id: Lobby
   name: Lobby
   priority: 1
+  root: true
   text: "/ServerInfo/_ES/Guidebook/Lobby.xml"

--- a/Resources/Prototypes/_ES/Guidebook/mechanics.yml
+++ b/Resources/Prototypes/_ES/Guidebook/mechanics.yml
@@ -3,6 +3,7 @@
   hidden: false
   name: Mechanics
   priority: 1
+  root: true
   text: "/ServerInfo/_ES/Guidebook/Mechanics.xml"
   children:
   - WarpDrive

--- a/Resources/Prototypes/_ES/Guidebook/new_player.yml
+++ b/Resources/Prototypes/_ES/Guidebook/new_player.yml
@@ -3,6 +3,7 @@
   hidden: false
   name: New Player Guide
   priority: 0
+  root: true
   text: "/ServerInfo/_ES/Guidebook/NewPlayer.xml"
   children:
   - Roundflow

--- a/Resources/Prototypes/_ES/Guidebook/organizations_and_secret_identities.yml
+++ b/Resources/Prototypes/_ES/Guidebook/organizations_and_secret_identities.yml
@@ -2,6 +2,7 @@
   id: OrganizationsAndSecretIdentities
   hidden: false
   priority: 2
+  root: true
   name: Organizations & Secret Identities
   text: "/ServerInfo/_ES/Guidebook/OrganizationsAndSecretIdentities.xml"
   children:

--- a/Resources/Prototypes/_ES/Guidebook/references.yml
+++ b/Resources/Prototypes/_ES/Guidebook/references.yml
@@ -3,6 +3,7 @@
   hidden: false
   name: References
   priority: 30
+  root: true
   text: "/ServerInfo/_ES/Guidebook/References.xml"
   children:
   - Rules


### PR DESCRIPTION
<!-- (IMPORTANT) ES Conventions: https://ephemeralspace.github.io/docs/coding/code-conventions.html -->

## About the PR
<!-- What did you change? -->
Closes #2610 

Adds test to prevent orphaned guides.

Generally prevents guides getting added but not put in the tree. We've had quite a few issues around this where new guides would just be in the root which is really silly. now that will get caught by automated testing unless explicitly allowed.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).-->

N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
