### PR TITLE
Optimize tile fire spread weight picking

### DIFF
--- a/Content.Server/_ES/TileFires/ESTileFireSystem.cs
+++ b/Content.Server/_ES/TileFires/ESTileFireSystem.cs
@@ -29,9 +29,9 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
     private static readonly EntProtoId Stage1Fire = "ESTileFire";
 
     /// <summary>
-    /// Scratch buffer for weighted neighbor picks. Cleared each spread so we do not alloc a Dictionary per event.
+    /// Scratch weights buffer. Cleared each spread to avoid allocating a new Dictionary per event.
     /// </summary>
-    private readonly List<(EntityCoordinates Coords, float Weight)> _spreadWeights = new();
+    private readonly Dictionary<EntityCoordinates, float> _spreadWeights = new();
 
     public override void Initialize()
     {
@@ -135,10 +135,10 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
             if (_atmos.GetHeatCapacity(mixture, false) < Atmospherics.MinimumHeatCapacity)
                 score *= 0;
 
-            var neighborCoords = MapSys.GridTileToLocal(neighbor.Tile.GridUid, neighbor.Grid, neighbor.Tile.GridIndices);
+            var coords = MapSys.GridTileToLocal(neighbor.Tile.GridUid, neighbor.Grid, neighbor.Tile.GridIndices);
 
             if (score > 0)
-                _spreadWeights.Add((neighborCoords, score));
+                _spreadWeights.Add(coords, score);
         }
 
         while (args.Updates > 0)
@@ -146,7 +146,7 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
             if (flammable.FireStacks < ent.Comp.MinFirestacksToSpread || _spreadWeights.Count == 0)
                 return;
 
-            var coords = PickAndTakeWeight(_spreadWeights);
+            var coords = _random.PickAndTake(_spreadWeights);
             var fire = Spawn(ent.Comp.Prototype, coords);
 
             if (ent.Comp.Origin is { } origin)

--- a/Content.Server/_ES/TileFires/ESTileFireSystem.cs
+++ b/Content.Server/_ES/TileFires/ESTileFireSystem.cs
@@ -28,6 +28,11 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
 
     private static readonly EntProtoId Stage1Fire = "ESTileFire";
 
+    /// <summary>
+    /// Scratch buffer for weighted neighbor picks. Cleared each spread so we do not alloc a Dictionary per event.
+    /// </summary>
+    private readonly List<(EntityCoordinates Coords, float Weight)> _spreadWeights = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -97,7 +102,7 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
             return;
 
         // Score neighboring tiles based on criteria, then do a weighted pick to spread
-        Dictionary<EntityCoordinates, float> weights = new(args.NeighborFreeTiles.Count);
+        _spreadWeights.Clear();
         foreach (var neighbor in args.NeighborFreeTiles)
         {
             // not updating the spreader api to get rid of this .owner sorry too many breakchanges for me
@@ -130,18 +135,18 @@ public sealed partial class ESTileFireSystem : ESSharedTileFireSystem
             if (_atmos.GetHeatCapacity(mixture, false) < Atmospherics.MinimumHeatCapacity)
                 score *= 0;
 
-            var coords = MapSys.GridTileToLocal(neighbor.Tile.GridUid, neighbor.Grid, neighbor.Tile.GridIndices);
+            var neighborCoords = MapSys.GridTileToLocal(neighbor.Tile.GridUid, neighbor.Grid, neighbor.Tile.GridIndices);
 
             if (score > 0)
-                weights.Add(coords, score);
+                _spreadWeights.Add((neighborCoords, score));
         }
 
         while (args.Updates > 0)
         {
-            if (flammable.FireStacks < ent.Comp.MinFirestacksToSpread || weights.Count == 0)
+            if (flammable.FireStacks < ent.Comp.MinFirestacksToSpread || _spreadWeights.Count == 0)
                 return;
 
-            var coords = _random.PickAndTake(weights);
+            var coords = PickAndTakeWeight(_spreadWeights);
             var fire = Spawn(ent.Comp.Prototype, coords);
 
             if (ent.Comp.Origin is { } origin)


### PR DESCRIPTION
## About
Tile fire neighbor spread was allocating a new `Dictionary<EntityCoordinates, float>` on every `SpreadNeighbors` event.

This keeps a cleared scratch `List<(EntityCoordinates, float)>` on the system and does a weighted pick/remove against that list instead. Scoring and spread behavior are unchanged.

## Test Plan
- [x] Start a tile fire and confirm it still spreads across flammable tiles
- [x] Hot tiles / oxygen gates still affect where it prefers to go
- [x] No obvious perf regression with a large fire